### PR TITLE
Vulnerability Report overview statistic tables

### DIFF
--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/InventoryReport.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/InventoryReport.java
@@ -138,6 +138,11 @@ public class InventoryReport {
 
     private float vulnerabilityScoreThreshold = 7.0f;
     private final List<String> vulnerabilityAdvisoryFilter = new ArrayList<>();
+    /**
+     * For what advisory providers to generate additional tables in the overview section containing statistic data on
+     * what vulnerabilities have already been reviewed.
+     */
+    private final List<String> generateOverviewTablesForAdvisories = new ArrayList<>();
 
     private ArtifactFilter artifactFilter;
 
@@ -1134,16 +1139,33 @@ public class InventoryReport {
         return Collections.unmodifiableList(vulnerabilityAdvisoryFilter);
     }
 
-    public void addVulnerabilityAdvisoryFilter(String advisoryProvider) {
-        if (advisoryProvider != null && advisoryProvider.length() > 0) {
-            if (advisoryProvider.contains(",")) {
-                Arrays.stream(advisoryProvider.split(", ?")).forEach(this::addVulnerabilityAdvisoryFilter);
-            } else {
-                if (Arrays.stream(VALID_VULNERABILITY_ADVISORY_PROVIDERS).anyMatch(e -> e.equals(advisoryProvider.toUpperCase()))) {
-                    LOG.debug("Filtering vulnerabilities for advisory [{}]", artifactFilter);
-                    vulnerabilityAdvisoryFilter.add(advisoryProvider.toUpperCase());
-                } else {
-                    LOG.warn("Unknown vulnerability advisory provider [{}], must be one of {}", advisoryProvider, Arrays.toString(VALID_VULNERABILITY_ADVISORY_PROVIDERS));
+    public void addVulnerabilityAdvisoryFilter(String... advisoryProvider) {
+        splitAndAppendCsvAdvisoryProviders(vulnerabilityAdvisoryFilter, advisoryProvider);
+    }
+
+    public List<String> getGenerateOverviewTablesForAdvisories() {
+        return generateOverviewTablesForAdvisories;
+    }
+
+    public void addGenerateOverviewTablesForAdvisories(String... advisoryProvider) {
+        splitAndAppendCsvAdvisoryProviders(generateOverviewTablesForAdvisories, advisoryProvider);
+    }
+
+    private void splitAndAppendCsvAdvisoryProviders(List<String> listToAddProvidersTo, String... commaSeperatedProviders) {
+        if (commaSeperatedProviders != null && commaSeperatedProviders.length > 0) {
+            for (String commaSeperatedProvider : commaSeperatedProviders) {
+                if (commaSeperatedProvider != null && commaSeperatedProvider.length() > 0) {
+                    if (commaSeperatedProvider.contains(",")) {
+                        splitAndAppendCsvAdvisoryProviders(listToAddProvidersTo, commaSeperatedProvider.split(", ?"));
+                    } else {
+                        if (Arrays.stream(VALID_VULNERABILITY_ADVISORY_PROVIDERS).anyMatch(e -> e.equals(commaSeperatedProvider.toUpperCase()))) {
+                            listToAddProvidersTo.add(commaSeperatedProvider.toUpperCase());
+                        } else if (commaSeperatedProvider.equals("ALL")) {
+                            listToAddProvidersTo.addAll(Arrays.asList(VALID_VULNERABILITY_ADVISORY_PROVIDERS));
+                        } else {
+                            LOG.warn("Unknown vulnerability advisory provider [{}], must be one of {}", commaSeperatedProvider, Arrays.toString(VALID_VULNERABILITY_ADVISORY_PROVIDERS));
+                        }
+                    }
                 }
             }
         }

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/VulnerabilityReportAdapter.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/VulnerabilityReportAdapter.java
@@ -28,7 +28,7 @@ import java.util.stream.Collectors;
  */
 public class VulnerabilityReportAdapter {
 
-    private Inventory inventory;
+    private final Inventory inventory;
 
     public VulnerabilityReportAdapter(Inventory inventory) {
         this.inventory = inventory;
@@ -121,6 +121,172 @@ public class VulnerabilityReportAdapter {
                 .filter(e -> Objects.equals(status, e.get(CertMetaData.Attribute.REVIEW_STATUS)))
                 .sorted(CertMetaData.CERT_COMPARATOR_LAST_UPDATED_DESC)
                 .collect(Collectors.toList());
+    }
+
+    public StatisticsOverviewTable createStatisticsOverviewTable() {
+        return createStatisticsOverviewTable(null);
+    }
+
+    public StatisticsOverviewTable createStatisticsOverviewTable(String filterCert) {
+        return StatisticsOverviewTable.generateFromInventory(inventory, filterCert);
+    }
+
+    private static void filterVulnerabilityMetaDataForAdvisories(List<VulnerabilityMetaData> vmds, String filterCert) {
+        vmds.removeIf(
+                vmd -> {
+                    String adv = vmd.getComplete("Advisories");
+                    if (adv == null) return true;
+                    JSONArray advisories = new JSONArray(adv);
+                    for (int j = 0; j < advisories.length(); j++) {
+                        if (advisories.optJSONObject(j).optString("source", "").equals(filterCert)) {
+                            return false;
+                        }
+                    }
+                    return true;
+                }
+        );
+    }
+
+    public static class StatisticsOverviewTable {
+        private final Map<String, Map<String, Integer>> severityStatusCountMap = new LinkedHashMap<>();
+
+        private void addSeverityCategory(String severityCategory) {
+            severityStatusCountMap.putIfAbsent(normalize(severityCategory), new LinkedHashMap<>());
+        }
+
+        private void addStatus(String status) {
+            final String normalizedStatus = normalize(status);
+            severityStatusCountMap.values().forEach(m -> m.putIfAbsent(normalizedStatus, 0));
+        }
+
+        private void incrementCount(String severity, String status) {
+            severity = normalize(severity);
+            status = normalize(status);
+            addSeverityCategory(severity);
+            addStatus(status);
+            severityStatusCountMap.get(severity).put(status, severityStatusCountMap.get(severity).get(status) + 1);
+        }
+
+        public List<String> getHeaders() {
+            List<String> headers = new ArrayList<>();
+            headers.add("Severity");
+            headers.addAll(severityStatusCountMap.values().stream().findFirst().orElse(new LinkedHashMap<>()).keySet());
+            return headers.stream().map(this::capitalizeWords).collect(Collectors.toList());
+        }
+
+        public List<String> getSeverityCategories() {
+            return severityStatusCountMap.keySet().stream().map(this::capitalizeWords).collect(Collectors.toList());
+        }
+
+        public List<Integer> getCountsForSeverityCategory(String severityCategory) {
+            severityCategory = normalize(severityCategory);
+            List<Integer> counts = new ArrayList<>();
+            for (String status : severityStatusCountMap.get(severityCategory).keySet()) {
+                counts.add(severityStatusCountMap.get(severityCategory).get(status));
+            }
+            return counts;
+        }
+
+        /**
+         * Checks if the table is empty.<br>
+         * The table is considered empty if all cells have the value "0", except for the "% assessed" column.
+         *
+         * @return true if the table is empty, false otherwise.
+         */
+        public boolean isEmpty() {
+            for (Map<String, Integer> m : severityStatusCountMap.values()) {
+                for (Map.Entry<String, Integer> e : m.entrySet()) {
+                    if (!e.getKey().equals("% assessed")) {
+                        if (e.getValue() != 0) {
+                            return false;
+                        }
+                    }
+                }
+            }
+            return true;
+        }
+
+        private String normalize(String s) {
+            return s.toLowerCase();
+        }
+
+        private String capitalizeWords(String s) {
+            if (s == null || s.isEmpty()) {
+                return s;
+            }
+            return Arrays.stream(s.split(" "))
+                    .map(word -> Character.toUpperCase(word.charAt(0)) + word.substring(1))
+                    .collect(Collectors.joining(" "));
+        }
+
+        public static StatisticsOverviewTable generateFromInventory(Inventory inventory, String filterCert) {
+            List<VulnerabilityMetaData> vmds = new ArrayList<>(inventory.getVulnerabilityMetaData());
+            if (filterCert != null) {
+                filterVulnerabilityMetaDataForAdvisories(vmds, filterCert);
+            }
+
+            StatisticsOverviewTable table = new StatisticsOverviewTable();
+
+            // add the default severity categories in the case there are no vulnerabilities with that category
+            for (String severityCategory : new String[]{"critical", "high", "medium", "low"}) {
+                table.addSeverityCategory(severityCategory);
+            }
+
+            for (VulnerabilityMetaData vmd : vmds) {
+                String severity = vmd.getComplete("CVSS Unmodified Severity (max)");
+                String status = vmd.getComplete(VulnerabilityMetaData.Attribute.STATUS);
+                if (status == null) status = "not assessed";
+                if (severity == null) severity = "unset";
+
+                table.incrementCount(severity, status);
+            }
+
+            // make sure all severities have all statuses
+            for (String severity : table.severityStatusCountMap.keySet()) {
+                table.severityStatusCountMap.get(severity).forEach((status, count) -> {
+                    table.addStatus(status);
+                });
+            }
+
+            // find the total number of vulnerabilities for each severity category
+            for (Map.Entry<String, Map<String, Integer>> severityMap : table.severityStatusCountMap.entrySet()) {
+                int total = 0;
+                for (Map.Entry<String, Integer> statusMap : severityMap.getValue().entrySet()) {
+                    total += statusMap.getValue();
+                }
+                severityMap.getValue().put("total", total);
+            }
+
+            // find the % of assessed vulnerabilities for each severity category
+            for (Map.Entry<String, Map<String, Integer>> severityMap : table.severityStatusCountMap.entrySet()) {
+                int applicable = severityMap.getValue().getOrDefault("applicable", 0);
+                int notApplicable = severityMap.getValue().getOrDefault("not applicable", 0);
+                int notAssessed = severityMap.getValue().getOrDefault("not assessed", 0);
+                if (notAssessed == 0) {
+                    severityMap.getValue().put("% assessed", 100);
+                } else {
+                    // ratio of (applicable + not applicable) to (applicable + not applicable + not assessed)
+                    double ratio = (double) (applicable + notApplicable) / (notAssessed + applicable + notApplicable);
+                    severityMap.getValue().put("% assessed", (int) (ratio * 100));
+                }
+            }
+
+            return table;
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+
+            sb.append(String.join(" ", getHeaders())).append("\n");
+            for (String severityCategory : getSeverityCategories()) {
+                sb.append(severityCategory).append("\t");
+                sb.append(getCountsForSeverityCategory(severityCategory).stream().map(String::valueOf).collect(Collectors.joining("\t"))).append("\n");
+            }
+            sb.append("\n");
+
+            return sb.toString();
+        }
     }
 
     public static class LabelColor {

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/VulnerabilityReportAdapter.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/VulnerabilityReportAdapter.java
@@ -227,7 +227,7 @@ public class VulnerabilityReportAdapter {
 
         private static String getStatusFromVMD(VulnerabilityMetaData vulnerabilityMetaData) {
             final String status = vulnerabilityMetaData.getComplete(VulnerabilityMetaData.Attribute.STATUS);
-            if (status == null) return "not assessed";
+            if (status == null) return "in review";
             return status;
         }
 
@@ -270,12 +270,12 @@ public class VulnerabilityReportAdapter {
             for (Map.Entry<String, Map<String, Integer>> severityMap : table.severityStatusCountMap.entrySet()) {
                 int applicable = severityMap.getValue().getOrDefault("applicable", 0);
                 int notApplicable = severityMap.getValue().getOrDefault("not applicable", 0);
-                int notAssessed = severityMap.getValue().getOrDefault("not assessed", 0);
-                if (notAssessed == 0) {
+                int inReview = severityMap.getValue().getOrDefault("in review", 0);
+                if (inReview == 0) {
                     severityMap.getValue().put("% assessed", 100);
                 } else {
-                    // ratio of (applicable + not applicable) to (applicable + not applicable + not assessed)
-                    double ratio = (double) (applicable + notApplicable) / (notAssessed + applicable + notApplicable);
+                    // ratio of (applicable + not applicable) to (applicable + not applicable + in review)
+                    double ratio = (double) (applicable + notApplicable) / (inReview + applicable + notApplicable);
                     severityMap.getValue().put("% assessed", (int) (ratio * 100));
                 }
             }
@@ -299,8 +299,8 @@ public class VulnerabilityReportAdapter {
     }
 
     public static class LabelColor {
-        private String background;
-        private String foreground;
+        private final String background;
+        private final String foreground;
 
         LabelColor(String background, String foreground) {
             this.background = background;

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/VulnerabilityReportAdapter.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/VulnerabilityReportAdapter.java
@@ -219,9 +219,21 @@ public class VulnerabilityReportAdapter {
                     .collect(Collectors.joining(" "));
         }
 
+        private static String getSeverityFromVMD(VulnerabilityMetaData vulnerabilityMetaData) {
+            final String severity = vulnerabilityMetaData.getComplete("CVSS Unmodified Severity (max)");
+            if (severity == null) return "unset";
+            return severity;
+        }
+
+        private static String getStatusFromVMD(VulnerabilityMetaData vulnerabilityMetaData) {
+            final String status = vulnerabilityMetaData.getComplete(VulnerabilityMetaData.Attribute.STATUS);
+            if (status == null) return "not assessed";
+            return status;
+        }
+
         public static StatisticsOverviewTable generateFromInventory(Inventory inventory, String filterCert) {
             List<VulnerabilityMetaData> vmds = new ArrayList<>(inventory.getVulnerabilityMetaData());
-            if (filterCert != null) {
+            if (filterCert != null && !filterCert.isEmpty()) {
                 filterVulnerabilityMetaDataForAdvisories(vmds, filterCert);
             }
 
@@ -232,23 +244,20 @@ public class VulnerabilityReportAdapter {
                 table.addSeverityCategory(severityCategory);
             }
 
+            // the columns have to be created first, for them to be added in the correct order below
             for (VulnerabilityMetaData vmd : vmds) {
-                String severity = vmd.getComplete("CVSS Unmodified Severity (max)");
-                String status = vmd.getComplete(VulnerabilityMetaData.Attribute.STATUS);
-                if (status == null) status = "not assessed";
-                if (severity == null) severity = "unset";
+                table.addStatus(getStatusFromVMD(vmd));
+                table.addSeverityCategory(getSeverityFromVMD(vmd));
+            }
 
+            // now that the cells exist, count the individual severity and status combinations
+            for (VulnerabilityMetaData vmd : vmds) {
+                String status = getStatusFromVMD(vmd);
+                String severity = getSeverityFromVMD(vmd);
                 table.incrementCount(severity, status);
             }
 
-            // make sure all severities have all statuses
-            for (String severity : table.severityStatusCountMap.keySet()) {
-                table.severityStatusCountMap.get(severity).forEach((status, count) -> {
-                    table.addStatus(status);
-                });
-            }
-
-            // find the total number of vulnerabilities for each severity category
+            // add up the total number of vulnerabilities for each severity category
             for (Map.Entry<String, Map<String, Integer>> severityMap : table.severityStatusCountMap.entrySet()) {
                 int total = 0;
                 for (Map.Entry<String, Integer> statusMap : severityMap.getValue().entrySet()) {
@@ -280,8 +289,8 @@ public class VulnerabilityReportAdapter {
 
             sb.append(String.join(" ", getHeaders())).append("\n");
             for (String severityCategory : getSeverityCategories()) {
-                sb.append(severityCategory).append("\t");
-                sb.append(getCountsForSeverityCategory(severityCategory).stream().map(String::valueOf).collect(Collectors.joining("\t"))).append("\n");
+                sb.append(String.format("%8s", severityCategory)).append("\t");
+                sb.append(getCountsForSeverityCategory(severityCategory).stream().map(String::valueOf).collect(Collectors.joining("\t\t"))).append("\n");
             }
             sb.append("\n");
 

--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/macros/inventory-report-vulnerabilities.vm
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/macros/inventory-report-vulnerabilities.vm
@@ -168,3 +168,42 @@
     </tgroup>
 </table>
 #end
+#macro (statisticsOverviewTable $id $title $filterCert)
+#set($overviewTableData=$vulnerabilityAdapter.createStatisticsOverviewTable($filterCert))
+#if($overviewTableData.isEmpty())
+    <p>
+        No matching vulnerabilities.
+    </p>
+#else
+    <table id="$id">
+        <title>$title</title>
+#set($colWidth=100 / $overviewTableData.getHeaders().size())
+        <tgroup cols="$overviewTableData.getHeaders().size()">
+#foreach($header in $overviewTableData.getHeaders())
+#set($colIndex=$overviewTableData.getHeaders().indexOf($header) + 1)
+            <colspec colname="COLSPEC$colIndex" colnum="$colIndex" colwidth="$colWidth*" />
+#end
+
+            <thead>
+                <row>
+#foreach($header in $overviewTableData.getHeaders())
+#set($colIndex=$overviewTableData.getHeaders().indexOf($header) + 1)
+                    <entry colname="COLSPEC$colIndex" valign="top">$header</entry>
+#end
+                </row>
+            </thead>
+
+            <tbody>
+#foreach($severityCategory in $overviewTableData.getSeverityCategories())
+                <row>
+                    <entry>$severityCategory</entry>
+#foreach($severityCategoryPerCategoryCount in $overviewTableData.getCountsForSeverityCategory($severityCategory))
+                    <entry>$severityCategoryPerCategoryCount</entry>
+#end
+                </row>
+#end
+            </tbody>
+        </tgroup>
+    </table>
+#end
+#end

--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/macros/inventory-report-vulnerabilities.vm
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/macros/inventory-report-vulnerabilities.vm
@@ -170,11 +170,7 @@
 #end
 #macro (statisticsOverviewTable $id $title $filterCert)
 #set($overviewTableData=$vulnerabilityAdapter.createStatisticsOverviewTable($filterCert))
-#if($overviewTableData.isEmpty())
-    <p>
-        No matching vulnerabilities.
-    </p>
-#else
+#if(!$overviewTableData.isEmpty())
     <table id="$id">
         <title>$title</title>
 #set($colWidth=100 / $overviewTableData.getHeaders().size())

--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/tpc_inventory-vulnerability-statistics.dita.vt
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/tpc_inventory-vulnerability-statistics.dita.vt
@@ -5,9 +5,9 @@
     <title>$reportContext.combinedTitle("Overview statistics tables", true)</title>
 
     <body>
-#statisticsOverviewTable("all_vulnerabilities_statistics_table", "All vulnerabilities$reportContext.inContextOf()", "")
-#statisticsOverviewTable("cert_fr_vulnerabilities_statistics_table", "CERT-FR vulnerabilities$reportContext.inContextOf()", "CERT-FR")
-#statisticsOverviewTable("cert_sei_vulnerabilities_statistics_table", "CERT-SEI vulnerabilities$reportContext.inContextOf()", "CERT-SEI")
-#statisticsOverviewTable("msrc_vulnerabilities_statistics_table", "MSRC vulnerabilities$reportContext.inContextOf()", "MSRC")
+#statisticsOverviewTable("vulnerabilities_statistics_table_all", "All vulnerabilities$reportContext.inContextOf()", "")
+#foreach($advisory in $report.getGenerateOverviewTablesForAdvisories())
+#statisticsOverviewTable("vulnerabilities_statistics_table_$advisory.toLowerCase()", "Vulnerabilities with $advisory advisories$reportContext.inContextOf()", "$advisory")
+#end
     </body>
 </topic>

--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/tpc_inventory-vulnerability-statistics.dita.vt
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/tpc_inventory-vulnerability-statistics.dita.vt
@@ -5,9 +5,9 @@
     <title>$reportContext.combinedTitle("Overview statistics tables", true)</title>
 
     <body>
-#statisticsOverviewTable("vulnerabilities_statistics_table_all", "All vulnerabilities$reportContext.inContextOf()", "")
+#statisticsOverviewTable("vulnerabilities_statistics_table_all", "Overview table for all Vulnerabilities$reportContext.inContextOf()", "")
 #foreach($advisory in $report.getGenerateOverviewTablesForAdvisories())
-#statisticsOverviewTable("vulnerabilities_statistics_table_$advisory.toLowerCase()", "Vulnerabilities with $advisory advisories$reportContext.inContextOf()", "$advisory")
+#statisticsOverviewTable("vulnerabilities_statistics_table_$advisory.toLowerCase()", "Overview Table for Vulnerabilities with $advisory advisories$reportContext.inContextOf()", "$advisory")
 #end
     </body>
 </topic>

--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/tpc_inventory-vulnerability-statistics.dita.vt
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/tpc_inventory-vulnerability-statistics.dita.vt
@@ -1,0 +1,13 @@
+#parse("META-INF/templates/en/inventory-report-vulnerability/macros/inventory-report-vulnerabilities.vm")
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "http://docs.oasis-open.org/dita/v1.1/OS/dtd/topic.dtd">
+<topic id="tpc_vulnerability-summary-$reportContext.id" xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/">
+    <title>$reportContext.combinedTitle("Overview statistics tables", true)</title>
+
+    <body>
+#statisticsOverviewTable("all_vulnerabilities_statistics_table", "All vulnerabilities$reportContext.inContextOf()", "")
+#statisticsOverviewTable("cert_fr_vulnerabilities_statistics_table", "CERT-FR vulnerabilities$reportContext.inContextOf()", "CERT-FR")
+#statisticsOverviewTable("cert_sei_vulnerabilities_statistics_table", "CERT-SEI vulnerabilities$reportContext.inContextOf()", "CERT-SEI")
+#statisticsOverviewTable("msrc_vulnerabilities_statistics_table", "MSRC vulnerabilities$reportContext.inContextOf()", "MSRC")
+    </body>
+</topic>

--- a/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/RepositoryReportTest.java
+++ b/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/RepositoryReportTest.java
@@ -244,6 +244,7 @@ public class RepositoryReportTest {
 
         InventoryReport report = new InventoryReport();
         //report.addVulnerabilityAdvisoryFilter("CERT-FR"); // this also filters out the 'void' vulnerability
+        report.addGenerateOverviewTablesForAdvisories("CERT-FR", "CERT-SEI", "MSRC");
 
         createReport(inventoryDir, "*.xls", reportDir, report);
 

--- a/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/report/VulnerabilityReportAdapterTest.java
+++ b/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/report/VulnerabilityReportAdapterTest.java
@@ -60,6 +60,20 @@ public class VulnerabilityReportAdapterTest {
         Assert.assertEquals(Arrays.asList(1, 1, 100), vra.createStatisticsOverviewTable("MSRC").getCountsForSeverityCategory("unset"));
     }
 
+    @Test
+    public void createStatisticsOverviewTableAddStatusAfterwardsTest() {
+        Inventory inventory = new Inventory();
+        VulnerabilityReportAdapter vra = new VulnerabilityReportAdapter(inventory);
+
+        inventory.getVulnerabilityMetaData().add(createVMD(null, SEVERITY.CRITICAL.toString()));
+        inventory.getVulnerabilityMetaData().add(createVMD(null, SEVERITY.CRITICAL.toString()));
+        inventory.getVulnerabilityMetaData().add(createVMD(null, SEVERITY.HIGH.toString()));
+        inventory.getVulnerabilityMetaData().add(createVMD(null, SEVERITY.LOW.toString()));
+        inventory.getVulnerabilityMetaData().add(createVMD(VulnerabilityMetaData.STATUS_VALUE_VOID, null));
+
+        Assert.assertEquals(Arrays.asList(0, 1, 1, 100), vra.createStatisticsOverviewTable().getCountsForSeverityCategory("unset"));
+    }
+
     private VulnerabilityMetaData createVMD(String status, String severity, String... cert) {
         VulnerabilityMetaData vmd = new VulnerabilityMetaData();
 

--- a/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/report/VulnerabilityReportAdapterTest.java
+++ b/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/report/VulnerabilityReportAdapterTest.java
@@ -63,7 +63,7 @@ public class VulnerabilityReportAdapterTest {
         Assert.assertEquals(Arrays.asList("Critical", "High", "Medium", "Low"), vra.createStatisticsOverviewTable("CERT-SEI").getSeverityCategories());
         Assert.assertEquals(Arrays.asList(1, 1, 100), vra.createStatisticsOverviewTable("CERT-SEI").getCountsForSeverityCategory("critical"));
 
-        Assert.assertEquals(Arrays.asList("Severity", "Applicable", "Not Assessed", "Total", "% Assessed"), vra.createStatisticsOverviewTable().getHeaders());
+        Assert.assertEquals(Arrays.asList("Severity", "Applicable", "In Review", "Total", "% Assessed"), vra.createStatisticsOverviewTable().getHeaders());
         Assert.assertEquals(Arrays.asList("Critical", "High", "Medium", "Low"), vra.createStatisticsOverviewTable().getSeverityCategories());
         Assert.assertEquals(Arrays.asList(2, 1, 3, 66), vra.createStatisticsOverviewTable().getCountsForSeverityCategory("critical"));
         Assert.assertEquals(Arrays.asList(0, 1, 1, 0), vra.createStatisticsOverviewTable().getCountsForSeverityCategory("high"));

--- a/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/report/VulnerabilityReportAdapterTest.java
+++ b/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/report/VulnerabilityReportAdapterTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2009-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.metaeffekt.core.inventory.processor.report;
 
 import org.json.JSONArray;

--- a/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/report/VulnerabilityReportAdapterTest.java
+++ b/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/report/VulnerabilityReportAdapterTest.java
@@ -1,0 +1,77 @@
+package org.metaeffekt.core.inventory.processor.report;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Test;
+import org.metaeffekt.core.inventory.processor.model.Inventory;
+import org.metaeffekt.core.inventory.processor.model.VulnerabilityMetaData;
+
+import java.util.Arrays;
+
+public class VulnerabilityReportAdapterTest {
+
+    private enum SEVERITY {
+        CRITICAL,
+        HIGH,
+        MEDIUM,
+        LOW,
+        NONE
+    }
+
+    @Test
+    public void createStatisticsOverviewTableTest() {
+        Inventory inventory = new Inventory();
+        VulnerabilityReportAdapter vra = new VulnerabilityReportAdapter(inventory);
+
+        Assert.assertTrue(vra.createStatisticsOverviewTable().isEmpty());
+
+        inventory.getVulnerabilityMetaData().add(createVMD(VulnerabilityMetaData.STATUS_VALUE_APPLICABLE, SEVERITY.CRITICAL.toString(), "CERT-FR"));
+        inventory.getVulnerabilityMetaData().add(createVMD(VulnerabilityMetaData.STATUS_VALUE_APPLICABLE, SEVERITY.CRITICAL.toString(), "CERT-FR", "CERT-SEI"));
+
+        Assert.assertFalse(vra.createStatisticsOverviewTable().isEmpty());
+        Assert.assertTrue(vra.createStatisticsOverviewTable("MSRC").isEmpty());
+        Assert.assertFalse(vra.createStatisticsOverviewTable("CERT-FR").isEmpty());
+        Assert.assertEquals(Arrays.asList("Severity", "Applicable", "Total", "% Assessed"), vra.createStatisticsOverviewTable().getHeaders());
+        Assert.assertEquals(Arrays.asList("Critical", "High", "Medium", "Low"), vra.createStatisticsOverviewTable().getSeverityCategories());
+        Assert.assertEquals(Arrays.asList(2, 2, 100), vra.createStatisticsOverviewTable().getCountsForSeverityCategory("critical"));
+
+        inventory.getVulnerabilityMetaData().add(createVMD(null, SEVERITY.CRITICAL.toString()));
+        inventory.getVulnerabilityMetaData().add(createVMD(null, SEVERITY.HIGH.toString()));
+
+        Assert.assertFalse(vra.createStatisticsOverviewTable().isEmpty());
+        Assert.assertEquals(Arrays.asList("Severity", "Applicable", "Total", "% Assessed"), vra.createStatisticsOverviewTable("CERT-FR").getHeaders());
+        Assert.assertEquals(Arrays.asList("Critical", "High", "Medium", "Low"), vra.createStatisticsOverviewTable("CERT-FR").getSeverityCategories());
+        Assert.assertEquals(Arrays.asList(2, 2, 100), vra.createStatisticsOverviewTable("CERT-FR").getCountsForSeverityCategory("critical"));
+
+        Assert.assertEquals(Arrays.asList("Severity", "Applicable", "Total", "% Assessed"), vra.createStatisticsOverviewTable("CERT-SEI").getHeaders());
+        Assert.assertEquals(Arrays.asList("Critical", "High", "Medium", "Low"), vra.createStatisticsOverviewTable("CERT-SEI").getSeverityCategories());
+        Assert.assertEquals(Arrays.asList(1, 1, 100), vra.createStatisticsOverviewTable("CERT-SEI").getCountsForSeverityCategory("critical"));
+
+        Assert.assertEquals(Arrays.asList("Severity", "Applicable", "Not Assessed", "Total", "% Assessed"), vra.createStatisticsOverviewTable().getHeaders());
+        Assert.assertEquals(Arrays.asList("Critical", "High", "Medium", "Low"), vra.createStatisticsOverviewTable().getSeverityCategories());
+        Assert.assertEquals(Arrays.asList(2, 1, 3, 66), vra.createStatisticsOverviewTable().getCountsForSeverityCategory("critical"));
+        Assert.assertEquals(Arrays.asList(0, 1, 1, 0), vra.createStatisticsOverviewTable().getCountsForSeverityCategory("high"));
+
+        inventory.getVulnerabilityMetaData().add(createVMD(VulnerabilityMetaData.STATUS_VALUE_VOID, null, "MSRC"));
+        Assert.assertEquals(Arrays.asList("Severity", "Void", "Total", "% Assessed"), vra.createStatisticsOverviewTable("MSRC").getHeaders());
+        Assert.assertEquals(Arrays.asList("Critical", "High", "Medium", "Low", "Unset"), vra.createStatisticsOverviewTable("MSRC").getSeverityCategories());
+        Assert.assertEquals(Arrays.asList(0, 0, 100), vra.createStatisticsOverviewTable("MSRC").getCountsForSeverityCategory("high"));
+        Assert.assertEquals(Arrays.asList(1, 1, 100), vra.createStatisticsOverviewTable("MSRC").getCountsForSeverityCategory("unset"));
+    }
+
+    private VulnerabilityMetaData createVMD(String status, String severity, String... cert) {
+        VulnerabilityMetaData vmd = new VulnerabilityMetaData();
+
+        vmd.set(VulnerabilityMetaData.Attribute.STATUS, status);
+        vmd.set("CVSS Unmodified Severity (max)", severity);
+        JSONArray certs = new JSONArray();
+        for (String c : cert) {
+            certs.put(new JSONObject().put("source", c));
+        }
+        vmd.set("Advisories", certs.toString());
+
+        return vmd;
+    }
+
+}

--- a/plugins/ae-inventory-maven-plugin/src/main/java/org/metaeffekt/core/maven/inventory/mojo/AbstractInventoryReportCreationMojo.java
+++ b/plugins/ae-inventory-maven-plugin/src/main/java/org/metaeffekt/core/maven/inventory/mojo/AbstractInventoryReportCreationMojo.java
@@ -225,14 +225,31 @@ public abstract class AbstractInventoryReportCreationMojo extends AbstractProjec
      * If left empty, no filter will be applied.<br>
      * Available advisory providers:
      * <ul>
-     *     <li>CERT-FR</li>
-     *     <li>CERT-SEI</li>
-     *     <li>MSRC</li>
+     *     <li><code>CERT-FR</code></li>
+     *     <li><code>CERT-SEI</code></li>
+     *     <li><code>MSRC</code></li>
      * </ul>
+     * To address all providers, use <code>ALL</code>
      *
      * @parameter default-value=""
      */
     private String vulnerabilityAdvisoryFilter;
+
+    /**
+     * Comma seperated list of advisory providers. For every provider, an additional overview table will be generated
+     * only evaluating the vulnerabilities containing the respecting provider.<br>
+     * If left empty, no additional table will be created.<br>
+     * Available advisory providers:
+     * <ul>
+     *     <li><code>CERT-FR</code></li>
+     *     <li><code>CERT-SEI</code></li>
+     *     <li><code>MSRC</code></li>
+     * </ul>
+     * To address all providers, use <code>ALL</code>
+     *
+     * @parameter default-value=""
+     */
+    private String generateOverviewTablesForAdvisories;
 
     /**
      * @parameter default-value="en"
@@ -292,6 +309,7 @@ public abstract class AbstractInventoryReportCreationMojo extends AbstractProjec
         // vulnerability settings
         report.setVulnerabilityScoreThreshold(Float.parseFloat(vulnerabilityScoreThreshold));
         report.addVulnerabilityAdvisoryFilter(vulnerabilityAdvisoryFilter);
+        report.addGenerateOverviewTablesForAdvisories(generateOverviewTablesForAdvisories);
 
         // diff settings
         report.setDiffInventoryFile(diffInventoryFile);


### PR DESCRIPTION
Generates a new dita topic containing overview statistics, such as the table below:

<img width="676" alt="Screenshot 2022-05-17 at 11 45 48" src="https://user-images.githubusercontent.com/37689635/168782496-f21837d8-a9bb-4dbc-845f-bf5df1ad8614.png">

To also include filtered views for different advisory providers (`CERT-FR`, `CERT-SEI`, `MSRC` or `ALL`), set the parameter `generateOverviewTablesForAdvisories` in the POM or call the according add-method in the inventory report class.

The `% Assessed` column is calculated using the `applicable`, `not applicable` and `in review` columns. The `void` and `insignificant` columns are ignored for this.