### PR TITLE
AECORE-115: Fixing the vulnerability count in the Assessment Overview table

### DIFF
--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/AssessmentReportAdapter.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/AssessmentReportAdapter.java
@@ -43,32 +43,45 @@ public class AssessmentReportAdapter {
     public VulnerabilityCounts countVulnerabilities(AssetMetaData assetMetaData, boolean useModifiedSeverity) {
         // check for asset-specific assessment
         final String assessment = assetMetaData.get("Assessment");
-
         final List<VulnerabilityMetaData> vulnerabilities = inventory.getVulnerabilityMetaData(assessment);
 
         final VulnerabilityCounts counts = new VulnerabilityCounts();
+
         if (vulnerabilities != null && !vulnerabilities.isEmpty()) {
-            for (VulnerabilityMetaData vulnerabilityMetaData : vulnerabilities) {
-                final String severity = getSeverity(vulnerabilityMetaData, useModifiedSeverity);
+            if (useModifiedSeverity) {
+                final StatisticsOverviewTable table = StatisticsOverviewTable.fromVmd(new VulnerabilityReportAdapter(new Inventory()), vulnerabilities, null, useModifiedSeverity, StatisticsOverviewTable.VULNERABILITY_STATUS_MAPPER_DEFAULT);
 
-                switch (severity.toLowerCase()) {
-                    case "critical":
-                        counts.criticalCounter++;
-                        break;
-                    case "high":
-                        counts.highCounter++;
-                        break;
-                    case "medium":
-                        counts.mediumCounter++;
-                        break;
-                    case "low":
-                        counts.lowCounter++;
-                        break;
-                    case "none":
-                        counts.noneCounter++;
-                        break;
+                counts.criticalCounter = table.getTotalForSeverity("critical");
+                counts.highCounter = table.getTotalForSeverity("high");
+                counts.mediumCounter = table.getTotalForSeverity("medium");
+                counts.lowCounter = table.getTotalForSeverity("low");
+                counts.noneCounter = table.getTotalForSeverity("none");
+
+            } else {
+                for (VulnerabilityMetaData vulnerabilityMetaData : vulnerabilities) {
+                    final String severity = getSeverity(vulnerabilityMetaData, useModifiedSeverity);
+
+                    switch (severity.toLowerCase()) {
+                        case "critical":
+                            counts.criticalCounter++;
+                            break;
+                        case "high":
+                            counts.highCounter++;
+                            break;
+                        case "medium":
+                            counts.mediumCounter++;
+                            break;
+                        case "low":
+                            counts.lowCounter++;
+                            break;
+                        case "none":
+                            counts.noneCounter++;
+                            break;
+                    }
                 }
+            }
 
+            for (VulnerabilityMetaData vulnerabilityMetaData : vulnerabilities) {
                 final boolean isAssessed = vulnerabilityMetaData.isStatus(STATUS_VALUE_APPLICABLE) ||
                         vulnerabilityMetaData.isStatus(STATUS_VALUE_NOTAPPLICABLE) ||
                         vulnerabilityMetaData.isStatus(STATUS_VALUE_VOID);
@@ -110,7 +123,7 @@ public class AssessmentReportAdapter {
     /**
      * Helper class to collect information per {@link AssetMetaData} instance.
      */
-    public class VulnerabilityCounts {
+    public static class VulnerabilityCounts {
         public long criticalCounter;
         public long highCounter;
         public long mediumCounter;

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/StatisticsOverviewTable.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/StatisticsOverviewTable.java
@@ -99,6 +99,19 @@ public class StatisticsOverviewTable {
                 .mapToInt(Integer::intValue).sum();
     }
 
+    public int getTotalForSeverity(String severity) {
+        severity = normalize(severity);
+        if (severityStatusCountMap.containsKey(severity)) {
+            final Object total = severityStatusCountMap.get(severity).getOrDefault("total", 0);
+            if (total instanceof Number) {
+                return (Integer) total;
+            } else if (total instanceof String && StringUtils.isNumeric((String) total)) {
+                return Integer.parseInt((String) total);
+            }
+        }
+        return 0;
+    }
+
     /**
      * Checks if the table is empty.<br>
      * The table is considered empty if all cells have the value "0", except for the "% assessed" column.
@@ -148,7 +161,7 @@ public class StatisticsOverviewTable {
         );
     }
 
-    private static void filterVulnerabilityMetaDataForAdvisories(List<VulnerabilityMetaData> vmds, String filterCert) {
+    private static void filterVulnerabilityMetaDataForAdvisories(Collection<VulnerabilityMetaData> vmds, String filterCert) {
         vmds.removeIf(
                 vmd -> {
                     String adv = vmd.getComplete("Advisories");
@@ -169,24 +182,22 @@ public class StatisticsOverviewTable {
     }
 
     public static StatisticsOverviewTable fromInventoryUnmodified(VulnerabilityReportAdapter adapter, Function<String, String> vulnerabilityStatusMapper) {
-        return StatisticsOverviewTable.fromInventory(adapter, null, false, vulnerabilityStatusMapper);
+        return StatisticsOverviewTable.fromVmd(adapter, adapter.inventory.getVulnerabilityMetaData(), null, false, vulnerabilityStatusMapper);
     }
 
     public static StatisticsOverviewTable fromInventoryModified(VulnerabilityReportAdapter adapter, Function<String, String> vulnerabilityStatusMapper) {
-        return StatisticsOverviewTable.fromInventory(adapter, null, true, vulnerabilityStatusMapper);
+        return StatisticsOverviewTable.fromVmd(adapter, adapter.inventory.getVulnerabilityMetaData(), null, true, vulnerabilityStatusMapper);
     }
 
     public static StatisticsOverviewTable fromInventoryUnmodified(VulnerabilityReportAdapter adapter, String filterCert, Function<String, String> vulnerabilityStatusMapper) {
-        return StatisticsOverviewTable.fromInventory(adapter, filterCert, false, vulnerabilityStatusMapper);
+        return StatisticsOverviewTable.fromVmd(adapter, adapter.inventory.getVulnerabilityMetaData(), filterCert, false, vulnerabilityStatusMapper);
     }
 
     public static StatisticsOverviewTable fromInventoryModified(VulnerabilityReportAdapter adapter, String filterCert, Function<String, String> vulnerabilityStatusMapper) {
-        return StatisticsOverviewTable.fromInventory(adapter, filterCert, true, vulnerabilityStatusMapper);
+        return StatisticsOverviewTable.fromVmd(adapter, adapter.inventory.getVulnerabilityMetaData(), filterCert, true, vulnerabilityStatusMapper);
     }
 
-    private static StatisticsOverviewTable fromInventory(VulnerabilityReportAdapter adapter, String filterCert, boolean useModifiedSeverity, Function<String, String> vulnerabilityStatusMapper) {
-        final List<VulnerabilityMetaData> vmds = new ArrayList<>(adapter.inventory.getVulnerabilityMetaData());
-
+    public static StatisticsOverviewTable fromVmd(VulnerabilityReportAdapter adapter, Collection<VulnerabilityMetaData> vmds, String filterCert, boolean useModifiedSeverity, Function<String, String> vulnerabilityStatusMapper) {
         if (filterCert != null && !filterCert.isEmpty()) {
             StatisticsOverviewTable.filterVulnerabilityMetaDataForAdvisories(vmds, filterCert);
         }

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/StatisticsOverviewTable.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/StatisticsOverviewTable.java
@@ -197,7 +197,8 @@ public class StatisticsOverviewTable {
         return StatisticsOverviewTable.fromVmd(adapter, adapter.inventory.getVulnerabilityMetaData(), filterCert, true, vulnerabilityStatusMapper);
     }
 
-    public static StatisticsOverviewTable fromVmd(VulnerabilityReportAdapter adapter, Collection<VulnerabilityMetaData> vmds, String filterCert, boolean useModifiedSeverity, Function<String, String> vulnerabilityStatusMapper) {
+    public static StatisticsOverviewTable fromVmd(VulnerabilityReportAdapter adapter, Collection<VulnerabilityMetaData> inputVmds, String filterCert, boolean useModifiedSeverity, Function<String, String> vulnerabilityStatusMapper) {
+        final Collection<VulnerabilityMetaData> vmds = new ArrayList<>(inputVmds);
         if (filterCert != null && !filterCert.isEmpty()) {
             StatisticsOverviewTable.filterVulnerabilityMetaDataForAdvisories(vmds, filterCert);
         }


### PR DESCRIPTION
Now uses the `StatisticsOverviewTable` to generate the chart information if the modified chart is generated.