### PR TITLE
AEAA-234: Inventory Info sheet

### DIFF
--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/model/Inventory.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/model/Inventory.java
@@ -176,10 +176,9 @@ public class Inventory {
     }
 
     public InventoryInfo findOrCreateInventoryInfo(String id) {
-        for (InventoryInfo inventoryInfo : getInventoryInfo()) {
-            if (id.equals(inventoryInfo.getId())) {
-                return inventoryInfo;
-            }
+        final InventoryInfo info = findInventoryInfo(id);
+        if (info != null) {
+            return info;
         }
 
         final InventoryInfo inventoryInfo = new InventoryInfo();
@@ -187,6 +186,16 @@ public class Inventory {
         getInventoryInfo().add(inventoryInfo);
 
         return inventoryInfo;
+    }
+
+    public InventoryInfo findInventoryInfo(String id) {
+        for (InventoryInfo inventoryInfo : getInventoryInfo()) {
+            if (id.equals(inventoryInfo.getId())) {
+                return inventoryInfo;
+            }
+        }
+
+        return null;
     }
 
     private boolean isVariableVersion(String version) {

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/model/Inventory.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/model/Inventory.java
@@ -61,6 +61,8 @@ public class Inventory {
 
     private List<CertMetaData> certMetaData = new ArrayList<>();
 
+    private List<InventoryInfo> inventoryInfo = new ArrayList<>();
+
     private List<AssetMetaData> assetMetaData = new ArrayList<>();
 
     private Map<String, String> licenseNameMap = new HashMap<>();
@@ -171,6 +173,20 @@ public class Inventory {
         }
 
         return null;
+    }
+
+    public InventoryInfo findOrCreateInventoryInfo(String id) {
+        for (InventoryInfo inventoryInfo : getInventoryInfo()) {
+            if (id.equals(inventoryInfo.getId())) {
+                return inventoryInfo;
+            }
+        }
+
+        final InventoryInfo inventoryInfo = new InventoryInfo();
+        inventoryInfo.set(InventoryInfo.Attribute.ID, id);
+        getInventoryInfo().add(inventoryInfo);
+
+        return inventoryInfo;
     }
 
     private boolean isVariableVersion(String version) {
@@ -610,10 +626,10 @@ public class Inventory {
     }
 
 
-
     private String artifactSortString(ArtifactLicenseData o1) {
         return o1.getComponentName() + "-" + o1.getComponentVersion();
     }
+
     private boolean matches(String effectiveLicense, LicenseMetaData match) {
         List<String> licenses = Arrays.asList(match.deriveLicenseInEffect().split("\\|"));
         return licenses.contains(effectiveLicense);
@@ -1443,7 +1459,7 @@ public class Inventory {
 
     public List<VulnerabilityMetaData> getVoidVulnerabilities() {
         List<VulnerabilityMetaData> vmd = VulnerabilityMetaData.filterVoidVulnerabilities(getVulnerabilityMetaData());
-         vmd.sort(VulnerabilityMetaData.VULNERABILITY_COMPARATOR_OVERALL_SCORE);
+        vmd.sort(VulnerabilityMetaData.VULNERABILITY_COMPARATOR_OVERALL_SCORE);
         return vmd;
     }
 
@@ -1453,6 +1469,14 @@ public class Inventory {
 
     public void setCertMetaData(List<CertMetaData> certMetaData) {
         this.certMetaData = certMetaData;
+    }
+
+    public List<InventoryInfo> getInventoryInfo() {
+        return inventoryInfo;
+    }
+
+    public void setInventoryInfo(List<InventoryInfo> inventoryInfo) {
+        this.inventoryInfo = inventoryInfo;
     }
 
     public List<AssetMetaData> getAssetMetaData() {

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/model/InventoryInfo.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/model/InventoryInfo.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2009-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.metaeffekt.core.inventory.processor.model;
+
+import org.springframework.util.ObjectUtils;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class InventoryInfo extends AbstractModelBase {
+
+    public InventoryInfo(InventoryInfo info) {
+        super(info);
+    }
+
+    public InventoryInfo() {
+    }
+
+    /**
+     * Core attributes to support cert advisories.
+     */
+    public enum Attribute implements AbstractModelBase.Attribute {
+        ID("Id");
+
+        private String key;
+
+        Attribute(String key) {
+            this.key = key;
+        }
+
+        public static Attribute match(String key) {
+            for (Attribute a : values()) {
+                if (a.getKey().equalsIgnoreCase(key)) {
+                    return a;
+                }
+            }
+            return null;
+        }
+
+        public String getKey() {
+            return key;
+        }
+    }
+
+    public static ArrayList<String> CORE_ATTRIBUTES = new ArrayList<>();
+
+    static {
+        // fix selection and order
+        CORE_ATTRIBUTES.add(Attribute.ID.getKey());
+    }
+
+    /**
+     * Validates that the mandatory attributes of a component are set.
+     *
+     * @return Boolean indicating whether the instance is valid.
+     */
+    public boolean isValid() {
+        if (ObjectUtils.isEmpty(get(Attribute.ID))) return false;
+        return true;
+    }
+
+    /**
+     * @return The derived string qualifier for this instance.
+     */
+    public String deriveQualifier() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(get(Attribute.ID));
+        return sb.toString();
+    }
+
+    /**
+     * The compare string representations is built from the core attributes.
+     *
+     * @return String to compare component patterns.
+     */
+    public String createCompareStringRepresentation() {
+        StringBuilder sb = new StringBuilder();
+        for (String attributeKey : CORE_ATTRIBUTES) {
+            if (sb.length() > 0) {
+                sb.append(":");
+            }
+            sb.append(get(attributeKey));
+        }
+        return sb.toString();
+    }
+
+    public String get(Attribute attribute, String defaultValue) {
+        return get(attribute.getKey(), defaultValue);
+    }
+
+    public float getFloat(Attribute attribute, float defaultValue) {
+        return getFloat(attribute.getKey(), defaultValue);
+    }
+
+    public String get(Attribute attribute) {
+        return get(attribute.getKey());
+    }
+
+    public void set(Attribute attribute, String value) {
+        set(attribute.getKey(), value);
+    }
+
+    public void append(Attribute attribute, String value, String delimiter) {
+        append(attribute.getKey(), value, delimiter);
+    }
+
+    public String getId() {
+        return get(Attribute.ID);
+    }
+
+    public static InventoryInfo getById(Collection<InventoryInfo> inventoryInfos, String id) {
+        return inventoryInfos.stream()
+                .filter(e -> id.equals(e.get(Attribute.ID)))
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/reader/AbstractXlsInventoryReader.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/reader/AbstractXlsInventoryReader.java
@@ -54,6 +54,7 @@ public abstract class AbstractXlsInventoryReader {
         readComponentPatternData(workbook, inventory);
         readVulnerabilityMetaData(workbook, inventory);
         readCertMetaData(workbook, inventory);
+        readInventoryInfo(workbook, inventory);
         readAssetMetaData(workbook, inventory);
 
         return inventory;
@@ -156,16 +157,45 @@ public abstract class AbstractXlsInventoryReader {
 
         while (rows.hasNext()) {
             HSSFRow row = (HSSFRow) rows.next();
-            CertMetaData vmd = readCertMetaData(row);
-            if (vmd != null) {
-                certMetadata.add(vmd);
-                columns = vmd.numAttributes();
+            CertMetaData cert = readCertMetaData(row);
+            if (cert != null) {
+                certMetadata.add(cert);
+                columns = cert.numAttributes();
             }
         }
 
         for (int i = 0; i < columns; i++) {
             int width = sheet.getColumnWidth(i);
             inventory.getContextMap().put("cert.column[" + i + "].width", width);
+        }
+    }
+
+    protected void readInventoryInfo(HSSFWorkbook workbook, Inventory inventory) {
+        HSSFSheet sheet = workbook.getSheet("Info");
+        if (sheet == null) return;
+        Iterator<?> rows = sheet.rowIterator();
+
+        List<InventoryInfo> inventoryInfo = new ArrayList<>();
+        inventory.setInventoryInfo(inventoryInfo);
+
+        if (rows.hasNext()) {
+            readInventoryInfoHeader((HSSFRow) rows.next());
+        }
+
+        int columns = 0;
+
+        while (rows.hasNext()) {
+            HSSFRow row = (HSSFRow) rows.next();
+            InventoryInfo info = readInventoryInfo(row);
+            if (info != null) {
+                inventoryInfo.add(info);
+                columns = info.numAttributes();
+            }
+        }
+
+        for (int i = 0; i < columns; i++) {
+            int width = sheet.getColumnWidth(i);
+            inventory.getContextMap().put("info.column[" + i + "].width", width);
         }
     }
 
@@ -213,6 +243,8 @@ public abstract class AbstractXlsInventoryReader {
     abstract protected void readVulnerabilityMetaDataHeader(HSSFRow row);
 
     abstract protected void readCertMetaDataHeader(HSSFRow row);
+
+    abstract protected void readInventoryInfoHeader(HSSFRow row);
 
     abstract protected void readAssetMetaDataHeader(HSSFRow row);
 
@@ -293,7 +325,12 @@ public abstract class AbstractXlsInventoryReader {
     protected AssetMetaData readAssetMetaData(HSSFRow row) {
         throw new UnsupportedOperationException();
     }
+
     protected CertMetaData readCertMetaData(HSSFRow row) {
+        throw new UnsupportedOperationException();
+    }
+
+    protected InventoryInfo readInventoryInfo(HSSFRow row) {
         throw new UnsupportedOperationException();
     }
 

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/reader/InventoryReader.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/reader/InventoryReader.java
@@ -39,6 +39,7 @@ public class InventoryReader extends AbstractXlsInventoryReader {
     private Map<Integer, String> componentPatternDataColumnMap = new HashMap<>();
     private Map<Integer, String> vulnerabilityMetaDataColumnMap = new HashMap<>();
     private Map<Integer, String> certMetaDataColumnMap = new HashMap<>();
+    private Map<Integer, String> inventoryInfoColumnMap = new HashMap<>();
     private Map<Integer, String> assetMetaDataColumnMap = new HashMap<>();
 
     @Override
@@ -74,6 +75,11 @@ public class InventoryReader extends AbstractXlsInventoryReader {
     @Override
     protected void readCertMetaDataHeader(HSSFRow row) {
         parseColumns(row, certMetaDataColumnMap);
+    }
+
+    @Override
+    protected void readInventoryInfoHeader(HSSFRow row) {
+        parseColumns(row, inventoryInfoColumnMap);
     }
 
     protected List<String> parseColumns(HSSFRow row, Map<Integer, String> map) {
@@ -215,6 +221,16 @@ public class InventoryReader extends AbstractXlsInventoryReader {
         readValues(row, certMetaData, this.certMetaDataColumnMap);
         if (certMetaData.isValid()) {
             return certMetaData;
+        }
+        return null;
+    }
+
+    @Override
+    protected InventoryInfo readInventoryInfo(HSSFRow row) {
+        final InventoryInfo info = new InventoryInfo();
+        readValues(row, info, this.inventoryInfoColumnMap);
+        if (info.isValid()) {
+            return info;
         }
         return null;
     }

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/writer/InventoryWriter.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/writer/InventoryWriter.java
@@ -70,6 +70,7 @@ public class InventoryWriter {
         writeComponentPatterns(inventory, workbook);
         writeVulnerabilities(inventory, workbook);
         writeCertMetaData(inventory, workbook);
+        writeInventoryInfo(inventory, workbook);
         writeLicenseData(inventory, workbook);
         writeAssetMetaData(inventory, workbook);
 
@@ -439,6 +440,60 @@ public class InventoryWriter {
                 } else {
                     cell.setCellValue(new HSSFRichTextString(value));
                 }
+            }
+        }
+
+        sheet.setAutoFilter(new CellRangeAddress(0, sheet.getLastRowNum(), 0, numCol - 1));
+    }
+
+    private void writeInventoryInfo(Inventory inventory, HSSFWorkbook myWorkBook) {
+        if (isEmpty(inventory.getInventoryInfo())) return;
+
+        HSSFSheet sheet = myWorkBook.createSheet("Info");
+        sheet.createFreezePane(0, 1);
+        sheet.setDefaultColumnWidth(20);
+
+        HSSFRow row = null;
+        HSSFCell cell = null;
+
+        int rowNum = 0;
+
+        row = sheet.createRow(rowNum++);
+
+        HSSFCellStyle headerStyle = createHeaderStyle(myWorkBook);
+
+        int cellNum = 0;
+
+        // create columns for key / value map content
+        Set<String> attributes = new HashSet<>();
+        for (InventoryInfo info : inventory.getInventoryInfo()) {
+            attributes.addAll(info.getAttributes());
+        }
+
+        attributes.removeAll(InventoryInfo.CORE_ATTRIBUTES);
+
+        List<String> ordered = new ArrayList<>(attributes);
+        Collections.sort(ordered);
+
+        List<String> finalOrder = new ArrayList<>(InventoryInfo.CORE_ATTRIBUTES);
+        finalOrder.addAll(ordered);
+
+        for (String key : finalOrder) {
+            cell = row.createCell(cellNum++);
+            cell.setCellStyle(headerStyle);
+            cell.setCellValue(new HSSFRichTextString(key));
+        }
+
+        int numCol = cellNum;
+
+        for (InventoryInfo info : inventory.getInventoryInfo()) {
+            row = sheet.createRow(rowNum++);
+            cellNum = 0;
+            for (String key : finalOrder) {
+                cell = row.createCell(cellNum++);
+                String value = info.get(key);
+
+                cell.setCellValue(new HSSFRichTextString(value));
             }
         }
 

--- a/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/RepositoryReportTest.java
+++ b/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/RepositoryReportTest.java
@@ -243,6 +243,9 @@ public class RepositoryReportTest {
         final File reportDir = new File("target/test-inventory-03");
 
         InventoryReport report = new InventoryReport();
+        report.setInventoryVulnerabilityStatisticsReportEnabled(true);
+        report.setFailOnMissingLicense(false);
+        report.setFailOnMissingLicenseFile(false);
         //report.addVulnerabilityAdvisoryFilter("CERT-FR"); // this also filters out the 'void' vulnerability
         report.addGenerateOverviewTablesForAdvisories("CERT-FR", "CERT-SEI", "MSRC");
 

--- a/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/model/InventoryInfoTest.java
+++ b/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/model/InventoryInfoTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2009-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.metaeffekt.core.inventory.processor.model;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.metaeffekt.core.inventory.processor.reader.InventoryReader;
+import org.metaeffekt.core.inventory.processor.writer.InventoryWriter;
+
+import java.io.File;
+import java.io.IOException;
+
+public class InventoryInfoTest {
+
+    private final File TARGET_DIRECTORY = new File("target");
+
+    @Test
+    public void basicTest() throws IOException {
+        final Inventory inventory = new Inventory();
+
+        final InventoryInfo info = inventory.findOrCreateInventoryInfo("test-id");
+        info.set("test-key", "test-value");
+
+        Assert.assertTrue(inventory.getInventoryInfo().contains(info));
+        Assert.assertEquals("test-id", info.get(InventoryInfo.Attribute.ID));
+
+        final File file = new File(TARGET_DIRECTORY, "test-inventory/info/info-inventory.xls");
+        file.getParentFile().mkdirs();
+        new InventoryWriter().writeInventory(inventory, file);
+
+        final Inventory read = new InventoryReader().readInventory(file);
+
+        Assert.assertEquals(1, read.getInventoryInfo().size());
+        Assert.assertEquals("test-id", read.getInventoryInfo().get(0).get(InventoryInfo.Attribute.ID));
+    }
+}

--- a/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/model/InventoryInfoTest.java
+++ b/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/model/InventoryInfoTest.java
@@ -28,7 +28,7 @@ public class InventoryInfoTest {
     private final File TARGET_DIRECTORY = new File("target");
 
     @Test
-    public void basicTest() throws IOException {
+    public void createNonExistingAndWrite() throws IOException {
         final Inventory inventory = new Inventory();
 
         final InventoryInfo info = inventory.findOrCreateInventoryInfo("test-id");


### PR DESCRIPTION
Added sheet `Info` to Inventory containing `InventoryInfo` instances.

These are simple key-value pairs that can be used to store information concerning the entire inventory. Examples for this which are currently in development in AA:

- Periodic CERT: start/end date
- Vulnerability Status: `INVENTORY` context data