### PR TITLE
AbstractModelBase: Split value into multiple columns if value too long

### DIFF
--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/model/AbstractModelBase.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/model/AbstractModelBase.java
@@ -206,15 +206,24 @@ public abstract class AbstractModelBase {
      */
     // FIXME: limitation of excel
     public void setComplete(String key, String value) {
+        // clear the current value before writing the new value
+        int index = 1;
+        while (get(key + " (split-" + index + ")") != null) {
+            set(key + " (split-" + index + ")", null);
+            index++;
+        }
+
+        // if the new value is null, no need to split the value
         if (value == null) {
             set(key, null);
             return;
         }
+
         // if the content is longer than the maximum cell length, it has to be split up into multiple cells
         if (value.length() <= InventoryWriter.MAX_CELL_LENGTH) {
             set(key, value);
         } else {
-            int index = 0;
+            index = 0;
             while (index * InventoryWriter.MAX_CELL_LENGTH < value.length()) {
                 String part = value.substring(index * InventoryWriter.MAX_CELL_LENGTH, Math.min(value.length(), (index + 1) * InventoryWriter.MAX_CELL_LENGTH));
                 if (index == 0) set(key, part);

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/model/Artifact.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/model/Artifact.java
@@ -287,9 +287,8 @@ public class Artifact extends AbstractModelBase {
      * Where the file component is constructed as artifactId-version[-classifier].type. The version therefore can be used to
      * separate the artifactId from the remaining pieces of the file component.
      *
-     * @param id The artifact id.
+     * @param id      The artifact id.
      * @param version The version of the artifact.
-     *
      * @return The derived artifact id or null, in case the version is not part of the file component.
      */
     public String extractArtifactId(String id, String version) {
@@ -566,6 +565,14 @@ public class Artifact extends AbstractModelBase {
 
     public void setVulnerability(String vulnerability) {
         set(Attribute.VULNERABILITY, vulnerability);
+    }
+
+    public String getCompleteVulnerability() {
+        return getComplete(Attribute.VULNERABILITY);
+    }
+
+    public void setCompleteVulnerability(String vulnerability) {
+        setComplete(Attribute.VULNERABILITY, vulnerability);
     }
 
     public boolean isValid() {

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/writer/InventoryWriter.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/writer/InventoryWriter.java
@@ -140,7 +140,7 @@ public class InventoryWriter {
                     // FIXME: log something
                     //        is this fine as log message?
                     LOG.warn("Cell content [{}] is longer than max cell length of [{}] and will be cropped", key, MAX_CELL_LENGTH);
-                    value = value.substring(0, Math.min(value.length(), MAX_CELL_LENGTH));
+                    value = value.substring(0, MAX_CELL_LENGTH);
                     value = value + "...";
                 }
                 myCell.setCellValue(new HSSFRichTextString(value));

--- a/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/model/ArtifactTest.java
+++ b/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/model/ArtifactTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2009-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.metaeffekt.core.inventory.processor.model;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.metaeffekt.core.inventory.processor.writer.InventoryWriter;
+
+import java.util.StringJoiner;
+
+public class ArtifactTest {
+
+    @Test
+    public void vulnerabilityLengthTest() {
+        Artifact artifact = new Artifact();
+        StringJoiner cveData = new StringJoiner(", ");
+        for (int i = 0; i < 4000; i++) cveData.add("CVE-2022-21907 (9.8)");
+        artifact.setCompleteVulnerability(cveData.toString());
+        Assert.assertEquals(InventoryWriter.MAX_CELL_LENGTH, artifact.get("Vulnerability (split-1)").length());
+        Assert.assertEquals(cveData.toString(), artifact.getCompleteVulnerability());
+    }
+
+    @Test
+    public void vulnerabilityNullTest() {
+        Artifact artifact = new Artifact();
+        artifact.setCompleteVulnerability(null);
+        Assert.assertNull(artifact.getCompleteVulnerability());
+    }
+
+}

--- a/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/model/ArtifactTest.java
+++ b/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/model/ArtifactTest.java
@@ -24,7 +24,7 @@ import java.util.StringJoiner;
 public class ArtifactTest {
 
     @Test
-    public void vulnerabilityLengthTest() {
+    public void completeVulnerabilityLengthTest() {
         Artifact artifact = new Artifact();
         StringJoiner cveData = new StringJoiner(", ");
         for (int i = 0; i < 4000; i++) cveData.add("CVE-2022-21907 (9.8)");
@@ -34,7 +34,18 @@ public class ArtifactTest {
     }
 
     @Test
-    public void vulnerabilityNullTest() {
+    public void completeVulnerabilityResetTest() {
+        Artifact artifact = new Artifact();
+        StringJoiner cveData = new StringJoiner(", ");
+        for (int i = 0; i < 4000; i++) cveData.add("CVE-2022-21907 (9.8)");
+        artifact.setCompleteVulnerability(cveData.toString());
+        Assert.assertNotNull(artifact.get("Vulnerability (split-1)"));
+        artifact.setCompleteVulnerability(null);
+        Assert.assertNull(artifact.get("Vulnerability (split-1)"));
+    }
+
+    @Test
+    public void completeVulnerabilityNullTest() {
         Artifact artifact = new Artifact();
         artifact.setCompleteVulnerability(null);
         Assert.assertNull(artifact.getCompleteVulnerability());


### PR DESCRIPTION
1. Excel limits the maximum cell length to `32767` characters.
   Some values that are to be stored in the inventory are longer than that value.
   Created methods:

   - `setComplete`
   - `getComplete`
   
   that safely create and read columns that can hold the entire string value.
2. Constant that holds the max cell length minus `7`: `InventoryWriter.MAX_CELL_LENGTH = SpreadsheetVersion.EXCEL97.getMaxTextLength() - 7`
3. Added a log message if the string that is to be written is too long.