### PR TITLE
AECORE-117 / AECORE-118 - Inventory Reader / Writer refactoring

### DIFF
--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/model/AbstractModelBase.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/model/AbstractModelBase.java
@@ -18,6 +18,7 @@ package org.metaeffekt.core.inventory.processor.model;
 import org.apache.commons.lang3.StringUtils;
 import org.metaeffekt.core.inventory.processor.writer.AbstractXlsxInventoryWriter;
 
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -27,7 +28,7 @@ import java.util.Set;
  * Abstract model base class. Support associating key and values as generic concept. Keys can be bound to enums specified
  * by the subclass.
  */
-public abstract class AbstractModelBase {
+public abstract class AbstractModelBase implements Serializable {
 
     public interface Attribute {
         String getKey();

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/model/AbstractModelBase.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/model/AbstractModelBase.java
@@ -15,8 +15,8 @@
  */
 package org.metaeffekt.core.inventory.processor.model;
 
-import org.metaeffekt.core.inventory.processor.writer.InventoryWriter;
 import org.apache.commons.lang3.StringUtils;
+import org.metaeffekt.core.inventory.processor.writer.AbstractXlsxInventoryWriter;
 
 import java.util.HashMap;
 import java.util.List;
@@ -218,7 +218,7 @@ public abstract class AbstractModelBase {
      * @param key   The key to set the value for.
      * @param value The value to set for the key.
      */
-    // FIXME: limitation of excel
+    // FIXME: limitation of excel, move into writers, letting them handle the issue when reading and writing
     public void setComplete(String key, String value) {
         // clear the current value before writing the new value
         int index = 1;
@@ -234,12 +234,12 @@ public abstract class AbstractModelBase {
         }
 
         // if the content is longer than the maximum cell length, it has to be split up into multiple cells
-        if (value.length() <= InventoryWriter.MAX_CELL_LENGTH) {
+        if (value.length() <= AbstractXlsxInventoryWriter.MAX_CELL_LENGTH) {
             set(key, value);
         } else {
             index = 0;
-            while (index * InventoryWriter.MAX_CELL_LENGTH < value.length()) {
-                String part = value.substring(index * InventoryWriter.MAX_CELL_LENGTH, Math.min(value.length(), (index + 1) * InventoryWriter.MAX_CELL_LENGTH));
+            while (index * AbstractXlsxInventoryWriter.MAX_CELL_LENGTH < value.length()) {
+                String part = value.substring(index * AbstractXlsxInventoryWriter.MAX_CELL_LENGTH, Math.min(value.length(), (index + 1) * AbstractXlsxInventoryWriter.MAX_CELL_LENGTH));
                 if (index == 0) set(key, part);
                 else set(key + " (split-" + index + ")", part);
                 index++;

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/model/Inventory.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/model/Inventory.java
@@ -42,7 +42,6 @@ import static org.metaeffekt.core.inventory.processor.model.Constants.*;
  *     <li>{@link #Inventory(Inventory)} - Used for deep-copying an instance, also used in deserialization</li>
  *     <li>{@link #hasInformationOtherThanArtifacts()} - Checks if the inventory contains more than just artifact data</li>
  * </ul>
- * </p>
  *
  * @author Karsten Klein
  */

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/model/Inventory.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/model/Inventory.java
@@ -16,10 +16,10 @@
 package org.metaeffekt.core.inventory.processor.model;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.metaeffekt.core.inventory.InventoryUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.apache.commons.lang3.StringUtils;
 
 import java.io.File;
 import java.io.IOException;
@@ -75,6 +75,18 @@ public class Inventory {
      * Enables to store serialization-related data with the inventory.
      */
     private final InventorySerializationContext serializationContext = new InventorySerializationContext();
+
+    public boolean hasInformationOtherThanArtifacts() {
+        if (!licenseMetaData.isEmpty()) return true;
+        if (!componentPatternData.isEmpty()) return true;
+        if (!licenseData.isEmpty()) return true;
+        if (!certMetaData.isEmpty()) return true;
+        if (!inventoryInfo.isEmpty()) return true;
+        if (!reportData.isEmpty()) return true;
+        if (!assetMetaData.isEmpty()) return true;
+        if (vulnerabilityMetaData.values().stream().anyMatch(l -> !l.isEmpty())) return true;
+        return false;
+    }
 
     public static void sortArtifacts(List<Artifact> artifacts) {
         final Comparator<Artifact> comparator = new Comparator<Artifact>() {
@@ -1161,7 +1173,7 @@ public class Inventory {
 
         if (getVulnerabilityMetaDataContexts().size() > 1) {
             getVulnerabilityMetaDataContexts().forEach(
-                context -> filteredInventory.setVulnerabilityMetaData(getVulnerabilityMetaData(context), context)
+                    context -> filteredInventory.setVulnerabilityMetaData(getVulnerabilityMetaData(context), context)
             );
         } else {
             filteredInventory.setVulnerabilityMetaData(getVulnerabilityMetaData());

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/reader/InventoryReader.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/reader/InventoryReader.java
@@ -15,42 +15,74 @@
  */
 package org.metaeffekt.core.inventory.processor.reader;
 
-import org.metaeffekt.core.inventory.processor.model.*;
-import org.metaeffekt.core.inventory.processor.writer.XlsInventoryWriter;
-import org.metaeffekt.core.inventory.processor.writer.XlsxInventoryWriter;
+import org.metaeffekt.core.inventory.processor.model.Inventory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
-import org.apache.commons.lang3.StringUtils;
 
 import java.io.File;
-import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Supplier;
 
-public class InventoryReader {
+public class InventoryReader extends AbstractInventoryReader {
 
+    private final static Logger LOG = LoggerFactory.getLogger(InventoryReader.class);
+
+    private final static Map<String, Supplier<AbstractInventoryReader>> EXTENSIONS_TO_READERS = new LinkedHashMap<String, Supplier<AbstractInventoryReader>>() {{
+        put(".xls", XlsInventoryReader::new);
+        put(".xlsx", XlsxInventoryReader::new);
+    }};
+
+    @Override
     public Inventory readInventory(File file) throws IOException {
-        if (file == null || !file.exists()) {
-            throw new IOException("File [" + file.getAbsolutePath()  + "] does not exist.");
+        if (file == null) {
+            throw new FileNotFoundException("File is null.");
         }
-        if (file.getName().toLowerCase().endsWith(".xls")) {
-            return new XlsInventoryReader().readInventory(file);
-        } else {
-            return new XlsxInventoryReader().readInventory(file);
+        if (!file.exists()) {
+            throw new FileNotFoundException("File [" + file.getAbsolutePath() + "] does not exist.");
         }
+
+        final String extension = getFileExtension(file.getName());
+        return getReaderForExtension(extension).readInventory(file);
     }
 
     public Inventory readInventoryAsClasspathResource(File file) throws IOException {
+        if (file == null) {
+            throw new FileNotFoundException("File is null.");
+        }
+
         final Resource inventoryResource = new ClassPathResource(file.getPath());
         try (InputStream in = inventoryResource.getInputStream()) {
-            if (file.getName().toLowerCase().endsWith(".xls")) {
-                return new XlsInventoryReader().readInventory(in);
-            } else {
-                return new XlsxInventoryReader().readInventory(in);
-            }
+            final String extension = getFileExtension(file.getName());
+            return getReaderForExtension(extension).readInventory(in);
         }
     }
 
+    @Override
+    public Inventory readInventory(InputStream in) throws IOException {
+        throw new UnsupportedOperationException("Reading from input stream is not supported. Use readInventory(InputStream in, String extension) or the specific implementations instead.");
+    }
+
+    public Inventory readInventory(InputStream in, String extension) throws IOException {
+        return getReaderForExtension(extension).readInventory(in);
+    }
+
+    private AbstractInventoryReader getReaderForExtension(String extension) throws IOException {
+        final Supplier<AbstractInventoryReader> readerSupplier = EXTENSIONS_TO_READERS.get(extension);
+        if (readerSupplier == null) {
+            throw new IOException("Unsupported file type [" + extension + "].");
+        }
+        return readerSupplier.get();
+    }
+
+    private String getFileExtension(String filename) {
+        int lastIndexOf = filename.toLowerCase().lastIndexOf(".");
+        if (lastIndexOf == -1) return "";
+        return filename.substring(lastIndexOf);
+    }
 }

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/reader/InventoryReader.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/reader/InventoryReader.java
@@ -36,6 +36,7 @@ public class InventoryReader extends AbstractInventoryReader {
     private final static Map<String, Supplier<AbstractInventoryReader>> EXTENSIONS_TO_READERS = new LinkedHashMap<String, Supplier<AbstractInventoryReader>>() {{
         put(".xls", XlsInventoryReader::new);
         put(".xlsx", XlsxInventoryReader::new);
+        put(".ser", SerializedInventoryReader::new);
     }};
 
     @Override

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/reader/SerializedInventoryReader.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/reader/SerializedInventoryReader.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2009-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.metaeffekt.core.inventory.processor.reader;
+
+import org.metaeffekt.core.inventory.processor.model.Inventory;
+
+import java.io.*;
+import java.util.zip.GZIPInputStream;
+
+public class SerializedInventoryReader extends AbstractInventoryReader {
+
+    @Override
+    public Inventory readInventory(File file) throws IOException {
+        try (FileInputStream fileIn = new FileInputStream(file)) {
+            return readInventory(fileIn);
+        }
+    }
+
+    @Override
+    public Inventory readInventory(InputStream in) throws IOException {
+        try (GZIPInputStream gzipIn = new GZIPInputStream(in);
+             final ObjectInputStream objIn = new ObjectInputStream(gzipIn)) {
+            return (Inventory) objIn.readObject();
+        } catch (ClassNotFoundException e) {
+            throw new IOException("Class not found during deserialization", e);
+        }
+    }
+}

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/writer/AbstractInventoryWriter.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/writer/AbstractInventoryWriter.java
@@ -15,11 +15,18 @@
  */
 package org.metaeffekt.core.inventory.processor.writer;
 
+import org.metaeffekt.core.inventory.processor.model.Inventory;
+
+import java.io.File;
+import java.io.IOException;
+
 import static org.metaeffekt.core.inventory.processor.model.VulnerabilityMetaData.VULNERABILITY_ASSESSMENT_CONTEXT_DEFAULT;
 import static org.metaeffekt.core.inventory.processor.writer.InventoryWriter.SINGLE_VULNERABILITY_ASSESSMENT_WORKSHEET;
 import static org.metaeffekt.core.inventory.processor.writer.InventoryWriter.VULNERABILITY_ASSESSMENT_WORKSHEET_PREFIX;
 
-public class AbstractInventoryWriter {
+public abstract class AbstractInventoryWriter {
+
+    public abstract void writeInventory(Inventory inventory, File file) throws IOException;
 
     public String assessmentContextToSheetName(String assessmentContext) {
         if (VULNERABILITY_ASSESSMENT_CONTEXT_DEFAULT.equals(assessmentContext)) {
@@ -36,6 +43,4 @@ public class AbstractInventoryWriter {
                 key.startsWith("IID-") ||
                 key.startsWith("EAID-");
     }
-
-
 }

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/writer/AbstractXlsInventoryWriter.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/writer/AbstractXlsInventoryWriter.java
@@ -25,9 +25,11 @@ import org.apache.poi.ss.usermodel.Font;
 import org.apache.poi.ss.usermodel.HorizontalAlignment;
 import org.apache.poi.ss.usermodel.VerticalAlignment;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 
-public class AbstractXlsInventoryWriter extends AbstractInventoryWriter {
+public abstract class AbstractXlsInventoryWriter extends AbstractInventoryWriter {
 
     /**
      * Excel 97 limits the maximum cell content length to <code>32767</code> characters. To ensure that the contents are

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/writer/AbstractXlsxInventoryWriter.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/writer/AbstractXlsxInventoryWriter.java
@@ -23,7 +23,7 @@ import org.apache.poi.xssf.usermodel.XSSFColor;
 
 import java.util.*;
 
-public class AbstractXlsxInventoryWriter extends AbstractInventoryWriter {
+public abstract class AbstractXlsxInventoryWriter extends AbstractInventoryWriter {
 
     /**
      * Excel 97 limits the maximum cell content length to <code>32767</code> characters. To ensure that the contents are

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/writer/InventoryWriter.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/writer/InventoryWriter.java
@@ -37,6 +37,7 @@ public class InventoryWriter extends AbstractInventoryWriter {
     private final static Map<String, Supplier<AbstractInventoryWriter>> EXTENSIONS_TO_WRITERS = new LinkedHashMap<String, Supplier<AbstractInventoryWriter>>() {{
         put(".xls", XlsInventoryWriter::new);
         put(".xlsx", XlsxInventoryWriter::new);
+        put(".ser", SerializedInventoryWriter::new);
     }};
 
     @Override

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/writer/InventoryWriter.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/writer/InventoryWriter.java
@@ -20,9 +20,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Supplier;
 
-public class InventoryWriter extends AbstractXlsInventoryWriter {
+public class InventoryWriter extends AbstractInventoryWriter {
 
     private final static Logger LOG = LoggerFactory.getLogger(InventoryWriter.class);
 
@@ -30,12 +34,32 @@ public class InventoryWriter extends AbstractXlsInventoryWriter {
 
     public static final String SINGLE_VULNERABILITY_ASSESSMENT_WORKSHEET = "Vulnerabilities";
 
+    private final static Map<String, Supplier<AbstractInventoryWriter>> EXTENSIONS_TO_WRITERS = new LinkedHashMap<String, Supplier<AbstractInventoryWriter>>() {{
+        put(".xls", XlsInventoryWriter::new);
+        put(".xlsx", XlsxInventoryWriter::new);
+    }};
+
+    @Override
     public void writeInventory(Inventory inventory, File file) throws IOException {
-        if (file.getName().endsWith(".xls")) {
-            new XlsInventoryWriter().writeInventory(inventory, file);
-        } else {
-            new XlsxInventoryWriter().writeInventory(inventory, file);
+        if (file == null) {
+            throw new FileNotFoundException("File is null.");
         }
+
+        final String extension = getFileExtension(file.getName());
+        getWriterForExtension(extension).writeInventory(inventory, file);
     }
 
+    private AbstractInventoryWriter getWriterForExtension(String extension) throws IOException {
+        final Supplier<AbstractInventoryWriter> writerSupplier = EXTENSIONS_TO_WRITERS.get(extension);
+        if (writerSupplier == null) {
+            throw new IOException("Unsupported file type [" + extension + "].");
+        }
+        return writerSupplier.get();
+    }
+
+    private String getFileExtension(String filename) {
+        int lastIndexOf = filename.toLowerCase().lastIndexOf(".");
+        if (lastIndexOf == -1) return "";
+        return filename.substring(lastIndexOf);
+    }
 }

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/writer/SerializedInventoryWriter.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/writer/SerializedInventoryWriter.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2009-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.metaeffekt.core.inventory.processor.writer;
+
+import org.metaeffekt.core.inventory.processor.model.Inventory;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.util.zip.GZIPOutputStream;
+
+public class SerializedInventoryWriter extends AbstractInventoryWriter {
+
+    @Override
+    public void writeInventory(Inventory inventory, File file) throws IOException {
+        try (FileOutputStream fileOut = new FileOutputStream(file);
+             final GZIPOutputStream gzipOut = new GZIPOutputStream(fileOut);
+             final ObjectOutputStream out = new ObjectOutputStream(gzipOut)) {
+            out.writeObject(inventory);
+        }
+    }
+}

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/writer/XlsInventoryWriter.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/writer/XlsInventoryWriter.java
@@ -36,7 +36,7 @@ import java.util.*;
 
 public class XlsInventoryWriter extends AbstractXlsInventoryWriter {
 
-    private final Logger LOG = LoggerFactory.getLogger(getClass());
+    private final static Logger LOG = LoggerFactory.getLogger(XlsInventoryWriter.class);
 
     public void writeInventory(Inventory inventory, File file) throws IOException {
         final HSSFWorkbook workbook = new HSSFWorkbook();
@@ -63,7 +63,13 @@ public class XlsInventoryWriter extends AbstractXlsInventoryWriter {
     }
 
     private void writeArtifacts(Inventory inventory, HSSFWorkbook workbook) {
-        // an artifact inventory is always written (an xls without sheets is regarded damaged by Excel)
+        // the artifact sheet is only written, if:
+        // - there are artifacts
+        // - there is no other information in the inventory
+        //   this has to be done, since a xls without sheets is regarded damaged by Excel
+        if (inventory.hasInformationOtherThanArtifacts() && inventory.getArtifacts().isEmpty()) {
+            return;
+        }
 
         final HSSFSheet sheet = workbook.createSheet(AbstractInventoryReader.WORKSHEET_NAME_ARTIFACT_DATA);
         sheet.createFreezePane(0, 1);

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/writer/XlsxInventoryWriter.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/writer/XlsxInventoryWriter.java
@@ -26,7 +26,8 @@ import org.apache.poi.xssf.streaming.SXSSFCell;
 import org.apache.poi.xssf.streaming.SXSSFRow;
 import org.apache.poi.xssf.streaming.SXSSFSheet;
 import org.apache.poi.xssf.streaming.SXSSFWorkbook;
-import org.apache.poi.xssf.usermodel.*;
+import org.apache.poi.xssf.usermodel.XSSFColor;
+import org.apache.poi.xssf.usermodel.XSSFRichTextString;
 import org.metaeffekt.core.inventory.processor.model.*;
 import org.metaeffekt.core.inventory.processor.model.CertMetaData.Attribute;
 import org.metaeffekt.core.inventory.processor.reader.AbstractInventoryReader;
@@ -40,7 +41,7 @@ import java.util.*;
 
 public class XlsxInventoryWriter extends AbstractXlsxInventoryWriter {
 
-    private final Logger LOG = LoggerFactory.getLogger(getClass());
+    private final static Logger LOG = LoggerFactory.getLogger(XlsxInventoryWriter.class);
 
     /**
      * Defines a default order.
@@ -90,7 +91,13 @@ public class XlsxInventoryWriter extends AbstractXlsxInventoryWriter {
     }
 
     private void writeArtifacts(Inventory inventory, SXSSFWorkbook workbook) {
-        // an artifact inventory is always written (an xls without sheets is regarded damaged by Excel)
+        // the artifact sheet is only written, if:
+        // - there are artifacts
+        // - there is no other information in the inventory
+        //   this has to be done, since a xls without sheets is regarded damaged by Excel
+        if (inventory.hasInformationOtherThanArtifacts() && inventory.getArtifacts().isEmpty()) {
+            return;
+        }
 
         final SXSSFSheet sheet = workbook.createSheet(AbstractInventoryReader.WORKSHEET_NAME_ARTIFACT_DATA);
         sheet.createFreezePane(0, 1);

--- a/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/model/ArtifactTest.java
+++ b/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/model/ArtifactTest.java
@@ -17,7 +17,7 @@ package org.metaeffekt.core.inventory.processor.model;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.metaeffekt.core.inventory.processor.writer.InventoryWriter;
+import org.metaeffekt.core.inventory.processor.writer.AbstractXlsxInventoryWriter;
 
 import java.util.Set;
 import java.util.StringJoiner;
@@ -30,7 +30,7 @@ public class ArtifactTest {
         StringJoiner cveData = new StringJoiner(", ");
         for (int i = 0; i < 4000; i++) cveData.add("CVE-2022-21907 (9.8)");
         artifact.setCompleteVulnerability(cveData.toString());
-        Assert.assertEquals(InventoryWriter.MAX_CELL_LENGTH, artifact.get("Vulnerability (split-1)").length());
+        Assert.assertEquals(AbstractXlsxInventoryWriter.MAX_CELL_LENGTH, artifact.get("Vulnerability (split-1)").length());
         Assert.assertEquals(cveData.toString(), artifact.getCompleteVulnerability());
     }
 

--- a/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/model/InventoryTest.java
+++ b/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/model/InventoryTest.java
@@ -342,6 +342,100 @@ public class InventoryTest {
         inventory.getFilteredInventory();
         new Inventory().inheritVulnerabilityMetaData(inventory, false);
         inventory.filterVulnerabilityMetaData();
+
+        cleanUpFiles(xlsInventoryFile, xlsxInventoryFile);
     }
 
+    @Test
+    public void writeAndReadInventoryWithArtifactsTest() throws IOException {
+        final Inventory initialInventory = new Inventory();
+        initialInventory.getArtifacts().add(dummyArtifact());
+
+        final File xlsInventoryFile = new File("target/writeAndReadInventoryWithArtifactsTest.xls");
+        new InventoryWriter().writeInventory(initialInventory, xlsInventoryFile);
+
+        final Inventory readInventoryXls = new InventoryReader().readInventory(xlsInventoryFile);
+        Assert.assertEquals(1, readInventoryXls.getArtifacts().size());
+
+        final File xlsxInventoryFile = new File("target/writeAndReadInventoryWithArtifactsTest.xlsx");
+        new InventoryWriter().writeInventory(initialInventory, xlsxInventoryFile);
+
+        final Inventory readInventoryXlsx = new InventoryReader().readInventory(xlsxInventoryFile);
+        Assert.assertEquals(1, readInventoryXlsx.getArtifacts().size());
+
+
+        initialInventory.getVulnerabilityMetaData().add(dummyVulnerabilityMetaData());
+
+        final File xlsInventoryFile2 = new File("target/writeAndReadInventoryWithArtifactsTest2.xls");
+        new InventoryWriter().writeInventory(initialInventory, xlsInventoryFile2);
+
+        final Inventory readInventoryXls2 = new InventoryReader().readInventory(xlsInventoryFile2);
+        Assert.assertEquals(1, readInventoryXls2.getVulnerabilityMetaData().size());
+        Assert.assertEquals(1, readInventoryXls2.getArtifacts().size());
+
+        final File xlsxInventoryFile2 = new File("target/writeAndReadInventoryWithArtifactsTest2.xlsx");
+        new InventoryWriter().writeInventory(initialInventory, xlsxInventoryFile2);
+
+        final Inventory readInventoryXlsx2 = new InventoryReader().readInventory(xlsxInventoryFile2);
+        Assert.assertEquals(1, readInventoryXlsx2.getVulnerabilityMetaData().size());
+        Assert.assertEquals(1, readInventoryXlsx2.getArtifacts().size());
+
+        cleanUpFiles(xlsInventoryFile, xlsxInventoryFile, xlsInventoryFile2, xlsxInventoryFile2);
+    }
+
+    @Test
+    public void writeAndReadInventoryWithoutArtifactsTest() throws IOException {
+        final Inventory initialInventory = new Inventory();
+
+        final File xlsInventoryFile = new File("target/writeAndReadInventoryWithoutArtifactsTest.xls");
+        new InventoryWriter().writeInventory(initialInventory, xlsInventoryFile);
+
+        final Inventory readInventoryXls = new InventoryReader().readInventory(xlsInventoryFile);
+        Assert.assertEquals(0, readInventoryXls.getArtifacts().size());
+        Assert.assertEquals(0, readInventoryXls.getVulnerabilityMetaData().size());
+
+        final File xlsxInventoryFile = new File("target/writeAndReadInventoryWithoutArtifactsTest.xlsx");
+        new InventoryWriter().writeInventory(initialInventory, xlsxInventoryFile);
+
+        final Inventory readInventoryXlsx = new InventoryReader().readInventory(xlsxInventoryFile);
+        Assert.assertEquals(0, readInventoryXlsx.getArtifacts().size());
+        Assert.assertEquals(0, readInventoryXlsx.getVulnerabilityMetaData().size());
+
+        initialInventory.getVulnerabilityMetaData().add(dummyVulnerabilityMetaData());
+
+        final File xlsInventoryFile2 = new File("target/writeAndReadInventoryWithoutArtifactsTest2.xls");
+        new InventoryWriter().writeInventory(initialInventory, xlsInventoryFile2);
+
+        final Inventory readInventoryXls2 = new InventoryReader().readInventory(xlsInventoryFile2);
+        Assert.assertEquals(1, readInventoryXls2.getVulnerabilityMetaData().size());
+
+        final File xlsxInventoryFile2 = new File("target/writeAndReadInventoryWithoutArtifactsTest2.xlsx");
+        new InventoryWriter().writeInventory(initialInventory, xlsxInventoryFile2);
+
+        final Inventory readInventoryXlsx2 = new InventoryReader().readInventory(xlsxInventoryFile2);
+        Assert.assertEquals(1, readInventoryXlsx2.getVulnerabilityMetaData().size());
+
+        cleanUpFiles(xlsInventoryFile, xlsxInventoryFile, xlsInventoryFile2, xlsxInventoryFile2);
+    }
+
+    private Artifact dummyArtifact() {
+        Artifact artifact = new Artifact();
+        artifact.setId("test.jar");
+        return artifact;
+    }
+
+    private VulnerabilityMetaData dummyVulnerabilityMetaData() {
+        VulnerabilityMetaData vulnerabilityMetaData = new VulnerabilityMetaData();
+        vulnerabilityMetaData.set(VulnerabilityMetaData.Attribute.NAME, "CVE-2023-1234");
+        vulnerabilityMetaData.set(VulnerabilityMetaData.Attribute.URL, " ");
+        return vulnerabilityMetaData;
+    }
+
+    private void cleanUpFiles(File... files) {
+        for (File file : files) {
+            if (file.exists()) {
+                file.delete();
+            }
+        }
+    }
 }


### PR DESCRIPTION
- Inventory sheet will now only be appended if it contains data or if no other sheet would exist.
- Refactored inventory reader and writer class to allow for easier extension with new file types.
- Added support for writing Inventory instances using their serialized form into a `.ser` file via the `SerializedInventoryReader` and `SerializedInventoryWriter` classes.