### PR TITLE
AECORE-115 Assessment Merger

### DIFF
--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/model/AssetMetaData.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/model/AssetMetaData.java
@@ -35,7 +35,9 @@ public class AssetMetaData extends AbstractModelBase {
      * Core attributes to support license data.
      */
     public enum Attribute implements AbstractModelBase.Attribute {
-        ASSET_ID("Asset Id");
+        ASSET_ID("Asset Id"),
+        ASSESSMENT("Assessment"),
+        ;
 
         private String key;
 

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/model/AssetMetaData.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/model/AssetMetaData.java
@@ -36,6 +36,8 @@ public class AssetMetaData extends AbstractModelBase {
      */
     public enum Attribute implements AbstractModelBase.Attribute {
         ASSET_ID("Asset Id"),
+        NAME("Name"),
+        VERSION("Version"),
         ASSESSMENT("Assessment"),
         ;
 

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/AssessmentInventoryMerger.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/AssessmentInventoryMerger.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2009-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.metaeffekt.core.inventory.processor.report;
+
+import org.apache.commons.lang3.StringUtils;
+import org.metaeffekt.core.inventory.processor.model.AssetMetaData;
+import org.metaeffekt.core.inventory.processor.model.Inventory;
+import org.metaeffekt.core.inventory.processor.reader.InventoryReader;
+import org.metaeffekt.core.inventory.processor.writer.InventoryWriter;
+import org.metaeffekt.core.util.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class AssessmentInventoryMerger {
+
+    private final static Logger LOG = LoggerFactory.getLogger(AssessmentInventoryMerger.class);
+
+    private List<File> inputInventoryFiles;
+    private List<Inventory> inputInventories;
+
+    public AssessmentInventoryMerger(List<File> inputInventoryFiles, List<Inventory> inputInventories) {
+        this.inputInventoryFiles = inputInventoryFiles;
+        this.inputInventories = inputInventories;
+    }
+
+    public AssessmentInventoryMerger() {
+        this.inputInventoryFiles = new ArrayList<>();
+        this.inputInventories = new ArrayList<>();
+    }
+
+    public Inventory mergeInventories() throws IOException {
+        final Inventory outputInventory = new Inventory();
+
+        final List<Inventory> collectedInventories = new ArrayList<>(inputInventories);
+        final List<File> inventoryFiles = collectInventoryFiles();
+        LOG.info("Processing [{}] inventories", collectedInventories.size() + inventoryFiles.size());
+
+        {
+            final InventoryReader reader = new InventoryReader();
+            for (File inventoryFile : inventoryFiles) {
+                collectedInventories.add(reader.readInventory(inventoryFile));
+            }
+        }
+
+        final Map<String, List<Inventory>> assessmentContextInventoryMap = new HashMap<>();
+        final Map<String, Inventory> assessmentInventoryMap = new HashMap<>();
+
+        for (Inventory inputInventory : collectedInventories) {
+            final AssetMetaData assetMetaData = inputInventory.getAssetMetaData().get(0);
+
+            // in this case the assessment context is the asset (assessment by asset case)
+            final String assetName = assetMetaData.get("Name");
+            final String assessmentContext = formatNormalizedAssessmentContextName(assetName);
+            LOG.info("Processing inventory with asset [{}] and assessment context [{}]", assetName, assessmentContext);
+
+            final List<Inventory> commonInventories = assessmentContextInventoryMap.computeIfAbsent(assessmentContext, a -> new ArrayList<>());
+            final int inventoryDisplayIndex = commonInventories.size() + 1;
+            final String localUniqueAssessmentId = String.format("%s-%03d", assessmentContext, inventoryDisplayIndex);
+
+            assetMetaData.set("Assessment", localUniqueAssessmentId);
+            assetMetaData.set("Name", assetName.toUpperCase());
+
+            commonInventories.add(inputInventory);
+            assessmentInventoryMap.put(localUniqueAssessmentId, inputInventory);
+
+            // contribute asset metadata to output inventory
+            outputInventory.getAssetMetaData().add(assetMetaData);
+        }
+
+        // iterate over each asset in the output inventory and add its respective vulnerabilities
+        for (AssetMetaData assetMetaData : outputInventory.getAssetMetaData()) {
+            final String localUniqueAssessmentId = assetMetaData.get(AssetMetaData.Attribute.ASSESSMENT);
+            if (StringUtils.isNotEmpty(localUniqueAssessmentId)) {
+                final Inventory singleInventory = assessmentInventoryMap.get(localUniqueAssessmentId);
+                if (singleInventory != null) {
+                    outputInventory.getVulnerabilityMetaData(localUniqueAssessmentId).addAll(singleInventory.getVulnerabilityMetaData());
+                }
+            }
+        }
+
+        return outputInventory;
+    }
+
+    protected String formatNormalizedAssessmentContextName(String assetName) {
+        String assessmentContext = assetName.toUpperCase().replace(" ", "_");
+        final int maxAllowedChars = 25;
+        assessmentContext = assessmentContext.substring(0, Math.min(assessmentContext.length(), maxAllowedChars - InventoryWriter.VULNERABILITY_ASSESSMENT_WORKSHEET_PREFIX.length()));
+
+        // remove trailing "_-"
+        while (assessmentContext.endsWith("_") || assessmentContext.endsWith("-")) {
+            assessmentContext = assessmentContext.substring(0, assessmentContext.length() - 1);
+        }
+        return assessmentContext;
+    }
+
+    private List<File> collectInventoryFiles() {
+        final List<File> inventoryFiles = new ArrayList<>();
+
+        for (File inputInventory : inputInventoryFiles) {
+            if (inputInventory.isDirectory()) {
+                final String[] files = FileUtils.scanDirectoryForFiles(inputInventory, "*.xls");
+                for (String file : files) {
+                    inventoryFiles.add(new File(inputInventory, file));
+                }
+            } else {
+                inventoryFiles.add(inputInventory);
+            }
+        }
+
+        return inventoryFiles;
+    }
+
+    public void addInputInventoryFile(File inputInventory) {
+        this.inputInventoryFiles.add(inputInventory);
+    }
+
+    public void setInputInventoryFiles(List<File> inputInventoryFiles) {
+        this.inputInventoryFiles = inputInventoryFiles;
+    }
+
+    public List<File> getInputInventoryFiles() {
+        return inputInventoryFiles;
+    }
+
+    public void addInputInventory(Inventory inputInventory) {
+        this.inputInventories.add(inputInventory);
+    }
+
+    public void setInputInventories(List<Inventory> inputInventories) {
+        this.inputInventories = inputInventories;
+    }
+
+    public List<Inventory> getInputInventories() {
+        return inputInventories;
+    }
+}

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/AssessmentReportAdapter.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/AssessmentReportAdapter.java
@@ -69,7 +69,7 @@ public class AssessmentReportAdapter {
                         break;
                 }
 
-                boolean isAssessed = vulnerabilityMetaData.isStatus(STATUS_VALUE_APPLICABLE) ||
+                final boolean isAssessed = vulnerabilityMetaData.isStatus(STATUS_VALUE_APPLICABLE) ||
                         vulnerabilityMetaData.isStatus(STATUS_VALUE_NOTAPPLICABLE) ||
                         vulnerabilityMetaData.isStatus(STATUS_VALUE_VOID);
 

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/writer/InventoryWriter.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/writer/InventoryWriter.java
@@ -24,7 +24,7 @@ import java.io.IOException;
 
 public class InventoryWriter extends AbstractXlsInventoryWriter {
 
-    private final Logger LOG = LoggerFactory.getLogger(getClass());
+    private final static Logger LOG = LoggerFactory.getLogger(InventoryWriter.class);
 
     public static final String VULNERABILITY_ASSESSMENT_WORKSHEET_PREFIX = "Assessment-";
 

--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/assessment-report/macros/assessment-report.vm
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/assessment-report/macros/assessment-report.vm
@@ -29,7 +29,6 @@
         <tbody>
 #foreach ($asset in $assets)
 #set($counts = $assessmentReportAdapter.countVulnerabilities($asset, $useModifiedSeverity))
-$counts
             <row  align="center">
                 <entry align="center">$report.xmlEscapeString($asset.get("Name"))</entry>
                 <entry>$counts.criticalCounter</entry>

--- a/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/report/AssessmentInventoryMergerTest.java
+++ b/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/report/AssessmentInventoryMergerTest.java
@@ -101,7 +101,6 @@ public class AssessmentInventoryMergerTest {
     public void mergeInventoriesWithDuplicateAssetsTest() throws IOException {
         final AssessmentInventoryMerger merger = new AssessmentInventoryMerger();
 
-        // First inventory
         {
             final Inventory inputInventory = new Inventory();
             merger.addInputInventory(inputInventory);
@@ -116,7 +115,6 @@ public class AssessmentInventoryMergerTest {
             vmd.set(VulnerabilityMetaData.Attribute.NAME, "CVE-2018-1234");
         }
 
-        // Second inventory with duplicate asset
         {
             final Inventory inputInventory = new Inventory();
             merger.addInputInventory(inputInventory);

--- a/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/report/AssessmentInventoryMergerTest.java
+++ b/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/report/AssessmentInventoryMergerTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2009-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.metaeffekt.core.inventory.processor.report;
+
+import org.junit.Test;
+import org.metaeffekt.core.inventory.processor.model.Inventory;
+import org.metaeffekt.core.inventory.processor.writer.InventoryWriter;
+
+import java.io.File;
+import java.io.IOException;
+
+public class AssessmentInventoryMergerTest {
+
+    @Test
+    public void sditMergedTest() throws IOException {
+        final AssessmentInventoryMerger merger = new AssessmentInventoryMerger();
+        merger.addInputInventoryFile(new File("/Users/ywittmann/workspace/ref/inventories/00_Other/testing/assessment_merging_S-DIT-007-Merged-Inventories-DK/S-DIT-007-Merged-Inventories-DK/merged"));
+
+        final Inventory merged = merger.mergeInventories();
+        new InventoryWriter().writeInventory(merged, new File("/Users/ywittmann/workspace/ref/inventories/00_Other/testing/assessment_merging_S-DIT-007-Merged-Inventories-DK/S-DIT-007-Merged-Inventories-DK/merged.xls"));
+    }
+
+    @Test
+    public void normalizeNameTest() {
+        AssessmentInventoryMerger merger = new AssessmentInventoryMerger();
+        System.out.println(merger.formatNormalizedAssessmentContextName("Test-Name-longer-than-25-chars"));
+    }
+}

--- a/plugins/ae-inventory-maven-plugin/src/main/java/org/metaeffekt/core/maven/inventory/mojo/AbstractMultipleInputInventoriesMojo.java
+++ b/plugins/ae-inventory-maven-plugin/src/main/java/org/metaeffekt/core/maven/inventory/mojo/AbstractMultipleInputInventoriesMojo.java
@@ -1,0 +1,68 @@
+package org.metaeffekt.core.maven.inventory.mojo;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.metaeffekt.core.util.FileUtils;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * This class is an abstract class that extends the AbstractProjectAwareConfiguredMojo class.<br>
+ * It provides the common functionalities for handling multiple input inventories for maven plugins.
+ */
+public abstract class AbstractMultipleInputInventoriesMojo extends AbstractProjectAwareConfiguredMojo {
+
+    /**
+     * The source inventory.
+     */
+    @Parameter(required = false)
+    protected File sourceInventory;
+
+    /**
+     * Alternatively to the sourceInventory parameter a directory can be specified. The inventory is scanned for files
+     * using sourceInventoryIncludes and sourceInventoryExcludes.
+     */
+    @Parameter(required = false)
+    protected File sourceInventoryBaseDir;
+
+    /**
+     * Includes based on sourceInventoryBaseDir.
+     */
+    @Parameter(defaultValue = "**/*.xls")
+    protected String sourceInventoryIncludes;
+
+    /**
+     * Excludes based on sourceInventoryBaseDir.
+     */
+    @Parameter
+    protected String sourceInventoryExcludes;
+
+    protected List<File> collectSourceInventories() throws MojoExecutionException {
+        final List<File> sourceInventories = new ArrayList<>();
+
+        if (sourceInventory != null) {
+            if (sourceInventory.exists() && sourceInventory.isFile()) {
+                sourceInventories.add(sourceInventory);
+            } else {
+                throw new MojoExecutionException("The parameter [sourceInventory] is set, but the file does not exist: " +
+                        sourceInventory.getAbsolutePath());
+            }
+        }
+
+        if (sourceInventoryBaseDir != null) {
+            if (sourceInventoryBaseDir.exists() && sourceInventoryBaseDir.isDirectory()) {
+                final String[] sourceFiles = FileUtils.scanForFiles(sourceInventoryBaseDir,
+                        sourceInventoryIncludes, sourceInventoryExcludes);
+                Arrays.stream(sourceFiles).forEach(f -> sourceInventories.add(new File(sourceInventoryBaseDir, f)));
+            } else {
+                throw new MojoExecutionException("The parameter [sourceInventoryBaseDir] parameter is set, but the directory does not exist: " +
+                        sourceInventoryBaseDir.getAbsolutePath());
+            }
+        }
+
+        return sourceInventories;
+    }
+}

--- a/plugins/ae-inventory-maven-plugin/src/main/java/org/metaeffekt/core/maven/inventory/mojo/AssessmentInventoryMergeMojo.java
+++ b/plugins/ae-inventory-maven-plugin/src/main/java/org/metaeffekt/core/maven/inventory/mojo/AssessmentInventoryMergeMojo.java
@@ -1,0 +1,43 @@
+package org.metaeffekt.core.maven.inventory.mojo;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.metaeffekt.core.inventory.processor.model.Inventory;
+import org.metaeffekt.core.inventory.processor.report.AssessmentInventoryMerger;
+import org.metaeffekt.core.inventory.processor.writer.InventoryWriter;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+@Mojo(name = "merge-inventories-assessment", defaultPhase = LifecyclePhase.PREPARE_PACKAGE)
+public class AssessmentInventoryMergeMojo extends AbstractMultipleInputInventoriesMojo {
+
+    @Parameter(required = true)
+    protected File targetInventory;
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        try {
+            final List<File> inputInventoryFiles = super.collectSourceInventories();
+
+            final AssessmentInventoryMerger merger = new AssessmentInventoryMerger(inputInventoryFiles, Collections.emptyList());
+            final Inventory mergedInventory = merger.mergeInventories();
+
+            // create target directory if not existing yet
+            final File targetParentFile = this.targetInventory.getParentFile();
+            if (targetParentFile != null && !this.targetInventory.exists()) {
+                targetParentFile.mkdirs();
+            }
+
+            // write inventory to target location
+            new InventoryWriter().writeInventory(mergedInventory, this.targetInventory);
+        } catch (IOException e) {
+            throw new MojoExecutionException(e.getMessage(), e);
+        }
+    }
+}


### PR DESCRIPTION
Added Assessment inventory merger that creates VMD contexts based on Asset information form multiple inventories.

```xml
<plugin>
    <groupId>org.metaeffekt.core</groupId>
    <artifactId>ae-inventory-maven-plugin</artifactId>
    <version>HEAD-SNAPSHOT</version>

    <executions>
        <execution>
            <id>data-mirror</id>
            <goals>
                <goal>merge-inventories-assessment</goal>
            </goals>
            <configuration>
                <sourceInventory>input-inventory.xls</sourceInventory>

                <sourceInventoryBaseDir>input-dir</sourceInventoryBaseDir>
                <sourceInventoryIncludes>**/*.xls</sourceInventoryIncludes>
                <sourceInventoryExcludes>**/*.yaml</sourceInventoryExcludes>

                <targetInventory>merged.xls</targetInventory>
            </configuration>
        </execution>
    </executions>
</plugin>
```