### PR TITLE
AEAA-414: Report XML escape method rewrite

### DIFF
--- a/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/report/PreFormattedEscapeUtilsTest.java
+++ b/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/report/PreFormattedEscapeUtilsTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2009-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.metaeffekt.core.inventory.processor.report;
 
 import org.junit.Assert;

--- a/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/report/PreFormattedEscapeUtilsTest.java
+++ b/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/report/PreFormattedEscapeUtilsTest.java
@@ -1,0 +1,69 @@
+package org.metaeffekt.core.inventory.processor.report;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class PreFormattedEscapeUtilsTest {
+
+    private static PreFormattedEscapeUtils escapeUtils;
+
+    @BeforeClass
+    public static void init() {
+        escapeUtils = new PreFormattedEscapeUtils();
+    }
+
+    @Test
+    public void xmlEscapeUnspecifiedTagsTest() {
+        final String input = "<code>In modern browsers, the MIME type<navbar>that is sent with the HTML document may<br>affect how the document is initially interpreted.</navbar></code>A document sent with the XHTML<test>MIME type is expected to be well";
+        Assert.assertEquals("&lt;code&gt;In modern browsers, the MIME type&lt;navbar&gt;that is sent with the HTML document may&lt;br&gt;affect how the document is initially interpreted.&lt;/navbar&gt;&lt;/code&gt;A document sent with the XHTML&lt;test&gt;MIME type is expected to be well", escapeUtils.xml(input));
+    }
+
+    @Test
+    public void xmlEscapeKnownBalancedTagsTest() {
+        final String input = "<p>syntax errors may cause</p>";
+        Assert.assertEquals("<p>syntax errors may cause</p>", escapeUtils.xml(input));
+    }
+
+    @Test
+    public void xmlEscapeNestedKnownBalancedTagsTest() {
+        final String input = "<p>There are two axes differentiating various variations of HTML as currently specified:<ul><li>SGML-based HTML</li><li>XML-based HTML</li></ul></p>";
+        Assert.assertEquals("<p>There are two axes differentiating various variations of HTML as currently specified:<ul><li>SGML-based HTML</li><li>XML-based HTML</li></ul></p>", escapeUtils.xml(input));
+    }
+
+    @Test
+    public void xmlEscapeNestedKnownUnbalanced1TagsTest() {
+        final String input = "<p>There are two axes differentiating various variations of HTML as currently specified:<ul><li>SGML-based HTML</li>XML-based HTML</li></p>";
+        Assert.assertEquals("<p>There are two axes differentiating various variations of HTML as currently specified:&lt;ul&gt;&lt;li&gt;SGML-based HTML&lt;/li&gt;XML-based HTML&lt;/li&gt;</p>", escapeUtils.xml(input));
+    }
+
+    @Test
+    public void xmlEscapeNestedKnownUnbalanced2TagsTest() {
+        final String input = "There are two axes differentiating various variations of HTML as currently specified:<ul><li>SGML-based HTML<li>XML-based HTML</li></ul></p>";
+        Assert.assertEquals("There are two axes differentiating various variations of HTML as currently specified:<ul>&lt;li&gt;SGML-based HTML&lt;li&gt;XML-based HTML&lt;/li&gt;</ul>&lt;/p&gt;", escapeUtils.xml(input));
+    }
+
+    @Test
+    public void xmlEscapeDoubleEscapeCharactersTest() {
+        final String input = "&lt;Test&gt;";
+        Assert.assertEquals("&lt;Test&gt;", escapeUtils.xml(input));
+    }
+
+    @Test
+    public void xmlEscapeHeaderHandlingTest() {
+        final String input = "<h3>To understand the subtle</h3><h2>differences between HTML and XHTML</h2><h1>it is important to understand</h1>";
+        Assert.assertEquals("<p><b>To understand the subtle</b></p><p><b>differences between HTML and XHTML</b></p><p><b>it is important to understand</b></p>", escapeUtils.xml(input));
+    }
+
+    @Test
+    public void xmlEscapeHeaderAndRawHeaderHandlingTest() {
+        final String input = "<h3>To understand the subtle</h3><h2>differences <p><b>between</p></b> HTML and XHTML</h2><h1>it is important to understand</h1>";
+        Assert.assertEquals("<p><b>To understand the subtle</b></p><p><b>differences <p><b>between</p></b> HTML and XHTML</b></p><p><b>it is important to understand</b></p>", escapeUtils.xml(input));
+    }
+
+    @Test
+    public void xmlEscapeHeaderAndRawHeaderHandlingUnbalancedTest() {
+        final String input = "<h3>To understand the subtle</h3><h2>differences <p><b>between</p></b> HTML and</b> XHTML</h2><h1>it is important to understand</h1>";
+        Assert.assertEquals("<p><b>To understand the subtle</b></p><p><b>differences <p>&lt;b&gt;between</p>&lt;/b&gt; HTML and&lt;/b&gt; XHTML</b></p><p><b>it is important to understand</b></p>", escapeUtils.xml(input));
+    }
+}

