### PR TITLE
Remove warning when Vulnerability/Cert metadata is written without URL

### DIFF
--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/writer/InventoryWriter.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/writer/InventoryWriter.java
@@ -355,9 +355,7 @@ public class InventoryWriter {
                             break;
                         case URL:
                             cell.setCellValue(new HSSFRichTextString(value));
-                            if (StringUtils.isEmpty(value)) {
-                                LOG.warn("Vulnerability URL [{}] is null or empty on [{} {} {}]", value, cell.getSheet().getSheetName(), cell.getColumnIndex(), cell.getRowIndex());
-                            } else {
+                            if (StringUtils.isNotEmpty(value)) {
                                 Hyperlink link = myWorkBook.getCreationHelper().createHyperlink(HyperlinkType.URL);
                                 link.setAddress(value);
                                 cell.setHyperlink(link);
@@ -428,9 +426,7 @@ public class InventoryWriter {
                     switch (attribute) {
                         case URL:
                             cell.setCellValue(new HSSFRichTextString(value));
-                            if (StringUtils.isEmpty(value)) {
-                                LOG.warn("CertMetaData URL [{}] is null or empty on [{} {} {}]", value, cell.getSheet().getSheetName(), cell.getColumnIndex(), cell.getRowIndex());
-                            } else {
+                            if (StringUtils.isNotEmpty(value)) {
                                 Hyperlink link = myWorkBook.getCreationHelper().createHyperlink(HyperlinkType.URL);
                                 link.setAddress(value);
                                 cell.setHyperlink(link);


### PR DESCRIPTION
Whenever an inventory is being written to a file, a warning is logged if a vulnerability does not contain an URL. I have added this in the past to prevent the process from throwing an exception and instead warn the user.

`Vulnerability URL [null] is null or empty on [Vulnerabilities 1 46]`

This is not useful however, as the expected behavior without an URL is to simply write an empty field (`null`) and not a nullpointerexception or a warning.

This PR removes the two warnings.