### PR TITLE
AEAA-294 added includeAdvisoryTypes parameter to VR

### DIFF
--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/InventoryReport.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/InventoryReport.java
@@ -178,6 +178,19 @@ public class InventoryReport {
      */
     private String cvssScoringPreference = VulnerabilityReportAdapter.CVSS_SCORING_PREFERENCE_LATEST_FIRST;
 
+    /**
+     * An array of advisory types to include in the report. The default is to include all types by using the value
+     * <code>all</code>.<br>
+     * Supported values are:
+     * <ul>
+     *     <li><code>all</code> to include all types</li>
+     *     <li><code>notice</code></li>
+     *     <li><code>alert</code></li>
+     *     <li><code>news</code></li>
+     * </ul>
+     */
+    private String[] includeAdvisoryTypes = new String[]{"all"};
+
     private ArtifactFilter artifactFilter;
 
     private boolean inventoryBomReportEnabled = false;
@@ -1273,8 +1286,26 @@ public class InventoryReport {
         return cvssScoringPreference;
     }
 
+    public void setIncludeAdvisoryTypes(String[] includeAdvisoryTypes) {
+        this.includeAdvisoryTypes = includeAdvisoryTypes;
+    }
+
+    public void setIncludeAdvisoryTypes(String includeAdvisoryTypes) {
+        if (includeAdvisoryTypes != null) {
+            if (includeAdvisoryTypes.length() > 0 && (!includeAdvisoryTypes.equals("null") && !includeAdvisoryTypes.equals("none"))) {
+                this.includeAdvisoryTypes = includeAdvisoryTypes.split(", ");
+            } else {
+                this.includeAdvisoryTypes = new String[]{};
+            }
+        }
+    }
+
+    public String[] getIncludeAdvisoryTypes() {
+        return includeAdvisoryTypes;
+    }
+
     private void splitAndAppendCsvAdvisoryProviders(List<String> listToAddProvidersTo, String... commaSeperatedProviders) {
-        if (commaSeperatedProviders != null && commaSeperatedProviders.length > 0) {
+        if (commaSeperatedProviders != null) { // && commaSeperatedProviders.length > 0) { // is always true
             for (String commaSeperatedProvider : commaSeperatedProviders) {
                 if (commaSeperatedProvider != null && commaSeperatedProvider.length() > 0) {
                     if (commaSeperatedProvider.contains(",")) {

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/VulnerabilityReportAdapter.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/VulnerabilityReportAdapter.java
@@ -97,6 +97,33 @@ public class VulnerabilityReportAdapter {
         return advisoryDataList.stream().filter(a -> type.equalsIgnoreCase(a.getType())).collect(Collectors.toList());
     }
 
+    private boolean isAdvisoryTypeIncluded(String advisoryType, String[] includeAdvisoryTypes) {
+        if (includeAdvisoryTypes == null) {
+            return true;
+        } else if (includeAdvisoryTypes.length == 0) {
+            return false;
+        }
+
+        // includeAdvisoryTypes might contain 'all', which means all advisory types should be included
+        if (Arrays.stream(includeAdvisoryTypes).anyMatch(e -> e.equalsIgnoreCase("all"))) {
+            return true;
+        }
+
+        for (String includeAdvisoryType : includeAdvisoryTypes) {
+            if (includeAdvisoryType.equalsIgnoreCase(advisoryType)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public List<AdvisoryData> filterIncludeAdvisoryTypes(List<AdvisoryData> advisoryDataList, String[] includeAdvisoryTypes) {
+        return advisoryDataList.stream()
+                .filter(a -> isAdvisoryTypeIncluded(a.getType(), includeAdvisoryTypes))
+                .collect(Collectors.toList());
+    }
+
     public List<CertMetaData> getCertMetaData() {
         return inventory.getCertMetaData();
     }

--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/tpc_inventory-vulnerability-details.dita.vt
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/tpc_inventory-vulnerability-details.dita.vt
@@ -28,10 +28,15 @@
 #foreach($vulnerability in $vulnerabilities)
 
     #set($vulnerabilityName = $vulnerability.get("Name"))
+
     #set($advisories        = $vulnerabilityAdapter.getAdvisories($vulnerability))
     #set($alerts            = $vulnerabilityAdapter.filterType($advisories, "alert"))
     #set($notices           = $vulnerabilityAdapter.filterType($advisories, "notice"))
     #set($news              = $vulnerabilityAdapter.filterType($advisories, "news"))
+
+    #set($alerts            = $vulnerabilityAdapter.filterIncludeAdvisoryTypes($alerts, $report.getIncludeAdvisoryTypes()))
+    #set($notices           = $vulnerabilityAdapter.filterIncludeAdvisoryTypes($notices, $report.getIncludeAdvisoryTypes()))
+    #set($news              = $vulnerabilityAdapter.filterIncludeAdvisoryTypes($news, $report.getIncludeAdvisoryTypes()))
 
     <topic id="$vulnerabilityName">
         <title>$vulnerabilityName</title>

--- a/plugins/ae-inventory-maven-plugin/src/main/java/org/metaeffekt/core/maven/inventory/mojo/AbstractInventoryReportCreationMojo.java
+++ b/plugins/ae-inventory-maven-plugin/src/main/java/org/metaeffekt/core/maven/inventory/mojo/AbstractInventoryReportCreationMojo.java
@@ -298,6 +298,21 @@ public abstract class AbstractInventoryReportCreationMojo extends AbstractProjec
     private String cvssScoringPreference;
 
     /**
+     * An array of advisory types to include in the report. The default is to include all types by using the value
+     * <code>all</code>.<br>
+     * Supported values are:
+     * <ul>
+     *     <li><code>all</code> to include all types</li>
+     *     <li><code>notice</code></li>
+     *     <li><code>alert</code></li>
+     *     <li><code>news</code></li>
+     * </ul>
+     *
+     * @parameter
+     */
+    private String includeAdvisoryTypes;
+
+    /**
      * @parameter default-value="en"
      */
     private String templateLanguageSelector;
@@ -368,6 +383,9 @@ public abstract class AbstractInventoryReportCreationMojo extends AbstractProjec
             } else {
                 report.setCvssScoringPreference(cvssScoringPreference);
             }
+        }
+        if (includeAdvisoryTypes != null) {
+            report.setIncludeAdvisoryTypes(includeAdvisoryTypes);
         }
 
         // diff settings


### PR DESCRIPTION
Added a `includeAdvisoryTypes` parameter to the vulnerability report:

```xml
<!-- [alert, notice, news, all, none] -->
<includeAdvisoryTypes>all</includeAdvisoryTypes>
```

Only advisories with a type listed in the comma-separated list will be included in the final report.

This is done by adding a new `filterIncludeAdvisoryTypes` method to the vulnerability adapter class, which is called on the advisories from the velocity templates:

    #set($advisories        = $vulnerabilityAdapter.getAdvisories($vulnerability))
    #set($alerts            = $vulnerabilityAdapter.filterType($advisories, "alert"))
    #set($alerts            = $vulnerabilityAdapter.filterIncludeAdvisoryTypes($alerts, $report.getIncludeAdvisoryTypes()))

The default value for this parameter is `all`, meaning all advisories are included.