### PR TITLE
includeAdvisoryTypes refactor

### DIFF
--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/InventoryReport.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/InventoryReport.java
@@ -189,7 +189,11 @@ public class InventoryReport {
      *     <li><code>news</code></li>
      * </ul>
      */
-    private String[] includeAdvisoryTypes = new String[]{"all"};
+    private List<String> includeAdvisoryTypes = new ArrayList<>();
+
+    {
+        includeAdvisoryTypes.add("all");
+    }
 
     private ArtifactFilter artifactFilter;
 
@@ -528,7 +532,7 @@ public class InventoryReport {
         // filter the vulnerability metadata to only include those with a score larger than the min score
         if (getMinimumVulnerabilityIncludeScore() >= 0) {
             final VulnerabilityReportAdapter adapter = new VulnerabilityReportAdapter(
-                    projectInventory, cvssScoringPreference, vulnerabilityScoreThreshold);
+                    projectInventory, cvssScoringPreference, vulnerabilityScoreThreshold, includeAdvisoryTypes);
 
             projectInventory.getVulnerabilityMetaData().removeIf(vmd -> {
                 final String compareScore = adapter.getUnmodifiedCvssScoreByScoringPreference(vmd, cvssScoringPreference);
@@ -899,7 +903,7 @@ public class InventoryReport {
             VulnerabilityReportAdapter adapter, List<VulnerabilityMetaData> vulnerabilityMetaData) {
         if (vulnerabilityAdvisoryFilter.size() > 0) {
             vulnerabilityMetaData.removeIf(vmd ->
-                    adapter.getAdvisories(vmd, null).stream()
+                    adapter.getAdvisories(vmd).stream()
                             .noneMatch(advisory -> vulnerabilityAdvisoryFilter.contains(advisory.getSource())));
         }
     }
@@ -924,7 +928,7 @@ public class InventoryReport {
 
         final AssetReportAdapter assetReportAdapter = new AssetReportAdapter(filteredInventory);
         final VulnerabilityReportAdapter vulnerabilityReportAdapter = new VulnerabilityReportAdapter(
-                filteredInventory, cvssScoringPreference, vulnerabilityScoreThreshold);
+                filteredInventory, cvssScoringPreference, vulnerabilityScoreThreshold, includeAdvisoryTypes);
 
         // if an advisory filter is set, filter out all vulnerabilities that do not contain a filter advisory source
         filterVulnerabilityMetadataByAdvisoryFilter(vulnerabilityReportAdapter, filteredInventory.getVulnerabilityMetaData());
@@ -1293,21 +1297,33 @@ public class InventoryReport {
         return cvssScoringPreference;
     }
 
+    public void setIncludeAdvisoryTypes(List<String> includeAdvisoryTypes) {
+        if (includeAdvisoryTypes != null) {
+            this.includeAdvisoryTypes = includeAdvisoryTypes;
+        } else {
+            this.includeAdvisoryTypes.clear();
+        }
+    }
+
     public void setIncludeAdvisoryTypes(String[] includeAdvisoryTypes) {
-        this.includeAdvisoryTypes = includeAdvisoryTypes;
+        if (includeAdvisoryTypes != null) {
+            this.includeAdvisoryTypes = Arrays.asList(includeAdvisoryTypes);
+        } else {
+            this.includeAdvisoryTypes.clear();
+        }
     }
 
     public void setIncludeAdvisoryTypes(String includeAdvisoryTypes) {
         if (includeAdvisoryTypes != null) {
             if (includeAdvisoryTypes.length() > 0 && (!includeAdvisoryTypes.equals("null") && !includeAdvisoryTypes.equals("none"))) {
-                this.includeAdvisoryTypes = includeAdvisoryTypes.split(", ");
+                this.includeAdvisoryTypes = Arrays.asList(includeAdvisoryTypes.split(", "));
             } else {
-                this.includeAdvisoryTypes = new String[]{};
+                this.includeAdvisoryTypes.clear();
             }
         }
     }
 
-    public String[] getIncludeAdvisoryTypes() {
+    public List<String> getIncludeAdvisoryTypes() {
         return includeAdvisoryTypes;
     }
 

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/StatisticsOverviewTable.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/StatisticsOverviewTable.java
@@ -168,6 +168,14 @@ public class StatisticsOverviewTable {
         return adapter.getStatusText(vulnerabilityMetaData);
     }
 
+    public static StatisticsOverviewTable fromInventoryUnmodified(VulnerabilityReportAdapter adapter, Function<String, String> vulnerabilityStatusMapper) {
+        return StatisticsOverviewTable.fromInventory(adapter, null, false, vulnerabilityStatusMapper);
+    }
+
+    public static StatisticsOverviewTable fromInventoryModified(VulnerabilityReportAdapter adapter, Function<String, String> vulnerabilityStatusMapper) {
+        return StatisticsOverviewTable.fromInventory(adapter, null, true, vulnerabilityStatusMapper);
+    }
+
     public static StatisticsOverviewTable fromInventoryUnmodified(VulnerabilityReportAdapter adapter, String filterCert, Function<String, String> vulnerabilityStatusMapper) {
         return StatisticsOverviewTable.fromInventory(adapter, filterCert, false, vulnerabilityStatusMapper);
     }
@@ -272,7 +280,7 @@ public class StatisticsOverviewTable {
             // information. That is when only 0 and n/a are included.
             if (noneEntry.values().stream().allMatch(obj -> {
                 final String str = String.valueOf(obj);
-                return "0".equals(str) && "n/a".equals(str);
+                return "0".equals(str) || "n/a".equals(str);
             })) {
                 table.severityStatusCountMap.remove("none");
             }

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/VulnerabilityReportAdapter.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/VulnerabilityReportAdapter.java
@@ -15,13 +15,14 @@
  */
 package org.metaeffekt.core.inventory.processor.report;
 
-import org.apache.commons.math3.exception.NotANumberException;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.metaeffekt.core.inventory.processor.model.Artifact;
 import org.metaeffekt.core.inventory.processor.model.CertMetaData;
 import org.metaeffekt.core.inventory.processor.model.Inventory;
 import org.metaeffekt.core.inventory.processor.model.VulnerabilityMetaData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
 import java.io.File;
@@ -34,6 +35,8 @@ import java.util.stream.Collectors;
  */
 public class VulnerabilityReportAdapter {
 
+    private static final Logger LOG = LoggerFactory.getLogger(VulnerabilityReportAdapter.class);
+
     public final static String CVSS_SCORING_PREFERENCE_LATEST_FIRST = "v3 v2";
 
     public final static String CVSS_SCORING_PREFERENCE_MAX = "max v3 v2";
@@ -41,12 +44,14 @@ public class VulnerabilityReportAdapter {
     protected final Inventory inventory;
 
     protected final String scoringPreference;
+    private final List<String> includeAdvisoryTypes;
 
     protected final float insignificantThreshold;
 
-    public VulnerabilityReportAdapter(Inventory inventory, String scoringPreference, float insignificantThreshold) {
+    public VulnerabilityReportAdapter(Inventory inventory, String scoringPreference, float insignificantThreshold, List<String> includeAdvisoryTypes) {
         this.inventory = inventory;
         this.scoringPreference = scoringPreference;
+        this.includeAdvisoryTypes = includeAdvisoryTypes == null ? Arrays.asList("all") : includeAdvisoryTypes;
         this.insignificantThreshold = insignificantThreshold;
     }
 
@@ -54,6 +59,7 @@ public class VulnerabilityReportAdapter {
         this.inventory = inventory;
         this.scoringPreference = CVSS_SCORING_PREFERENCE_LATEST_FIRST;
         this.insignificantThreshold = 7;
+        this.includeAdvisoryTypes = Arrays.asList("all");
     }
 
     public List<VulnerabilityMetaData> getVulnerabilityMetaDataForDetailReport() {
@@ -71,34 +77,33 @@ public class VulnerabilityReportAdapter {
     // FIXME: as the methods does not require any information from the local class it should be rather a
     //        method on VulnerabilityMetaData or on Advisory data not to mix model with supporting classes.
     //        Revise usages in core and artifact analysis.
-    public List<AdvisoryData> getAdvisories(VulnerabilityMetaData vulnerabilityMetaData, String[] includeAdvisoryTypes) {
+    public List<AdvisoryData> getAdvisories(VulnerabilityMetaData vulnerabilityMetaData) {
         final String advisories = vulnerabilityMetaData.getComplete("Advisories");
 
         final List<AdvisoryData> advisoryDataList = (advisories != null) ?
                 AdvisoryData.fromJson(new JSONArray(advisories)) : new ArrayList<>();
 
         if (advisories != null && includeAdvisoryTypes != null) {
-            return filterIncludeAdvisoryTypes(advisoryDataList, includeAdvisoryTypes);
+            return filterIncludeAdvisoryTypes(advisoryDataList);
         } else {
             return advisoryDataList;
         }
     }
 
-    public String getAdvisoryHeader(String[] includeAdvisoryTypes) {
-        if (includeAdvisoryTypes == null || includeAdvisoryTypes.length == 0) {
+    public String getAdvisoryHeader() {
+        if (includeAdvisoryTypes == null || includeAdvisoryTypes.size() == 0) {
             return "Alerts / Notices / Updates";
         }
         final StringBuilder sb = new StringBuilder();
-        List<String> set = Arrays.asList(includeAdvisoryTypes);
-        if (set.contains("all")) {
+        if (includeAdvisoryTypes.contains("all")) {
             return "Alerts / Notices / Updates";
         }
-        if (set.contains("alert")) sb.append("Alerts");
-        if (set.contains("notice")) {
+        if (includeAdvisoryTypes.contains("alert")) sb.append("Alerts");
+        if (includeAdvisoryTypes.contains("notice")) {
             if (sb.length() > 0) sb.append(" / ");
             sb.append("Notices");
         }
-        if (set.contains("news")) {
+        if (includeAdvisoryTypes.contains("news")) {
             if (sb.length() > 0) sb.append(" / ");
             sb.append("Updates");
         }
@@ -138,18 +143,25 @@ public class VulnerabilityReportAdapter {
     }
 
     public List<AdvisoryData> filterType(List<AdvisoryData> advisoryDataList, String type) {
-        return advisoryDataList.stream().filter(a -> type.equalsIgnoreCase(a.getType())).collect(Collectors.toList());
+        if (type == null) return advisoryDataList;
+        if (advisoryDataList == null) {
+            LOG.warn("No advisory data available for filtering on type [{}]", type);
+            return new ArrayList<>();
+        }
+        return advisoryDataList.stream()
+                .filter(a -> type.equalsIgnoreCase(a.getType()))
+                .collect(Collectors.toList());
     }
 
-    private boolean isAdvisoryTypeIncluded(String advisoryType, String[] includeAdvisoryTypes) {
+    private boolean isAdvisoryTypeIncluded(String advisoryType) {
         if (includeAdvisoryTypes == null) {
             return true;
-        } else if (includeAdvisoryTypes.length == 0) {
+        } else if (includeAdvisoryTypes.size() == 0) {
             return false;
         }
 
         // includeAdvisoryTypes might contain 'all', which means all advisory types should be included
-        if (Arrays.stream(includeAdvisoryTypes).anyMatch(e -> e.equalsIgnoreCase("all"))) {
+        if (includeAdvisoryTypes.stream().anyMatch(e -> e.equalsIgnoreCase("all"))) {
             return true;
         }
 
@@ -162,9 +174,9 @@ public class VulnerabilityReportAdapter {
         return false;
     }
 
-    public List<AdvisoryData> filterIncludeAdvisoryTypes(List<AdvisoryData> advisoryDataList, String[] includeAdvisoryTypes) {
+    public List<AdvisoryData> filterIncludeAdvisoryTypes(List<AdvisoryData> advisoryDataList) {
         return advisoryDataList.stream()
-                .filter(a -> isAdvisoryTypeIncluded(a.getType(), includeAdvisoryTypes))
+                .filter(a -> isAdvisoryTypeIncluded(a.getType()))
                 .collect(Collectors.toList());
     }
 
@@ -459,9 +471,8 @@ public class VulnerabilityReportAdapter {
      * Implements to CVSSv3 over CVSSv2 strategy to check whether the vulnerability is below the threshold.
      *
      * @param vulnerabilityMetaData
-     *
      * @return Returns <code>true</code> is the {@link VulnerabilityMetaData} relevant score is below the
-     *    insignificant threshold.
+     * insignificant threshold.
      */
     private boolean isBelowThreshold(VulnerabilityMetaData vulnerabilityMetaData) {
         final Float score = getFloat(getUnmodifiedCvssScoreByScoringPreference(vulnerabilityMetaData, scoringPreference));

--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/macros/inventory-report-vulnerabilities-abstracted.vm
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/macros/inventory-report-vulnerabilities-abstracted.vm
@@ -28,7 +28,7 @@
         <entry colname="COLSPEC0" valign="top">Name</entry>
         <entry colname="COLSPEC1" valign="top">Score</entry>
         <entry colname="COLSPEC2" valign="top">Score<sub>mod</sub></entry>
-        <entry colname="COLSPEC3" valign="top">$vulnerabilityAdapter.getAdvisoryHeader($report.getIncludeAdvisoryTypes())</entry>
+        <entry colname="COLSPEC3" valign="top">$vulnerabilityAdapter.getAdvisoryHeader()</entry>
         <entry colname="COLSPEC4" valign="top">Severity</entry>
         #if ($includeModifiedSevertiyColumns)
             <entry colname="COLSPEC5" valign="top">Severity<sub>mod</sub></entry>
@@ -49,7 +49,7 @@
             ## AEAA-242: use the CVSS scoring preference to determine which score to display
             <entry>$vulnerabilityAdapter.getUnmodifiedCvssScoreByScoringPreference($vulnerability, $cvssScoringPreference)</entry>
             <entry>$vulnerabilityAdapter.getModifiedCvssScoreByScoringPreference($vulnerability, $cvssScoringPreference)</entry>
-            <entry>$vulnerabilityAdapter.hyperlinkedAdvisories($vulnerabilityAdapter.getAdvisories($vulnerability, $report.getIncludeAdvisoryTypes()))</entry>
+            <entry>$vulnerabilityAdapter.hyperlinkedAdvisories($vulnerabilityAdapter.getAdvisories($vulnerability))</entry>
 ##
             #set($cvssSeverityUnmodified = $vulnerabilityAdapter.getUnmodifiedCvssSeverityByScoringPreference($vulnerability, $cvssScoringPreference))
             #if ($utils.notEmpty($cvssSeverityUnmodified) && !$cvssSeverityUnmodified.equals("N/A"))

--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/macros/inventory-report-vulnerabilities.vm
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/macros/inventory-report-vulnerabilities.vm
@@ -50,7 +50,7 @@
 
                 <entry>$vulnerabilityAdapter.getModifiedCvssScoreByScoringPreference($vulnerability, $cvssScoringPreference)</entry>
 
-                <entry>$vulnerabilityAdapter.hyperlinkedAdvisories($vulnerabilityAdapter.getAdvisories($vulnerability, $report.getIncludeAdvisoryTypes()))</entry>
+                <entry>$vulnerabilityAdapter.hyperlinkedAdvisories($vulnerabilityAdapter.getAdvisories($vulnerability))</entry>
 
 
 #set ($cvssStatusUnmodified = $vulnerabilityAdapter.getUnmodifiedCvssSeverityByScoringPreference($vulnerability, $cvssScoringPreference))

--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/tpc_inventory-vulnerability-details.dita.vt
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/tpc_inventory-vulnerability-details.dita.vt
@@ -27,15 +27,15 @@
 
     #set($vulnerabilityName = $vulnerability.get("Name"))
 
-    #set($advisories        = $vulnerabilityAdapter.getAdvisories($vulnerability, null))
+    #set($advisories        = $vulnerabilityAdapter.getAdvisories($vulnerability))
     #set($alerts            = $vulnerabilityAdapter.filterType($advisories, "alert"))
     #set($notices           = $vulnerabilityAdapter.filterType($advisories, "notice"))
     #set($news              = $vulnerabilityAdapter.filterType($advisories, "news"))
 
     ## on detail-level we do not filer the advisories
-    ##set($alerts            = $vulnerabilityAdapter.filterIncludeAdvisoryTypes($alerts, $report.getIncludeAdvisoryTypes()))
-    ##set($notices           = $vulnerabilityAdapter.filterIncludeAdvisoryTypes($notices, $report.getIncludeAdvisoryTypes()))
-    ##set($news              = $vulnerabilityAdapter.filterIncludeAdvisoryTypes($news, $report.getIncludeAdvisoryTypes()))
+    ##set($alerts            = $vulnerabilityAdapter.filterIncludeAdvisoryTypes($alerts))
+    ##set($notices           = $vulnerabilityAdapter.filterIncludeAdvisoryTypes($notices))
+    ##set($news              = $vulnerabilityAdapter.filterIncludeAdvisoryTypes($news))
 
     <topic id="$vulnerabilityName">
         <title>$vulnerabilityName</title>

--- a/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/report/StatisticsOverviewTableTest.java
+++ b/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/report/StatisticsOverviewTableTest.java
@@ -37,7 +37,7 @@ public class StatisticsOverviewTableTest {
     @Test
     public void createStatisticsOverviewTableTest() {
         Inventory inventory = new Inventory();
-        VulnerabilityReportAdapter vra = new VulnerabilityReportAdapter(inventory, VulnerabilityReportAdapter.CVSS_SCORING_PREFERENCE_LATEST_FIRST, 0.0f);
+        VulnerabilityReportAdapter vra = new VulnerabilityReportAdapter(inventory, VulnerabilityReportAdapter.CVSS_SCORING_PREFERENCE_LATEST_FIRST, 0.0f, null);
 
         // start with an empty inventory
         {
@@ -114,7 +114,7 @@ public class StatisticsOverviewTableTest {
     @Test
     public void createStatisticsOverviewTableAddStatusAfterwardsTest() {
         Inventory inventory = new Inventory();
-        VulnerabilityReportAdapter vra = new VulnerabilityReportAdapter(inventory, VulnerabilityReportAdapter.CVSS_SCORING_PREFERENCE_MAX, 0.0f);
+        VulnerabilityReportAdapter vra = new VulnerabilityReportAdapter(inventory, VulnerabilityReportAdapter.CVSS_SCORING_PREFERENCE_MAX, 0.0f, null);
 
         inventory.getVulnerabilityMetaData().add(createVMDUnmodifiedSeverity(null, SEVERITY.CRITICAL.toString()));
         inventory.getVulnerabilityMetaData().add(createVMDUnmodifiedSeverity(null, SEVERITY.CRITICAL.toString()));
@@ -129,7 +129,7 @@ public class StatisticsOverviewTableTest {
     @Test
     public void createStatisticsOverviewForEffectiveValuesTest() {
         Inventory inventory = new Inventory();
-        VulnerabilityReportAdapter vra = new VulnerabilityReportAdapter(inventory, VulnerabilityReportAdapter.CVSS_SCORING_PREFERENCE_LATEST_FIRST, 0.0f);
+        VulnerabilityReportAdapter vra = new VulnerabilityReportAdapter(inventory, VulnerabilityReportAdapter.CVSS_SCORING_PREFERENCE_LATEST_FIRST, 0.0f, null);
 
         inventory.getVulnerabilityMetaData().add(createVMDMultipleSeverities("applicable", SEVERITY.CRITICAL.toString(), SEVERITY.CRITICAL.toString()));
         inventory.getVulnerabilityMetaData().add(createVMDMultipleSeverities("in review", SEVERITY.CRITICAL.toString(), SEVERITY.CRITICAL.toString()));


### PR DESCRIPTION
Refactored usages of `includeAdvisoryTypes`:

- to be of type `List<String>`
- and moved them to `VulnerabilityReportAdapter`

Fixed bug where expression would never be `true` due to incorrect operator:

    - return "0".equals(str) && "n/a".equals(str);
    + return "0".equals(str) || "n/a".equals(str);

Base for **PR #64**.