### PR TITLE
AEAA-90: Vulnerability "Affected Components" table with MS KB information

### DIFF
--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/VulnerabilityReportAdapter.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/VulnerabilityReportAdapter.java
@@ -16,6 +16,8 @@
 package org.metaeffekt.core.inventory.processor.report;
 
 import org.json.JSONArray;
+import org.json.JSONObject;
+import org.metaeffekt.core.inventory.processor.model.Artifact;
 import org.metaeffekt.core.inventory.processor.model.CertMetaData;
 import org.metaeffekt.core.inventory.processor.model.Inventory;
 import org.metaeffekt.core.inventory.processor.model.VulnerabilityMetaData;
@@ -121,6 +123,94 @@ public class VulnerabilityReportAdapter {
                 .filter(e -> Objects.equals(status, e.get(CertMetaData.Attribute.REVIEW_STATUS)))
                 .sorted(CertMetaData.CERT_COMPARATOR_LAST_UPDATED_DESC)
                 .collect(Collectors.toList());
+    }
+
+    public List<Artifact> getAffectedComponents(VulnerabilityMetaData vmd) {
+        String name = vmd.get(VulnerabilityMetaData.Attribute.NAME);
+
+        return inventory.getArtifacts().stream().filter(
+                a -> getCveForArtifact(a).stream().anyMatch(cve -> cve.get(VulnerabilityMetaData.Attribute.NAME).equals(name))
+        ).collect(Collectors.toList());
+    }
+
+    public List<VulnerabilityMetaData> getCveForArtifact(Artifact artifact) {
+        List<VulnerabilityMetaData> vulnerabilities = new ArrayList<>();
+        String vulnerabilitiesString = artifact.getComplete(Artifact.Attribute.VULNERABILITY);
+
+        if (vulnerabilitiesString != null) {
+            for (String vulnerability : vulnerabilitiesString.split(", ?")) {
+                String name = vulnerability.trim().replaceAll(" .+", "");
+                VulnerabilityMetaData vmd = findVulnerabilityMetaData(name);
+                if (vmd != null) {
+                    vulnerabilities.add(vmd);
+                }
+            }
+        }
+
+        return vulnerabilities;
+    }
+
+    private VulnerabilityMetaData findVulnerabilityMetaData(String name) {
+        for (VulnerabilityMetaData vmd : inventory.getVulnerabilityMetaData()) {
+            if (vmd.get(VulnerabilityMetaData.Attribute.NAME).equals(name)) {
+                return vmd;
+            }
+        }
+
+        return null;
+    }
+
+    public List<String> getMicrosoftRemediationKBsForVulnerabilityOnArtifact(VulnerabilityMetaData vmd, Artifact artifact) {
+        List<String> kbIdentifiers = new ArrayList<>();
+
+        if (artifact.has("MS Remediations")) {
+            String vulnerabilityName = vmd.get(VulnerabilityMetaData.Attribute.NAME);
+            JSONObject remediationForVulnerability = new JSONObject(artifact.getComplete("MS Remediations"));
+
+            JSONArray remediationArray = remediationForVulnerability.optJSONArray(vulnerabilityName);
+            if (remediationArray != null) {
+                for (int i = 0; i < remediationArray.length(); i++) {
+                    JSONObject remediation = remediationArray.optJSONObject(i);
+                    if (remediation.has("kb")) {
+                        String kb = remediation.optString("kb", "N/A");
+                        kbIdentifiers.add(kb);
+                    }
+                }
+            }
+        }
+
+        return kbIdentifiers;
+    }
+
+    public Map<String, String> getMicrosoftRemediationUrlAndDescriptionForVulnerabilityOnArtifact(VulnerabilityMetaData vmd, Artifact artifact) {
+        Map<String, String> kbIdentifiers = new HashMap<>();
+
+        if (artifact.has("MS Remediations")) {
+            String vulnerabilityName = vmd.get(VulnerabilityMetaData.Attribute.NAME);
+            JSONObject remediationForVulnerability = new JSONObject(artifact.getComplete("MS Remediations"));
+
+            JSONArray remediationArray = remediationForVulnerability.optJSONArray(vulnerabilityName);
+            if (remediationArray != null) {
+                for (int i = 0; i < remediationArray.length(); i++) {
+                    JSONObject remediation = remediationArray.optJSONObject(i);
+                    if (remediation.has("url")) {
+                        String url = remediation.optString("url", "N/A");
+                        String description = remediation.optString("description", url);
+                        kbIdentifiers.put(url, description);
+                    }
+                }
+            }
+        }
+
+        return kbIdentifiers;
+    }
+
+    public boolean hasVulnerabilityMicrosoftRemediationInformationOnArtifact(VulnerabilityMetaData vmd, Collection<Artifact> artifacts) {
+        for (Artifact artifact : artifacts) {
+            if (getMicrosoftRemediationKBsForVulnerabilityOnArtifact(vmd, artifact).size() > 0) return true;
+            if (getMicrosoftRemediationUrlAndDescriptionForVulnerabilityOnArtifact(vmd, artifact).size() > 0) return true;
+        }
+        return false;
     }
 
     public StatisticsOverviewTable createStatisticsOverviewTable() {

--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/macros/inventory-report-vulnerabilities.vm
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/macros/inventory-report-vulnerabilities.vm
@@ -203,3 +203,86 @@
     </table>
 #end
 #end
+#macro(affectedComponentsTable $vulnerability $affectedComponents)
+#set($vulnerabilityName=$vulnerability.get("Name"))
+#if ($affectedComponents.size() > 0)
+#set($containsMsRemediationInformation=$vulnerabilityAdapter.hasVulnerabilityMicrosoftRemediationInformationOnArtifact($vulnerability, $affectedComponents))
+<table id="${vulnerabilityName}_affected_components}">
+    <title>${vulnerabilityName} Affected Components</title>
+    <tgroup cols="4">
+        <colspec colname="COLSPEC0" colnum="1" colwidth="10*" />
+        <colspec colname="COLSPEC1" colnum="2" colwidth="10*" />
+        <colspec colname="COLSPEC2" colnum="3" colwidth="8*" />
+        <colspec colname="COLSPEC3" colnum="4" colwidth="20*" />
+        #if($containsMsRemediationInformation)
+            <colspec colname="COLSPEC4" colnum="5" colwidth="20*" />
+        #end
+        <thead>
+        <row>
+            <entry colname="COLSPEC0" valign="top">Id</entry>
+            <entry colname="COLSPEC1" valign="top">Component</entry>
+            <entry colname="COLSPEC2" valign="top">Version</entry>
+            <entry colname="COLSPEC3" valign="top">Related Vulnerabilities</entry>
+            #if($containsMsRemediationInformation)
+                <entry colname="COLSPEC4" valign="top">MS Remediation</entry>
+            #end
+        </row>
+        </thead>
+        <tbody>
+            #foreach($artifact in $affectedComponents)
+            <row>
+                <entry>$report.xmlEscapePreformattedContentString($artifact.get("Id"))</entry>
+                <entry>$report.xmlEscapePreformattedContentString($artifact.get("Component"))</entry>
+                <entry>$report.xmlEscapePreformattedContentString($artifact.get("Version"))</entry>
+                <entry>
+                    #set($relatedVulnerabilities=$vulnerabilityAdapter.getCveForArtifact($artifact))
+                    #set($indexCounter=0)
+#foreach($relatedVulnerability in $relatedVulnerabilities)
+#if(!$relatedVulnerability.get("Name").equals($vulnerabilityName))
+#if ($vulnerabilityAdapter.hasDetails($relatedVulnerability, $threshold))<xref href="tpc_inventory-vulnerability-details.dita#$relatedVulnerability.get("Name")" type="topic"><codeph>$report.xmlEscapeString($relatedVulnerability.get("Name"))</codeph></xref>#else<xref href="$relatedVulnerability.get("Url")" type="html" scope="external"><codeph>$report.xmlEscapeString($relatedVulnerability.get("Name"))</codeph></xref>#end
+#set($indexCounter=$indexCounter + 1)
+#if($indexCounter < $relatedVulnerabilities.size() - 1)
+,
+#end
+#end
+#end
+                </entry>
+                #if($containsMsRemediationInformation)
+                    <entry>
+                        #set($msRemediationKbIdentifiers=$vulnerabilityAdapter.getMicrosoftRemediationKBsForVulnerabilityOnArtifact($vulnerability, $artifact))
+                        #if($msRemediationKbIdentifiers.size() > 0)
+                            <p>
+#set($indexCounter=0)
+#foreach($kb in $msRemediationKbIdentifiers)
+KB$kb
+#set($indexCounter=$indexCounter + 1)
+#if($indexCounter < $msRemediationKbIdentifiers.size() - 1)
+,
+#end
+#end
+                            </p>
+                        #end
+                        #set($msRemediationUrlDescription=$vulnerabilityAdapter.getMicrosoftRemediationUrlAndDescriptionForVulnerabilityOnArtifact($vulnerability, $artifact))
+                        #if($msRemediationUrlDescription.size() > 0)
+                            <p>
+#set($indexCounter=0)
+#foreach($entry in $msRemediationUrlDescription.entrySet())
+<xref href="$entry.getKey()" type="html" scope="external">$entry.getValue()</xref>
+#set($indexCounter=$indexCounter + 1)
+#if($indexCounter < $msRemediationUrlDescription.size() - 1)
+,
+#end
+#end
+                            </p>
+                        #end
+                    </entry>
+                #end
+            </row>
+            #end
+        </tbody>
+    </tgroup>
+</table>
+#else
+There are no affected components for this vulnerability.
+#end
+#end

--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/tpc_inventory-vulnerability-details.dita.vt
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/tpc_inventory-vulnerability-details.dita.vt
@@ -1,7 +1,7 @@
 #parse("META-INF/templates/en/inventory-report-vulnerability/macros/inventory-report-vulnerabilities.vm")
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "http://docs.oasis-open.org/dita/v1.1/OS/dtd/topic.dtd">
-<topic id="tpc_vulnerability-summary-$reportContext.id" xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/">
+<topic id="tpc_vulnerability-summary-$reportContext.id">
     <title>$reportContext.combinedTitle("Vulnerability Details", true)</title>
 #set($threshold=$report.getVulnerabilityScoreThreshold())
 #set($vulnerabilities=$vulnerabilityAdapter.getVulnerabilityMetaDataForDetailReport($threshold))
@@ -90,6 +90,14 @@
         <topic id="$vulnerability.get("Name")-assessment">
             <title>Assessment</title>
             <body>
+#set($affectedComponents=$vulnerabilityAdapter.getAffectedComponents($vulnerability))
+                <section>
+                    <title>Affected Components</title>
+                    <body>
+#affectedComponentsTable($vulnerability, $affectedComponents)
+                    </body>
+                </section>
+
                 <section>
                     <title>Applicability Status</title>
                     <body>
@@ -98,11 +106,17 @@
                             #set($labelColor=$vulnerabilityAdapter.getStatusLabelColor($labelText))
                             #label($labelText, $labelColor, 140, 70)
                         </p>
-#if ($vulnerability.get("Rationale"))
-                        <p>$report.xmlEscapePreformattedContentString($vulnerability.get("Rationale"))</p>
-#end
                     </body>
                 </section>
+
+#if ($vulnerability.get("Rationale"))
+                <section>
+                    <title>Rationale</title>
+                    <body>
+                        $report.xmlEscapePreformattedContentString($vulnerability.get("Rationale"))
+                    </body>
+                </section>
+#end
 
 #if ($vulnerability.get("Risk"))
                 <section>
@@ -121,6 +135,7 @@
                     </body>
                 </section>
 #end
+
             </body>
         </topic>
     </topic>


### PR DESCRIPTION
The affected components will now be listed in the vulnerability details of the vulnerability report:

<img width="711" alt="Screenshot 2022-05-31 at 13 55 27" src="https://user-images.githubusercontent.com/37689635/171167385-4bba3ee5-fc4d-49d9-8d43-ec6b5f6bf033.png">


If Microsoft Remediation information on the artifact is present, it will be included as well:

<img width="1324" alt="Screenshot 2022-05-31 at 12 52 31" src="https://user-images.githubusercontent.com/37689635/171166929-f95545d7-dbb3-42d3-a59c-8d904e94cf7a.png">

<img width="1339" alt="Screenshot 2022-05-31 at 12 29 01" src="https://user-images.githubusercontent.com/37689635/171166948-99858b26-7c42-4bb7-9fe1-e8e2ec7d6140.png">

