### PR TITLE
AEAA-236: Prioritise CVSS 3.1 over 2.0  &  AEAA-240: Remove 'None'/'unset' column

### DIFF
--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/VulnerabilityReportAdapter.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/VulnerabilityReportAdapter.java
@@ -221,19 +221,19 @@ public class VulnerabilityReportAdapter {
     }
 
     public StatisticsOverviewTable createUnmodifiedStatisticsOverviewTable() {
-        return createUnmodifiedStatisticsOverviewTable(null, 0.0f, this);
+        return createUnmodifiedStatisticsOverviewTable(null, 0.0f);
     }
 
     public StatisticsOverviewTable createUnmodifiedStatisticsOverviewTable(String filterCert) {
-        return createUnmodifiedStatisticsOverviewTable(filterCert, 0.0f, this);
+        return createUnmodifiedStatisticsOverviewTable(filterCert, 0.0f);
     }
 
-    public StatisticsOverviewTable createUnmodifiedStatisticsOverviewTable(String filterCert, float threshold, VulnerabilityReportAdapter adapter) {
-        return StatisticsOverviewTable.fromInventoryUnmodified(inventory, filterCert, threshold, adapter);
+    public StatisticsOverviewTable createUnmodifiedStatisticsOverviewTable(String filterCert, float threshold) {
+        return StatisticsOverviewTable.fromInventoryUnmodified(inventory, filterCert, threshold, this);
     }
 
-    public StatisticsOverviewTable createModifiedStatisticsOverviewTable(String filterCert, float threshold, VulnerabilityReportAdapter adapter) {
-        return StatisticsOverviewTable.fromInventoryModified(inventory, filterCert, threshold, adapter);
+    public StatisticsOverviewTable createModifiedStatisticsOverviewTable(String filterCert, float threshold) {
+        return StatisticsOverviewTable.fromInventoryModified(inventory, filterCert, threshold, this);
     }
 
     private static void filterVulnerabilityMetaDataForAdvisories(List<VulnerabilityMetaData> vmds, String filterCert) {
@@ -336,8 +336,10 @@ public class VulnerabilityReportAdapter {
 
         private static String getSeverityFromVMD(VulnerabilityMetaData vulnerabilityMetaData, boolean modified) {
             return ObjectUtils.firstNonNull(
-                    modified ? vulnerabilityMetaData.getComplete("CVSS Modified Severity (max)") : null,
-                    vulnerabilityMetaData.getComplete("CVSS Unmodified Severity (max)"),
+                    modified ? vulnerabilityMetaData.getComplete("CVSS Modified Severity (v3)") : null,
+                    vulnerabilityMetaData.getComplete("CVSS Unmodified Severity (v3)"),
+                    modified ? vulnerabilityMetaData.getComplete("CVSS Modified Severity (v2)") : null,
+                    vulnerabilityMetaData.getComplete("CVSS Unmodified Severity (v2)"),
                     "unset"
             );
         }
@@ -355,12 +357,13 @@ public class VulnerabilityReportAdapter {
         }
 
         private static StatisticsOverviewTable fromInventory(Inventory inventory, String filterCert, float threshold, VulnerabilityReportAdapter adapter, boolean effectiveValues) {
-            List<VulnerabilityMetaData> vmds = new ArrayList<>(inventory.getVulnerabilityMetaData());
+            final List<VulnerabilityMetaData> vmds = new ArrayList<>(inventory.getVulnerabilityMetaData());
+
             if (filterCert != null && !filterCert.isEmpty()) {
                 filterVulnerabilityMetaDataForAdvisories(vmds, filterCert);
             }
 
-            StatisticsOverviewTable table = new StatisticsOverviewTable();
+            final StatisticsOverviewTable table = new StatisticsOverviewTable();
 
             // add the default severity categories in the case there are no vulnerabilities with that category
             for (String severityCategory : new String[]{"critical", "high", "medium", "low"}) {
@@ -369,14 +372,18 @@ public class VulnerabilityReportAdapter {
 
             // the columns have to be created first, for them to be added in the correct order below
             for (VulnerabilityMetaData vmd : vmds) {
-                table.addStatus(getStatusFromVMD(vmd, threshold, adapter));
-                table.addSeverityCategory(getSeverityFromVMD(vmd, effectiveValues));
+                final String status = StatisticsOverviewTable.getStatusFromVMD(vmd, threshold, adapter);
+                final String severity = StatisticsOverviewTable.getSeverityFromVMD(vmd, effectiveValues);
+
+                table.addStatus(status);
+                table.addSeverityCategory(severity);
             }
 
             // now that the cells exist, count the individual severity and status combinations
             for (VulnerabilityMetaData vmd : vmds) {
-                String status = getStatusFromVMD(vmd, threshold, adapter);
-                String severity = getSeverityFromVMD(vmd, effectiveValues);
+                final String status = StatisticsOverviewTable.getStatusFromVMD(vmd, threshold, adapter);
+                final String severity = StatisticsOverviewTable.getSeverityFromVMD(vmd, effectiveValues);
+
                 table.incrementCount(severity, status);
             }
 
@@ -396,20 +403,26 @@ public class VulnerabilityReportAdapter {
 
             // find the % of assessed vulnerabilities for each severity category
             for (Map.Entry<String, Map<String, Integer>> severityMap : table.severityStatusCountMap.entrySet()) {
-                int applicable = severityMap.getValue().getOrDefault("reviewed", 0);
-                int notApplicable = effectiveValues ? 0 : severityMap.getValue().getOrDefault("not applicable", 0);
-                int inReview = severityMap.getValue().getOrDefault("in review", 0);
-                int insignificant = severityMap.getValue().getOrDefault("insignificant", 0);
-                int voidCat = severityMap.getValue().getOrDefault("void", 0);
+                final int applicable = severityMap.getValue().getOrDefault("reviewed", 0);
+                final int notApplicable = effectiveValues ? 0 : severityMap.getValue().getOrDefault("not applicable", 0);
+                final int inReview = severityMap.getValue().getOrDefault("in review", 0);
+                final int insignificant = severityMap.getValue().getOrDefault("insignificant", 0);
+                final int voidCat = severityMap.getValue().getOrDefault("void", 0);
 
-                int total = inReview + applicable + notApplicable + insignificant + voidCat;
+                final int total = inReview + applicable + notApplicable + insignificant + voidCat;
                 if (inReview == 0 && insignificant == 0) {
                     severityMap.getValue().put("% assessed", 100);
                 } else {
                     // ratio of (applicable + not applicable) to (applicable + not applicable + in review)
-                    double ratio = ((double) (applicable + notApplicable + voidCat)) / total;
+                    final double ratio = ((double) (applicable + notApplicable + voidCat)) / total;
                     severityMap.getValue().put("% assessed", (int) (ratio * 100));
                 }
+            }
+
+            // remove 'unset' if all but the '% assessed' column are 0
+            if (table.severityStatusCountMap.containsKey("unset")
+                    && table.severityStatusCountMap.get("unset").values().stream().filter(i -> i != 0).count() == 1) {
+                table.severityStatusCountMap.remove("unset");
             }
 
             LOG.debug("Generated Overview Table for [{}] vulnerabilities:\n{}", vmds.size(), table);

--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/macros/inventory-report-vulnerabilities.vm
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/macros/inventory-report-vulnerabilities.vm
@@ -1,3 +1,5 @@
+## do not insert blank lines in between macros. as this document is loaded before the XML tag of the main document,
+## this will result in the empty lines appearing at the head of the document, which is not allowed in XML.
 #macro (vulnerabilityOverview $id $title $vulnerabilities $listVulnerabilityStatus)
 <table id="$id">
     <title>$title</title>
@@ -41,7 +43,7 @@
                     #else<lines><line>#if ($vulnerabilityAdapter.hasDetails($vulnerability, $threshold))<xref href="tpc_inventory-vulnerability-details.dita#$vulnerability.get("Name")" type="topic"><codeph>$report.xmlEscapeString($vulnerability.get("Name"))</codeph></xref>#else<xref href="$vulnerability.get("Url")" type="html" scope="external"><codeph>$report.xmlEscapeString($vulnerability.get("Name"))</codeph></xref>#end</line></lines>#end
                 </entry>
 
-<!-- AEAA-236 prefer CVSS 3.1 over 2.0 -->
+## AEAA-236 prefer CVSS 3.1 over 2.0
 #if($utils.notEmpty($vulnerability.get("CVSS Unmodified Overall (v3)")))
                 <entry>$report.xmlEscapeString($vulnerability.get("CVSS Unmodified Overall (v3)"))</entry>
 #elseif($utils.notEmpty($vulnerability.get("CVSS Unmodified Overall (v2)")))
@@ -72,7 +74,7 @@
 #end
                 </entry>
 
-<!-- only include modified severity and vulnerability status (if present) in 'Potential Vulnerabilities' table -->
+## only include modified severity and vulnerability status (if present) in 'Potential Vulnerabilities' table
 #if($listVulnerabilityStatus)
                 <entry>
                 #if ($utils.notEmpty($vulnerability.get("CVSS Modified Severity (v3)")))
@@ -507,17 +509,23 @@ KB$kb
 There are no affected components for this vulnerability.
 #end
 #end
-#macro (statisticsOverviewTableUnmodified $id $title $filterCert $threshold $adapter)
-#statisticsOverviewTable($id, $title, $filterCert, $threshold, $adapter, false)
+##
+##
+#macro (statisticsOverviewTableUnmodified $id $title $filterCert $threshold)
+#statisticsOverviewTable($id, $title, $filterCert, $threshold, false)
 #end
-#macro (statisticsOverviewTableModified $id $title $filterCert $threshold $adapter)
-#statisticsOverviewTable($id, $title, $filterCert, $threshold, $adapter, true)
+##
+##
+#macro (statisticsOverviewTableModified $id $title $filterCert $threshold)
+#statisticsOverviewTable($id, $title, $filterCert, $threshold, true)
 #end
-#macro (statisticsOverviewTable $id $title $filterCert $threshold $adapter $useModified)
+##
+##
+#macro (statisticsOverviewTable $id $title $filterCert $threshold $useModified)
     #if($useModified)
-        #set($overviewTableData=$vulnerabilityAdapter.createModifiedStatisticsOverviewTable($filterCert, $threshold, $adapter))
+        #set($overviewTableData=$vulnerabilityAdapter.createModifiedStatisticsOverviewTable($filterCert, $threshold))
     #else
-        #set($overviewTableData=$vulnerabilityAdapter.createUnmodifiedStatisticsOverviewTable($filterCert, $threshold, $adapter))
+        #set($overviewTableData=$vulnerabilityAdapter.createUnmodifiedStatisticsOverviewTable($filterCert, $threshold))
     #end
     #if(!$overviewTableData.isEmpty())
     <table id="$id">

--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/macros/inventory-report-vulnerabilities.vm
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/macros/inventory-report-vulnerabilities.vm
@@ -40,39 +40,60 @@
                         <line>#if ($vulnerabilityAdapter.hasDetails($vulnerability, $threshold))<xref href="tpc_inventory-vulnerability-details.dita#$vulnerability.get("Name")" type="topic"><codeph>$report.xmlEscapeString($vulnerability.get("Name"))</codeph></xref>#else<xref href="$vulnerability.get("Url")" type="html" scope="external"><codeph>$report.xmlEscapeString($vulnerability.get("Name"))</codeph></xref>#end</line></lines>
                     #else<lines><line>#if ($vulnerabilityAdapter.hasDetails($vulnerability, $threshold))<xref href="tpc_inventory-vulnerability-details.dita#$vulnerability.get("Name")" type="topic"><codeph>$report.xmlEscapeString($vulnerability.get("Name"))</codeph></xref>#else<xref href="$vulnerability.get("Url")" type="html" scope="external"><codeph>$report.xmlEscapeString($vulnerability.get("Name"))</codeph></xref>#end</line></lines>#end
                 </entry>
-                <entry>$report.xmlEscapeString($vulnerability.get("CVSS Unmodified Overall (max)"))</entry>
-#if ($utils.notEmpty($vulnerability.get("CVSS Modified Severity (max)")))
-                <entry>$report.xmlEscapeString($vulnerability.get("CVSS Modified Overall (max)"))</entry>
+
+<!-- AEAA-236 prefer CVSS 3.1 over 2.0 -->
+#if($utils.notEmpty($vulnerability.get("CVSS Unmodified Overall (v3)")))
+                <entry>$report.xmlEscapeString($vulnerability.get("CVSS Unmodified Overall (v3)"))</entry>
+#elseif($utils.notEmpty($vulnerability.get("CVSS Unmodified Overall (v2)")))
+                <entry>$report.xmlEscapeString($vulnerability.get("CVSS Unmodified Overall (v2)"))</entry>
 #else
                 <entry>N/A</entry>
 #end
+
+#if($utils.notEmpty($vulnerability.get("CVSS Modified Overall (v3)")))
+                <entry>$report.xmlEscapeString($vulnerability.get("CVSS Modified Overall (v3)"))</entry>
+#elseif($utils.notEmpty($vulnerability.get("CVSS Modified Overall (v2)")))
+                <entry>$report.xmlEscapeString($vulnerability.get("CVSS Modified Overall (v2)"))</entry>
+#else
+                <entry>N/A</entry>
+#end
+
+
                 <entry>$vulnerabilityAdapter.hyperlinkedAdvisories($vulnerabilityAdapter.getAdvisories($vulnerability))</entry>
+
+
                 <entry>
-#if ($utils.notEmpty($vulnerability.get("CVSS Unmodified Severity (max)")))
-                    #set($labelText=$vulnerabilityAdapter.modulateSeverityText($vulnerability.get("CVSS Unmodified Severity (max)")))
-                    #labelRef($labelText)
+#if ($utils.notEmpty($vulnerability.get("CVSS Unmodified Severity (v3)")))
+                    #labelRef($vulnerabilityAdapter.modulateSeverityText($vulnerability.get("CVSS Unmodified Severity (v3)")))
+#elseif($utils.notEmpty($vulnerability.get("CVSS Unmodified Severity (v2)")))
+                    #labelRef($vulnerabilityAdapter.modulateSeverityText($vulnerability.get("CVSS Unmodified Severity (v2)")))
 #else
                     &nbsp;
 #end
                 </entry>
-#if($listVulnerabilityStatus && $utils.notEmpty($vulnerability.get("Status")))
+
+<!-- only include modified severity and vulnerability status (if present) in 'Potential Vulnerabilities' table -->
+#if($listVulnerabilityStatus)
                 <entry>
-                    #if ($vulnerability.get("CVSS Modified Severity (max)"))
-                        #set($labelText=$vulnerabilityAdapter.modulateSeverityText($vulnerability.get("CVSS Modified Severity (max)")))
-                        #labelRef($labelText)
-                    #else
-                        &nbsp;
-                    #end
+                #if ($utils.notEmpty($vulnerability.get("CVSS Modified Severity (v3)")))
+                    #labelRef($vulnerabilityAdapter.modulateSeverityText($vulnerability.get("CVSS Modified Severity (v3)")))
+                #elseif($utils.notEmpty($vulnerability.get("CVSS Modified Severity (v2)")))
+                    #labelRef($vulnerabilityAdapter.modulateSeverityText($vulnerability.get("CVSS Modified Severity (v2)")))
+                #else
+                    &nbsp;
+                #end
                 </entry>
+
                 <entry>
+                #if($utils.notEmpty($vulnerability.get("Status")))
                     #labelRef("Reviewed")
-                </entry>
-#elseif($listVulnerabilityStatus)
-                <entry>&nbsp;</entry>
-                <entry>
+                #else
                     #labelRef("In Review")
+                #end
                 </entry>
 #end
+
+
             </row>
 #end
         </tbody>

--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/tpc_inventory-vulnerability-details.dita.vt
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/tpc_inventory-vulnerability-details.dita.vt
@@ -19,12 +19,15 @@
             third-party advisories.
         </p>
     </body>
+
 #foreach($vulnerability in $vulnerabilities)
-#set($vulnerabilityName=$vulnerability.get("Name"))
-#set($advisories=$vulnerabilityAdapter.getAdvisories($vulnerability))
-#set($alerts=$vulnerabilityAdapter.filterType($advisories, "alert"))
-#set($notices=$vulnerabilityAdapter.filterType($advisories, "notice"))
-#set($news=$vulnerabilityAdapter.filterType($advisories, "news"))
+
+    #set($vulnerabilityName= $vulnerability.get("Name"))
+    #set($advisories=        $vulnerabilityAdapter.getAdvisories($vulnerability))
+    #set($alerts=            $vulnerabilityAdapter.filterType($advisories, "alert"))
+    #set($notices=           $vulnerabilityAdapter.filterType($advisories, "notice"))
+    #set($news=              $vulnerabilityAdapter.filterType($advisories, "news"))
+
     <topic id="$vulnerabilityName">
         <title>$vulnerabilityName</title>
         <body>
@@ -110,20 +113,24 @@
                 <p>
                     #if ($vulnerabilityAdapter.isPotentialVulnerability($vulnerability, $threshold))
                         #labelRef("Potential Vulnerability")
-                        #if ($utils.notEmpty($vulnerability.get("CVSS Modified Severity (max)")))
-                            #labelRef($vulnerability.get("CVSS Modified Severity (max)"))
-                        #else
-                            #if ($utils.notEmpty($vulnerability.get("CVSS Unmodified Severity (max)")))
-                                #labelRef($vulnerability.get("CVSS Unmodified Severity (max)"))
-                            #end
+                        #if ($utils.notEmpty($vulnerability.get("CVSS Modified Severity (v3)")))
+                            #labelRef($vulnerability.get("CVSS Modified Severity (v3)"))
+                        #elseif ($utils.notEmpty($vulnerability.get("CVSS Modified Severity (v2)")))
+                            #labelRef($vulnerability.get("CVSS Modified Severity (v2)"))
+                        #elseif ($utils.notEmpty($vulnerability.get("CVSS Unmodified Severity (v3)")))
+                            #labelRef($vulnerability.get("CVSS Unmodified Severity (v3)"))
+                        #elseif ($utils.notEmpty($vulnerability.get("CVSS Unmodified Severity (v2)")))
+                            #labelRef($vulnerability.get("CVSS Unmodified Severity (v2)"))
                         #end
                     #end
+
                     #if ($vulnerabilityAdapter.isNotApplicableVulnerability($vulnerability, $threshold))
                         #labelRef("Not Applicable")
                     #end
                     #if ($vulnerabilityAdapter.isVoidVulnerability($vulnerability, $threshold))
                         #labelRef("Void Vulnerability")
                     #end
+
                     #if ($vulnerabilityAdapter.isInsignificantVulnerability($vulnerability, $threshold))
                         #labelRef("Insignificant")
                         #if ($vulnerability.get("CVSS Modified Severity (max)"))

--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-statistics-vulnerability/tpc_inventory-vulnerability-statistics.dita.vt
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-statistics-vulnerability/tpc_inventory-vulnerability-statistics.dita.vt
@@ -12,24 +12,32 @@
             in the statistics with their original unmodified severity.
         </p>
         <p id="statistics-table">
-#statisticsOverviewTableUnmodified("vulnerabilities_statistics_table_unmodified_all", "Vulnerability Statistics$reportContext.inContextOf()", "", $threshold, $vulnerabilityAdapter)
+#statisticsOverviewTableUnmodified("vulnerabilities_statistics_table_unmodified_all", "Vulnerability Statistics$reportContext.inContextOf()", "", $threshold)
         </p>
+
+
+## iterate over all advisories that shall have their own overview table
 #foreach($advisory in $report.getGenerateOverviewTablesForAdvisories())
         <p id="statistics-preface-$advisory">
             The following table shows statistics for the identified vulnerabilities with advisory information from
             $advisory. The vulnerabilities are included in the statistics with their original unmodified severity.
         </p>
         <p id="statistics-table-$advisory">
-#statisticsOverviewTableUnmodified("vulnerabilities_statistics_table_unmodified_$advisory.toLowerCase()", "Vulnerability Statistics with $advisory Advisories$reportContext.inContextOf()", "$advisory", $threshold, $vulnerabilityAdapter)
+#statisticsOverviewTableUnmodified("vulnerabilities_statistics_table_unmodified_$advisory.toLowerCase()", "Vulnerability Statistics with $advisory Advisories$reportContext.inContextOf()", "$advisory", $threshold)
         </p>
 #end
+
+
         <p id="statistics-preface-modified">
             The following table shows statistics for the identified vulnerabilities. The vulnerabilities are included
             in the statistics with their modified severity if available or their unmodified severity otherwise.
         </p>
         <p id="statistics-table-modified">
-#statisticsOverviewTableModified("vulnerabilities_statistics_table_modified_all", "Effective Vulnerability Statistics$reportContext.inContextOf()", "", $threshold, $vulnerabilityAdapter)
+#statisticsOverviewTableModified("vulnerabilities_statistics_table_modified_all", "Effective Vulnerability Statistics$reportContext.inContextOf()", "", $threshold)
         </p>
+
+
+## iterate over all advisories that shall have their own modified overview table
 #foreach($advisory in $report.getGenerateOverviewTablesForAdvisories())
         <p id="statistics-preface-modified-$advisory">
             The following table shows statistics for the identified vulnerabilities with advisory information from
@@ -37,7 +45,7 @@
             their unmodified severity otherwise.
         </p>
         <p id="statistics-table-modified-$advisory">
-#statisticsOverviewTableModified("vulnerabilities_statistics_table_modified_$advisory.toLowerCase()", "Effective Vulnerability Statistics with $advisory Advisories$reportContext.inContextOf()", "$advisory", $threshold, $vulnerabilityAdapter)
+#statisticsOverviewTableModified("vulnerabilities_statistics_table_modified_$advisory.toLowerCase()", "Effective Vulnerability Statistics with $advisory Advisories$reportContext.inContextOf()", "$advisory", $threshold)
         </p>
 #end
     </body>

--- a/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/report/VulnerabilityReportAdapterTest.java
+++ b/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/report/VulnerabilityReportAdapterTest.java
@@ -141,7 +141,7 @@ public class VulnerabilityReportAdapterTest {
         inventory.getVulnerabilityMetaData().add(createVMDMultipleSeverities("in review", SEVERITY.MEDIUM.toString(), SEVERITY.MEDIUM.toString()));
         inventory.getVulnerabilityMetaData().add(createVMDUnmodifiedSeverity("in review", SEVERITY.MEDIUM.toString()));
 
-        VulnerabilityReportAdapter.StatisticsOverviewTable table = vra.createModifiedStatisticsOverviewTable(null, 0.0f, vra);
+        final VulnerabilityReportAdapter.StatisticsOverviewTable table = vra.createModifiedStatisticsOverviewTable(null, 0.0f);
         Assert.assertEquals(Arrays.asList("Severity", "Reviewed", "In Review", "Insignificant", "Total", "% Assessed"), table.getHeaders());
         Assert.assertEquals(Arrays.asList("Critical", "High", "Medium", "Low"), table.getSeverityCategories());
         Assert.assertEquals(Arrays.asList(2, 1, 1, 4, 50), table.getCountsForSeverityCategory("critical"));

--- a/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/report/VulnerabilityReportAdapterTest.java
+++ b/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/report/VulnerabilityReportAdapterTest.java
@@ -154,7 +154,7 @@ public class VulnerabilityReportAdapterTest {
         VulnerabilityMetaData vmd = new VulnerabilityMetaData();
 
         vmd.set(VulnerabilityMetaData.Attribute.STATUS, status);
-        vmd.set("CVSS Unmodified Severity (max)", severity);
+        vmd.set("CVSS Unmodified Severity (v3)", severity);
         JSONArray certs = new JSONArray();
         for (String c : cert) {
             certs.put(new JSONObject().put("source", c));
@@ -168,8 +168,8 @@ public class VulnerabilityReportAdapterTest {
         VulnerabilityMetaData vmd = new VulnerabilityMetaData();
 
         vmd.set(VulnerabilityMetaData.Attribute.STATUS, status);
-        vmd.set("CVSS Unmodified Severity (max)", severityUnmodified);
-        vmd.set("CVSS Modified Severity (max)", severityModified);
+        vmd.set("CVSS Unmodified Severity (v3)", severityUnmodified);
+        vmd.set("CVSS Modified Severity (v3)", severityModified);
         JSONArray certs = new JSONArray();
         for (String c : cert) {
             certs.put(new JSONObject().put("source", c));


### PR DESCRIPTION
AEAA-236: Files:

- `tpc_inventory-vulnerability-details.dita.vt`
- `tpc_inventory-vulnerability-statistics.dita.vt`
- `tpc_inventory-vulnerability-report.dita.vt`

will now use latest available of either CVSS v3.1 or CVSS v2.0 as fallback.

AEAA-240: Column `None` in the statistics overview table will no longer be displayed if all entries in it would be 0, except for `% assessed`.

Cleaned up Velocity Templates a bit.