### PR TITLE
Remove accidental javax import, Remove "Generated" tag in inspect reader library

### DIFF
--- a/libraries/ae-inspect-reader/src/main/java/org/metaeffekt/reader/inspect/image/model/ImageInspectElement.java
+++ b/libraries/ae-inspect-reader/src/main/java/org/metaeffekt/reader/inspect/image/model/ImageInspectElement.java
@@ -21,7 +21,6 @@ import org.metaeffekt.reader.inspect.image.model.subtypes.ContainerConfig;
 import org.metaeffekt.reader.inspect.image.model.subtypes.GraphDriver;
 import org.metaeffekt.reader.inspect.image.model.subtypes.RootFS;
 
-import javax.annotation.Generated;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -48,7 +47,6 @@ import java.util.Map;
     "RootFS",
     "Metadata"
 })
-@Generated("jsonschema2pojo")
 public class ImageInspectElement {
 
     @JsonProperty("Id")

--- a/libraries/ae-inspect-reader/src/main/java/org/metaeffekt/reader/inspect/image/model/subtypes/Config.java
+++ b/libraries/ae-inspect-reader/src/main/java/org/metaeffekt/reader/inspect/image/model/subtypes/Config.java
@@ -17,7 +17,6 @@ package org.metaeffekt.reader.inspect.image.model.subtypes;
 
 import com.fasterxml.jackson.annotation.*;
 
-import javax.annotation.Generated;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -45,7 +44,6 @@ import java.util.Map;
     "ArgsEscaped",
     "ExposedPorts"
 })
-@Generated("jsonschema2pojo")
 public class Config {
 
     @JsonProperty("Hostname")

--- a/libraries/ae-inspect-reader/src/main/java/org/metaeffekt/reader/inspect/image/model/subtypes/ContainerConfig.java
+++ b/libraries/ae-inspect-reader/src/main/java/org/metaeffekt/reader/inspect/image/model/subtypes/ContainerConfig.java
@@ -17,7 +17,6 @@ package org.metaeffekt.reader.inspect.image.model.subtypes;
 
 import com.fasterxml.jackson.annotation.*;
 
-import javax.annotation.Generated;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -44,7 +43,6 @@ import java.util.Map;
     "Labels",
     "ExposedPorts"
 })
-@Generated("jsonschema2pojo")
 public class ContainerConfig {
 
     @JsonProperty("Hostname")

--- a/libraries/ae-inspect-reader/src/main/java/org/metaeffekt/reader/inspect/image/model/subtypes/Data.java
+++ b/libraries/ae-inspect-reader/src/main/java/org/metaeffekt/reader/inspect/image/model/subtypes/Data.java
@@ -17,7 +17,6 @@ package org.metaeffekt.reader.inspect.image.model.subtypes;
 
 import com.fasterxml.jackson.annotation.*;
 
-import javax.annotation.Generated;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -28,7 +27,6 @@ import java.util.Map;
     "WorkDir",
     "LowerDir"
 })
-@Generated("jsonschema2pojo")
 public class Data {
 
     @JsonProperty("MergedDir")

--- a/libraries/ae-inspect-reader/src/main/java/org/metaeffekt/reader/inspect/image/model/subtypes/GraphDriver.java
+++ b/libraries/ae-inspect-reader/src/main/java/org/metaeffekt/reader/inspect/image/model/subtypes/GraphDriver.java
@@ -17,7 +17,6 @@ package org.metaeffekt.reader.inspect.image.model.subtypes;
 
 import com.fasterxml.jackson.annotation.*;
 
-import javax.annotation.Generated;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -26,7 +25,6 @@ import java.util.Map;
     "Data",
     "Name"
 })
-@Generated("jsonschema2pojo")
 public class GraphDriver {
 
     @JsonProperty("Data")

--- a/libraries/ae-inspect-reader/src/main/java/org/metaeffekt/reader/inspect/image/model/subtypes/RootFS.java
+++ b/libraries/ae-inspect-reader/src/main/java/org/metaeffekt/reader/inspect/image/model/subtypes/RootFS.java
@@ -17,7 +17,6 @@ package org.metaeffekt.reader.inspect.image.model.subtypes;
 
 import com.fasterxml.jackson.annotation.*;
 
-import javax.annotation.Generated;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -28,7 +27,6 @@ import java.util.Map;
     "Type",
     "Layers"
 })
-@Generated("jsonschema2pojo")
 public class RootFS {
 
     @JsonProperty("Type")


### PR DESCRIPTION
The accidental javax import has been removed.

Some interesting warnings came up (odd generated code, bad equals method) when removing the annotation.
I might want to fix those too.