--- a/plugins/ae-inventory-maven-plugin/src/main/java/org/metaeffekt/core/maven/inventory/extractor/windows/strategy/WindowsPartExtractorBios.java
+++ b/plugins/ae-inventory-maven-plugin/src/main/java/org/metaeffekt/core/maven/inventory/extractor/windows/strategy/WindowsPartExtractorBios.java
@@ -18,6 +18,7 @@ package org.metaeffekt.core.maven.inventory.extractor.windows.strategy;
 import org.json.JSONObject;
 import org.metaeffekt.core.inventory.processor.model.Artifact;
 import org.metaeffekt.core.inventory.processor.model.ArtifactType;
+import org.metaeffekt.core.inventory.processor.model.Constants;
 import org.metaeffekt.core.inventory.processor.model.Inventory;
 
 public class WindowsPartExtractorBios extends WindowsPartExtractorBase {
@@ -34,7 +35,7 @@ public class WindowsPartExtractorBios extends WindowsPartExtractorBase {
         //   The "Version" field is used as fallback.
         mapJsonFieldToInventory(biosJson, artifact, "Version", "SMBIOSBIOSVersion", "Version");
 
-        mapJsonFieldToInventory(biosJson, artifact, "Organisation", "Manufacturer");
+        mapJsonFieldToInventory(biosJson, artifact, Constants.KEY_ORGANIZATION, "Manufacturer");
         mapJsonFieldToInventory(biosJson, artifact, "SerialNumber", "SerialNumber");
         mapJsonFieldToInventory(biosJson, artifact, "ReleaseDate", "ReleaseDate");
 

--- a/plugins/ae-inventory-maven-plugin/src/main/java/org/metaeffekt/core/maven/inventory/extractor/windows/strategy/WindowsPartExtractorInstalledProduct.java
+++ b/plugins/ae-inventory-maven-plugin/src/main/java/org/metaeffekt/core/maven/inventory/extractor/windows/strategy/WindowsPartExtractorInstalledProduct.java
@@ -18,6 +18,7 @@ package org.metaeffekt.core.maven.inventory.extractor.windows.strategy;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.metaeffekt.core.inventory.processor.model.Artifact;
+import org.metaeffekt.core.inventory.processor.model.Constants;
 import org.metaeffekt.core.inventory.processor.model.Inventory;
 import org.metaeffekt.core.maven.inventory.extractor.windows.WindowsExtractorAnalysisFile;
 
@@ -41,7 +42,7 @@ public class WindowsPartExtractorInstalledProduct extends WindowsPartExtractorBa
                 mapJsonFieldToInventory(productJson, artifact, Artifact.Attribute.COMPONENT, "Name");
             }
             mapJsonFieldToInventory(productJson, artifact, Artifact.Attribute.VERSION, "Version");
-            mapJsonFieldToInventory(productJson, artifact, "Organisation", "Vendor", "Manufacturer");
+            mapJsonFieldToInventory(productJson, artifact, Constants.KEY_ORGANIZATION, "Vendor", "Manufacturer");
             mapJsonFieldToInventory(productJson, artifact, "Description", "Description", "Caption", "Name");
 
             // identification

--- a/plugins/ae-inventory-maven-plugin/src/main/java/org/metaeffekt/core/maven/inventory/extractor/windows/strategy/WindowsPartExtractorMotherboard.java
+++ b/plugins/ae-inventory-maven-plugin/src/main/java/org/metaeffekt/core/maven/inventory/extractor/windows/strategy/WindowsPartExtractorMotherboard.java
@@ -19,6 +19,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.json.JSONObject;
 import org.metaeffekt.core.inventory.processor.model.Artifact;
+import org.metaeffekt.core.inventory.processor.model.Constants;
 import org.metaeffekt.core.inventory.processor.model.Inventory;
 
 import java.util.StringJoiner;
@@ -59,7 +60,7 @@ public class WindowsPartExtractorMotherboard extends WindowsPartExtractorBase {
 
         mapJsonFieldToInventory(baseBoardJson, motherboardArtifact, Artifact.Attribute.VERSION, "Version");
 
-        mapJsonFieldToInventory(baseBoardJson, motherboardArtifact, "Organisation", "Manufacturer");
+        mapJsonFieldToInventory(baseBoardJson, motherboardArtifact, Constants.KEY_ORGANIZATION, "Manufacturer");
         mapJsonFieldToInventory(baseBoardJson, motherboardArtifact, "Product", "Product");
         mapJsonFieldToInventory(baseBoardJson, motherboardArtifact, "Description", "Description", "Caption", "Name", "Tag");
         mapJsonFieldToInventory(baseBoardJson, motherboardArtifact, "SerialNumber", "SerialNumber");

--- a/plugins/ae-inventory-maven-plugin/src/main/java/org/metaeffekt/core/maven/inventory/extractor/windows/strategy/WindowsPartExtractorNetworkAdapter.java
+++ b/plugins/ae-inventory-maven-plugin/src/main/java/org/metaeffekt/core/maven/inventory/extractor/windows/strategy/WindowsPartExtractorNetworkAdapter.java
@@ -19,6 +19,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.metaeffekt.core.inventory.processor.model.Artifact;
+import org.metaeffekt.core.inventory.processor.model.Constants;
 import org.metaeffekt.core.inventory.processor.model.Inventory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,7 +55,7 @@ public class WindowsPartExtractorNetworkAdapter extends WindowsPartExtractorBase
         mapBaseJsonInformationToInventory(networkAdapterJson, videoControllerArtifact);
         videoControllerArtifact.set("Windows Source", Class_Win32_NetworkAdapter.getTypeName());
 
-        mapJsonFieldToInventory(networkAdapterJson, videoControllerArtifact, "Organisation", "Manufacturer");
+        mapJsonFieldToInventory(networkAdapterJson, videoControllerArtifact, Constants.KEY_ORGANIZATION, "Manufacturer");
 
         mapJsonFieldToInventory(networkAdapterJson, videoControllerArtifact, "MACAddress", "MACAddress");
         mapJsonFieldToInventory(networkAdapterJson, videoControllerArtifact, "TimeOfLastReset", "TimeOfLastReset");

--- a/plugins/ae-inventory-maven-plugin/src/main/java/org/metaeffekt/core/maven/inventory/extractor/windows/strategy/WindowsPartExtractorOperatingSystem.java
+++ b/plugins/ae-inventory-maven-plugin/src/main/java/org/metaeffekt/core/maven/inventory/extractor/windows/strategy/WindowsPartExtractorOperatingSystem.java
@@ -119,7 +119,7 @@ public class WindowsPartExtractorOperatingSystem extends WindowsPartExtractorBas
             mapJsonFieldToInventory(systeminfoJson, windowsOsArtifact, Constants.KEY_ARCHITECTURE, "OS Architecture", "System Type");
         }
 
-        mapJsonFieldToInventory(systeminfoJson, windowsOsArtifact, "Organisation", "OS Manufacturer");
+        mapJsonFieldToInventory(systeminfoJson, windowsOsArtifact, Constants.KEY_ORGANIZATION, "OS Manufacturer");
 
         mapJsonFieldToInventory(systeminfoJson, windowsOsArtifact, "Registered Owner", "Registered Owner", "Registered Organization");
         if (!windowsOsArtifact.has("Registered Owner")) {

--- a/plugins/ae-inventory-maven-plugin/src/main/java/org/metaeffekt/core/maven/inventory/extractor/windows/strategy/WindowsPartExtractorPlugAndPlay.java
+++ b/plugins/ae-inventory-maven-plugin/src/main/java/org/metaeffekt/core/maven/inventory/extractor/windows/strategy/WindowsPartExtractorPlugAndPlay.java
@@ -19,6 +19,7 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.metaeffekt.core.inventory.processor.model.Artifact;
 import org.metaeffekt.core.inventory.processor.model.ArtifactType;
+import org.metaeffekt.core.inventory.processor.model.Constants;
 import org.metaeffekt.core.inventory.processor.model.Inventory;
 import org.metaeffekt.core.maven.inventory.extractor.windows.WindowsExtractorAnalysisFile;
 import org.metaeffekt.core.maven.inventory.extractor.windows.WindowsPnpClassGuid;
@@ -67,7 +68,7 @@ public class WindowsPartExtractorPlugAndPlay extends WindowsPartExtractorBase {
 
                 mapJsonFieldToInventory(effectiveJson, pnpDeviceArtifact, Artifact.Attribute.VERSION, "DriverVersion", "DriverDate");
                 mapJsonFieldToInventory(effectiveJson, pnpDeviceArtifact, "Description", "Description");
-                mapJsonFieldToInventory(effectiveJson, pnpDeviceArtifact, "Organisation", "Manufacturer", "DriverProviderName");
+                mapJsonFieldToInventory(effectiveJson, pnpDeviceArtifact, Constants.KEY_ORGANIZATION, "Manufacturer", "DriverProviderName");
 
                 // theses three values are always the same
                 mapJsonFieldToInventory(effectiveJson, pnpDeviceArtifact, "PNPDeviceID", "PNPDeviceID", "DeviceID", "InstanceId");
@@ -109,7 +110,7 @@ public class WindowsPartExtractorPlugAndPlay extends WindowsPartExtractorBase {
 
                 mapJsonFieldToInventory(pnpSignedDriver, signedDriverArtifact, Artifact.Attribute.VERSION, "DriverVersion", "DriverDate");
                 mapJsonFieldToInventory(pnpSignedDriver, signedDriverArtifact, "Description", "Description");
-                mapJsonFieldToInventory(pnpSignedDriver, signedDriverArtifact, "Organisation", "Manufacturer", "DriverProviderName");
+                mapJsonFieldToInventory(pnpSignedDriver, signedDriverArtifact, Constants.KEY_ORGANIZATION, "Manufacturer", "DriverProviderName");
 
                 mapJsonFieldToInventory(pnpSignedDriver, signedDriverArtifact, "PNPDeviceID", "PNPDeviceID", "DeviceID", "InstanceId");
                 // the PNPDeviceID might not exist on the PnpSignedDriver, so we attempt to find it on the PnpEntity

--- a/plugins/ae-inventory-maven-plugin/src/main/java/org/metaeffekt/core/maven/inventory/extractor/windows/strategy/WindowsPartExtractorRegUninstall.java
+++ b/plugins/ae-inventory-maven-plugin/src/main/java/org/metaeffekt/core/maven/inventory/extractor/windows/strategy/WindowsPartExtractorRegUninstall.java
@@ -19,6 +19,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.metaeffekt.core.inventory.processor.model.Artifact;
+import org.metaeffekt.core.inventory.processor.model.Constants;
 import org.metaeffekt.core.inventory.processor.model.Inventory;
 import org.metaeffekt.core.maven.inventory.extractor.windows.WindowsExtractorAnalysisFile;
 import org.slf4j.Logger;
@@ -68,7 +69,7 @@ public class WindowsPartExtractorRegUninstall extends WindowsPartExtractorBase {
 
         mapJsonFieldToInventory(properties, productArtifact, Artifact.Attribute.ID, "DisplayName", "PSChildName");
         mapJsonFieldToInventory(properties, productArtifact, Artifact.Attribute.VERSION, "DisplayVersion");
-        mapJsonFieldToInventory(properties, productArtifact, "Organisation", "Publisher");
+        mapJsonFieldToInventory(properties, productArtifact, Constants.KEY_ORGANIZATION, "Publisher");
 
         if (productArtifact.get(Artifact.Attribute.ID) == null) {
             LOG.warn("Failed to extract artifact Id for registry uninstall entry: {}", regUninstallJson);

--- a/plugins/ae-inventory-maven-plugin/src/main/java/org/metaeffekt/core/maven/inventory/extractor/windows/strategy/WindowsPartExtractorSoftwareElement.java
+++ b/plugins/ae-inventory-maven-plugin/src/main/java/org/metaeffekt/core/maven/inventory/extractor/windows/strategy/WindowsPartExtractorSoftwareElement.java
@@ -19,6 +19,7 @@ import org.apache.commons.lang3.ObjectUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.metaeffekt.core.inventory.processor.model.Artifact;
+import org.metaeffekt.core.inventory.processor.model.Constants;
 import org.metaeffekt.core.inventory.processor.model.Inventory;
 import org.metaeffekt.core.maven.inventory.extractor.windows.WindowsExtractorAnalysisFile;
 import org.slf4j.Logger;
@@ -82,7 +83,7 @@ public class WindowsPartExtractorSoftwareElement extends WindowsPartExtractorBas
 
             mapJsonFieldToInventory(softwareFeature, featureArtifact, "Description", "Description");
             mapJsonFieldToInventory(softwareFeature, featureArtifact, "Caption", "Caption");
-            mapJsonFieldToInventory(softwareFeature, featureArtifact, "Organisation", "Vendor");
+            mapJsonFieldToInventory(softwareFeature, featureArtifact, Constants.KEY_ORGANIZATION, "Vendor");
 
             mapJsonFieldToInventory(softwareFeature, featureArtifact, "InstallDate", "InstallDate");
             mapJsonFieldToInventory(softwareFeature, featureArtifact, "InstallState", "InstallState");


### PR DESCRIPTION
- Rewrote XML escape method for report to check for balance of tag before unescaping it.
- Fixed windows inventory extractor using incorrect "Organisation" instead of "Organization".