### PR TITLE
Fix Inventory's cleanup() function to be consistent with artifact.isValid()

### DIFF
--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/model/Inventory.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/model/Inventory.java
@@ -1016,8 +1016,7 @@ public class Inventory {
             final Artifact artifact = iterator.next();
 
             // an artifact requires at least an id or a component (name)
-            if (!StringUtils.hasText(artifact.getArtifactId()) &&
-                    !StringUtils.hasText(artifact.getComponent())) {
+            if (!artifact.isValid()) {
                 iterator.remove();
             }
         }


### PR DESCRIPTION
The cleanup() function now uses artifact.isValid() to determine if an entry is valid.
This makes the behaviour more consistent with what is expected when calling it.
This change will affect / might break the legacy CleanupInventoryProcessor.