### PR TITLE
AEAA-309: NVD CVSS Link fix

### DIFF
--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/macros/inventory-report-vulnerabilities.vm
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/macros/inventory-report-vulnerabilities.vm
@@ -208,6 +208,7 @@
             #if ($modified)
                 #set ($link = "https://www.first.org/cvss/calculator/3.1#$vector")
             #else
+                #set ($vector = $vector.replace("CVSS:3.1/", ""))
                 #set ($link = "https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?version=3.1&amp;vector=$vector")
             #end
         #else


### PR DESCRIPTION
This PR fixes the link to the CVSS calculator by the NVD:

Use 

    https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?version=3.1&vector=AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H 

instead of 

    https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?version=3.1&vector=CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H

_A PR with a single line of code changed, amazing._