### PR TITLE
Vulnerability report advisory provider filter

### DIFF
--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/InventoryReport.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/InventoryReport.java
@@ -39,7 +39,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.*;
-import java.util.stream.Collectors;
 
 import static org.metaeffekt.core.inventory.processor.model.Constants.*;
 
@@ -788,8 +787,6 @@ public class InventoryReport {
     }
 
     private void filterVulnerabilityMetadataByAdvisoryFilter(List<VulnerabilityMetaData> vulnerabilityMetaData) {
-        LOG.info("Filtering for {}", vulnerabilityAdvisoryFilter);
-        LOG.info("on {}", vulnerabilityMetaData.stream().map(VulnerabilityReportAdapter::getAdvisories).map(e -> e.stream().map(AdvisoryData::getSource).collect(Collectors.joining(", "))).collect(Collectors.joining(";; ")));
         if (vulnerabilityAdvisoryFilter.size() > 0) {
             vulnerabilityMetaData.removeIf(vmd ->
                     VulnerabilityReportAdapter.getAdvisories(vmd).stream()
@@ -1122,11 +1119,11 @@ public class InventoryReport {
     }
 
     public void addVulnerabilityAdvisoryFilter(String advisoryProvider) {
-        LOG.info("Adding filter [{}]", artifactFilter);
         if (advisoryProvider == null || advisoryProvider.length() == 0) {
             return;
         }
         if (Arrays.stream(VALID_VULNERABILITY_ADVISORY_PROVIDERS).anyMatch(e -> e.equals(advisoryProvider.toUpperCase()))) {
+            LOG.debug("Filtering vulnerabilities for advisory [{}]", artifactFilter);
             vulnerabilityAdvisoryFilter.add(advisoryProvider.toUpperCase());
         } else {
             LOG.warn("Unknown vulnerability advisory provider [{}], must be one of {}", advisoryProvider, Arrays.toString(VALID_VULNERABILITY_ADVISORY_PROVIDERS));

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/InventoryReport.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/InventoryReport.java
@@ -1119,14 +1119,17 @@ public class InventoryReport {
     }
 
     public void addVulnerabilityAdvisoryFilter(String advisoryProvider) {
-        if (advisoryProvider == null || advisoryProvider.length() == 0) {
-            return;
-        }
-        if (Arrays.stream(VALID_VULNERABILITY_ADVISORY_PROVIDERS).anyMatch(e -> e.equals(advisoryProvider.toUpperCase()))) {
-            LOG.debug("Filtering vulnerabilities for advisory [{}]", artifactFilter);
-            vulnerabilityAdvisoryFilter.add(advisoryProvider.toUpperCase());
-        } else {
-            LOG.warn("Unknown vulnerability advisory provider [{}], must be one of {}", advisoryProvider, Arrays.toString(VALID_VULNERABILITY_ADVISORY_PROVIDERS));
+        if (advisoryProvider != null && advisoryProvider.length() > 0) {
+            if (advisoryProvider.contains(",")) {
+                Arrays.stream(advisoryProvider.split(", ?")).forEach(this::addVulnerabilityAdvisoryFilter);
+            } else {
+                if (Arrays.stream(VALID_VULNERABILITY_ADVISORY_PROVIDERS).anyMatch(e -> e.equals(advisoryProvider.toUpperCase()))) {
+                    LOG.debug("Filtering vulnerabilities for advisory [{}]", artifactFilter);
+                    vulnerabilityAdvisoryFilter.add(advisoryProvider.toUpperCase());
+                } else {
+                    LOG.warn("Unknown vulnerability advisory provider [{}], must be one of {}", advisoryProvider, Arrays.toString(VALID_VULNERABILITY_ADVISORY_PROVIDERS));
+                }
+            }
         }
     }
 

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/InventoryReport.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/InventoryReport.java
@@ -38,10 +38,7 @@ import org.springframework.util.StringUtils;
 import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Properties;
-import java.util.Set;
+import java.util.*;
 
 import static org.metaeffekt.core.inventory.processor.model.Constants.*;
 
@@ -138,6 +135,7 @@ public class InventoryReport {
     private boolean failOnMissingComponentFiles = false;
 
     private float vulnerabilityScoreThreshold = 7.0f;
+    private final List<String> vulnerabilityAdvisoryFilter = new ArrayList<>();
 
     private ArtifactFilter artifactFilter;
 
@@ -598,7 +596,6 @@ public class InventoryReport {
      * @param licenseFolderName
      * @param targetDir
      * @param reportedLicenseFolders
-     *
      * @return true if all information is available.
      */
     private boolean checkAndCopyLicenseFolder(String licenseFolderName, File targetDir,
@@ -1015,6 +1012,7 @@ public class InventoryReport {
     }
 
     private PreFormattedEscapeUtils preFormattedEscapeUtils = new PreFormattedEscapeUtils();
+
     public String xmlEscapePreformattedContentString(String string) {
         if (string == null) return "";
 
@@ -1026,7 +1024,6 @@ public class InventoryReport {
 
         return s;
     }
-
 
 
     public String xmlEscapeLicense(String license) {
@@ -1101,6 +1098,20 @@ public class InventoryReport {
 
     public void setVulnerabilityScoreThreshold(float vulnerabilityScoreThreshold) {
         this.vulnerabilityScoreThreshold = vulnerabilityScoreThreshold;
+    }
+
+    private final static String[] VALID_VULNERABILITY_ADVISORY_PROVIDERS = {"CERT-FR", "CERT-SEI", "MSRC"};
+
+    public void addVulnerabilityAdvisoryFilter(String advisoryProvider) {
+        if (advisoryProvider == null || advisoryProvider.length() == 0) {
+            return;
+        }
+        if (Arrays.stream(VALID_VULNERABILITY_ADVISORY_PROVIDERS).anyMatch(e -> e.equals(advisoryProvider.toUpperCase()))) {
+            vulnerabilityAdvisoryFilter.add(advisoryProvider.toUpperCase());
+            LOG.info("Added [{}] to the vulnerability advisory filter", advisoryProvider.toUpperCase());
+        } else {
+            LOG.warn("Unknown vulnerability advisory provider [{}], must be one of [{}]", advisoryProvider, Arrays.toString(VALID_VULNERABILITY_ADVISORY_PROVIDERS));
+        }
     }
 
     public void setTargetReportDir(File reportTarget) {

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/VulnerabilityReportAdapter.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/VulnerabilityReportAdapter.java
@@ -34,14 +34,16 @@ public class VulnerabilityReportAdapter {
     }
 
     public List<VulnerabilityMetaData> getVulnerabilityMetaDataForDetailReport(float threshold) {
-        return VulnerabilityMetaData.sortVulnerabilitiesByOverallScore(VulnerabilityMetaData.filterVulnerabilitiesForDetails(inventory.getVulnerabilityMetaData(), threshold));
+        return VulnerabilityMetaData.sortVulnerabilitiesByOverallScore(
+                VulnerabilityMetaData.filterVulnerabilitiesForDetails(inventory.getVulnerabilityMetaData(), threshold)
+        );
     }
 
     public boolean hasDetails(VulnerabilityMetaData vulnerabilityMetaData, float threshold) {
         return VulnerabilityMetaData.hasDetails(vulnerabilityMetaData, threshold);
     }
 
-    public List<AdvisoryData> getAdvisories(VulnerabilityMetaData vulnerabilityMetaData) {
+    public static List<AdvisoryData> getAdvisories(VulnerabilityMetaData vulnerabilityMetaData) {
         List<AdvisoryData> advisoryDataList = new ArrayList<>();
 
         final String advisories = vulnerabilityMetaData.getComplete("Advisories");

--- a/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/RepositoryReportTest.java
+++ b/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/RepositoryReportTest.java
@@ -241,7 +241,11 @@ public class RepositoryReportTest {
     public void testCreateTestReport003() throws Exception {
         final File inventoryDir = new File("src/test/resources/test-inventory-03");
         final File reportDir = new File("target/test-inventory-03");
-        createReport(inventoryDir, "*.xls", reportDir);
+
+        InventoryReport report = new InventoryReport();
+        report.addVulnerabilityAdvisoryFilter("CERT-FR");
+
+        createReport(inventoryDir, "*.xls", reportDir, report);
 
         // put asserts here
 
@@ -250,7 +254,10 @@ public class RepositoryReportTest {
 
 
     private boolean createReport(File inventoryDir, String inventoryIncludes, File reportTarget) throws Exception {
-        InventoryReport report = new InventoryReport();
+        return createReport(inventoryDir, inventoryIncludes, reportTarget, new InventoryReport());
+    }
+
+    private boolean createReport(File inventoryDir, String inventoryIncludes, File reportTarget, InventoryReport report) throws Exception {
 
         report.setReportContext(new ReportContext("test", "Test", "Test Context"));
 

--- a/plugins/ae-inventory-maven-plugin/src/main/java/org/metaeffekt/core/maven/inventory/mojo/AbstractInventoryReportCreationMojo.java
+++ b/plugins/ae-inventory-maven-plugin/src/main/java/org/metaeffekt/core/maven/inventory/mojo/AbstractInventoryReportCreationMojo.java
@@ -26,7 +26,6 @@ import org.metaeffekt.core.inventory.processor.report.ReportContext;
 import org.metaeffekt.core.maven.kernel.log.MavenLogAdapter;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -292,7 +291,7 @@ public abstract class AbstractInventoryReportCreationMojo extends AbstractProjec
 
         // vulnerability settings
         report.setVulnerabilityScoreThreshold(Float.parseFloat(vulnerabilityScoreThreshold));
-        Arrays.stream(vulnerabilityAdvisoryFilter.split(", ?")).forEach(report::addVulnerabilityAdvisoryFilter);
+        report.addVulnerabilityAdvisoryFilter(vulnerabilityAdvisoryFilter);
 
         // diff settings
         report.setDiffInventoryFile(diffInventoryFile);

--- a/plugins/ae-inventory-maven-plugin/src/main/java/org/metaeffekt/core/maven/inventory/mojo/AbstractInventoryReportCreationMojo.java
+++ b/plugins/ae-inventory-maven-plugin/src/main/java/org/metaeffekt/core/maven/inventory/mojo/AbstractInventoryReportCreationMojo.java
@@ -26,6 +26,7 @@ import org.metaeffekt.core.inventory.processor.report.ReportContext;
 import org.metaeffekt.core.maven.kernel.log.MavenLogAdapter;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -220,6 +221,21 @@ public abstract class AbstractInventoryReportCreationMojo extends AbstractProjec
     private String vulnerabilityScoreThreshold;
 
     /**
+     * Comma seperated list of advisory providers. All vulnerabilities not containing at least one of the providers
+     * will be ignored when generating the report.<br>
+     * If left empty, no filter will be applied.<br>
+     * Available advisory providers:
+     * <ul>
+     *     <li>CERT-FR</li>
+     *     <li>CERT-SEI</li>
+     *     <li>MSRC</li>
+     * </ul>
+     *
+     * @parameter default-value=""
+     */
+    private String vulnerabilityAdvisoryFilter;
+
+    /**
      * @parameter default-value="en"
      */
     private String templateLanguageSelector;
@@ -276,6 +292,7 @@ public abstract class AbstractInventoryReportCreationMojo extends AbstractProjec
 
         // vulnerability settings
         report.setVulnerabilityScoreThreshold(Float.parseFloat(vulnerabilityScoreThreshold));
+        Arrays.stream(vulnerabilityAdvisoryFilter.split(", ?")).forEach(report::addVulnerabilityAdvisoryFilter);
 
         // diff settings
         report.setDiffInventoryFile(diffInventoryFile);


### PR DESCRIPTION
Via the configuration property

    <vulnerabilityAdvisoryFilter>CERT-SEI, CERT-FR, MSRC</vulnerabilityAdvisoryFilter>

in the `ae-inventory-maven-plugin` plugin, the `create-inventory-report` goal, vulnerabilities not containing a specific advisory type can be filtered out of the vulnerability report.

If the vulnerability contains at least one of the advisory providers listed, the vulnerability will be kept in the report.

This is documented in AEAA-113.