### PR TITLE
AEAA-182: VR: Fixed modified CVSS chart being displayed even if vectors not present

### DIFF
--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/macros/inventory-report-vulnerabilities.vm
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/macros/inventory-report-vulnerabilities.vm
@@ -192,7 +192,6 @@
 </table>
 #end
 #macro (severityDetailsModified $id $title $vulnerability)
-#if ($vulnerability.get("CVSS Modified Vector (v2)") || $vulnerability.get("CVSS Modified Vector (v3)"))
 <table id="$id">
     <title>$title</title>
     <tgroup cols="4">
@@ -234,11 +233,6 @@
         </tbody>
     </tgroup>
 </table>
-#else
-<p>
-    The provided CVSS vectors have not been modified.
-</p>
-#end
 #end
 #macro (severityChartModified $id $title $vulnerability)
 #set($vulnerabilityName=$vulnerability.get("Name"))

--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/tpc_inventory-vulnerability-details.dita.vt
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/tpc_inventory-vulnerability-details.dita.vt
@@ -124,10 +124,16 @@
                 <section>
                     <title>Modified Severity</title>
                     <body>
+#if ($vulnerability.get("CVSS Modified Vector (v2)") || $vulnerability.get("CVSS Modified Vector (v3)"))
                         <p>
                             #severityDetailsModified("${vulnerabilityName}_modified_severity", "$vulnerabilityName Modified Severity", $vulnerability)
                         </p>
                         #severityChartModified("${vulnerabilityName}_modified_severity_charts", "$vulnerabilityName Modified Severity Details", $vulnerability)
+#else
+                        <p>
+                            The provided CVSS vectors have not been modified.
+                        </p>
+#end
                     </body>
                 </section>
 


### PR DESCRIPTION
The check, whether modified CVSS information should be displayed previously only included the base information on the vectors. CVSS Charts would still be displayed in some cases, which would lead to corrupted tables with sometimes the chart being rendered twice.

This should now be fixed.