### PR TITLE
AEAA-266: VR: minimumVulnerabilityIncludeScore parameter

### DIFF
--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/model/Inventory.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/model/Inventory.java
@@ -1589,10 +1589,10 @@ public class Inventory {
 
     public List<String> getRepresentedLicenses(List<String> effectiveLicenses) {
         return effectiveLicenses.stream()
-            .map(this::getRepresentedLicenseName)
-            .sorted(String.CASE_INSENSITIVE_ORDER)
-            .distinct()
-            .collect(Collectors.toList());
+                .map(this::getRepresentedLicenseName)
+                .sorted(String.CASE_INSENSITIVE_ORDER)
+                .distinct()
+                .collect(Collectors.toList());
     }
 
     public List<String> getLicensesRepresentedBy(String representedLicenseName) {
@@ -1617,9 +1617,8 @@ public class Inventory {
      *     <li>the represented name and variant license name deviates</li>
      * </ol>
      *
-     * @param license The license for which the request needs to ne answered.
+     * @param license                      The license for which the request needs to ne answered.
      * @param representedEffectiveLicenses List of represented effective licenses
-     *
      * @return Returns <code>true</code> when a substructure to represent the licenses is required.
      */
     public boolean isSubstructureRequired(String license, List<String> representedEffectiveLicenses) {

--- a/plugins/ae-inventory-maven-plugin/src/main/java/org/metaeffekt/core/maven/inventory/mojo/AbstractInventoryReportCreationMojo.java
+++ b/plugins/ae-inventory-maven-plugin/src/main/java/org/metaeffekt/core/maven/inventory/mojo/AbstractInventoryReportCreationMojo.java
@@ -237,6 +237,11 @@ public abstract class AbstractInventoryReportCreationMojo extends AbstractProjec
     private String vulnerabilityScoreThreshold;
 
     /**
+     * @parameter default-value="-1.0"
+     */
+    private String minimumVulnerabilityIncludeScore;
+
+    /**
      * Comma seperated list of advisory providers. All vulnerabilities not containing at least one of the providers
      * will be ignored when generating the report.<br>
      * If left empty, no filter will be applied.<br>
@@ -349,6 +354,7 @@ public abstract class AbstractInventoryReportCreationMojo extends AbstractProjec
 
         // vulnerability settings
         report.setVulnerabilityScoreThreshold(Float.parseFloat(vulnerabilityScoreThreshold));
+        report.setMinimumVulnerabilityIncludeScore(Float.parseFloat(minimumVulnerabilityIncludeScore));
         report.addVulnerabilityAdvisoryFilter(vulnerabilityAdvisoryFilter);
         report.addGenerateOverviewTablesForAdvisories(generateOverviewTablesForAdvisories);
         if (overviewTablesVulnerabilityStatusMappingFunction != null) {


### PR DESCRIPTION
Added a parameter `minimumVulnerabilityIncludeScore` that filters the source inventory in the `InventoryReport#createReport()` method for vulnerabilities that have a score lower than the provided score.

The compare score is provided by the `cvssScoringPreference` parameter (e.g. `latest`, `max`)

Example: The report on the left has a min score of `8.0`:

<img width="1093" alt="Screenshot 2023-02-15 at 09 39 53" src="https://user-images.githubusercontent.com/37689635/218976961-fb57e828-1f2a-4789-85e8-ef99a6b1a95d.png">

Fixed indentation of code in `Inventory`.