### PR TITLE
AEAA-438: Finalizing Generation 3

### DIFF
--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/InventoryReport.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/InventoryReport.java
@@ -170,6 +170,12 @@ public class InventoryReport {
      * detail the artifacts-level information and only provide assets and asset-level assessment information.
      */
     private boolean filterVulnerabilitiesNotCoveredByArtifacts = false;
+    /**
+     * Whether to hide the periodic status "unclassified" in the vulnerability report. If set to <code>true</code>, the
+     * section will simply not be generated.<br>
+     * Defaults to <code>false</code>.
+     */
+    private boolean filterAdvisorySummary = false;
 
     private boolean inventoryBomReportEnabled = false;
     private boolean inventoryDiffReportEnabled = false;
@@ -1441,6 +1447,14 @@ public class InventoryReport {
 
     public void setFilterVulnerabilitiesNotCoveredByArtifacts(boolean filterVulnerabilitiesNotCoveredByArtifacts) {
         this.filterVulnerabilitiesNotCoveredByArtifacts = filterVulnerabilitiesNotCoveredByArtifacts;
+    }
+
+    public void setFilterAdvisorySummary(boolean filterAdvisorySummary) {
+        this.filterAdvisorySummary = filterAdvisorySummary;
+    }
+
+    public boolean isFilterAdvisorySummary() {
+        return filterAdvisorySummary;
     }
 
     public void setIncludeInofficialOsiStatus(boolean includeInofficialOsiStatus) {

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/adapter/VulnerabilityReportAdapter.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/adapter/VulnerabilityReportAdapter.java
@@ -33,6 +33,7 @@ import org.metaeffekt.core.security.cvss.CvssSeverityRanges;
 import org.metaeffekt.core.security.cvss.CvssVector;
 import org.metaeffekt.core.security.cvss.KnownCvssEntities;
 import org.metaeffekt.core.security.cvss.MultiScoreCvssVector;
+import org.metaeffekt.core.security.cvss.processor.CvssSelectionResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,6 +51,7 @@ public class VulnerabilityReportAdapter {
 
     protected final Inventory inventory;
     private final AeaaVulnerabilityContextInventory vInventory;
+    private final AeaaVulnerabilityContextInventory vInitialInventory;
 
     private final CentralSecurityPolicyConfiguration securityPolicy;
 
@@ -60,6 +62,11 @@ public class VulnerabilityReportAdapter {
         this.vInventory = AeaaVulnerabilityContextInventory.fromInventory(inventory);
         this.vInventory.calculateEffectiveCvssVectorsForVulnerabilities(securityPolicy);
         this.vInventory.applyEffectiveVulnerabilityStatus(securityPolicy);
+
+        this.vInitialInventory = AeaaVulnerabilityContextInventory.fromInventory(inventory);
+        this.vInitialInventory.calculateEffectiveCvssVectorsForVulnerabilities(securityPolicy);
+        this.vInitialInventory.getVulnerabilities().forEach(v -> v.mapCvssSelectionResult(CvssSelectionResult::deriveInitialOnlySelectionResult));
+        this.vInitialInventory.applyEffectiveVulnerabilityStatus(securityPolicy);
     }
 
     public Inventory getInventory() {
@@ -78,6 +85,14 @@ public class VulnerabilityReportAdapter {
 
     public List<AeaaVulnerability> getEffectiveVulnerabilitiesAll() {
         final List<AeaaVulnerability> vulnerabilities = vInventory.getSortedVulnerabilities();
+        return vulnerabilities.stream()
+                .filter(securityPolicy::isVulnerabilityIncludedRegardingAdvisoryProviders)
+                .filter(securityPolicy::isVulnerabilityAboveIncludeScoreThreshold)
+                .collect(Collectors.toList());
+    }
+
+    public List<AeaaVulnerability> getEffectiveVulnerabilitiesInitialInventoryAll() {
+        final List<AeaaVulnerability> vulnerabilities = vInitialInventory.getSortedVulnerabilities();
         return vulnerabilities.stream()
                 .filter(securityPolicy::isVulnerabilityIncludedRegardingAdvisoryProviders)
                 .filter(securityPolicy::isVulnerabilityAboveIncludeScoreThreshold)
@@ -105,6 +120,15 @@ public class VulnerabilityReportAdapter {
         return advisories.stream()
                 .filter(securityPolicy::isSecurityAdvisoryIncludedRegardingEntrySourceType)
                 .filter(securityPolicy::isSecurityAdvisoryIncludedRegardingEntryProvider)
+                .collect(Collectors.toList());
+    }
+
+    public List<List<AeaaAdvisoryEntry>> groupSecurityAdvisoriesBySourceAndType(List<AeaaAdvisoryEntry> sourceSecurityAdvisoryEntries) {
+        return sourceSecurityAdvisoryEntries.stream()
+                .collect(Collectors.groupingBy(a -> a.getEntrySource() + " " + a.getType()))
+                .entrySet().stream().sorted(Map.Entry.comparingByKey())
+                .map(Map.Entry::getValue)
+                .map(l -> l.stream().sorted(Comparator.comparing(AeaaAdvisoryEntry::getEntrySource)).collect(Collectors.toList()))
                 .collect(Collectors.toList());
     }
 

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/configuration/CentralSecurityPolicyConfiguration.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/configuration/CentralSecurityPolicyConfiguration.java
@@ -27,6 +27,7 @@ import org.metaeffekt.core.inventory.processor.report.model.aeaa.advisory.AeaaAd
 import org.metaeffekt.core.security.cvss.CvssSeverityRanges;
 import org.metaeffekt.core.security.cvss.CvssVector;
 import org.metaeffekt.core.security.cvss.KnownCvssEntities;
+import org.metaeffekt.core.security.cvss.processor.CvssSelectionResult;
 import org.metaeffekt.core.security.cvss.processor.CvssSelectionResult.CvssScoreVersionSelectionPolicy;
 import org.metaeffekt.core.security.cvss.processor.CvssSelector;
 import org.metaeffekt.core.security.cvss.processor.CvssSelector.*;
@@ -224,7 +225,7 @@ public class CentralSecurityPolicyConfiguration extends ProcessConfiguration {
         if (insignificantThreshold == -1.0) return true;
         final CvssVector vector = vulnerability.getCvssSelectionResult().getSelectedContextIfAvailableOtherwiseInitial();
         final double score = vector == null ? 0.0 : vector.getOverallScore();
-        return score <= insignificantThreshold;
+        return score < insignificantThreshold;
     }
 
     public double getIncludeScoreThreshold() {
@@ -233,9 +234,9 @@ public class CentralSecurityPolicyConfiguration extends ProcessConfiguration {
 
     public boolean isVulnerabilityAboveIncludeScoreThreshold(AeaaVulnerability vulnerability) {
         if (includeScoreThreshold == -1.0 || includeScoreThreshold == Double.MIN_VALUE) return true;
-        final CvssVector vector = vulnerability.getCvssSelectionResult().getSelectedContextIfAvailableOtherwiseInitial();
+        final CvssVector vector = vulnerability.getCvssSelectionResult().getSelectedByCustomMetric(CvssVector::getOverallScore, CvssSelectionResult.CUSTOM_VECTOR_SCORE_SELECTOR_MAX);
         final double score = vector == null ? 0.0 : vector.getOverallScore();
-        return score >= includeScoreThreshold;
+        return isVulnerabilityAboveIncludeScoreThreshold(score);
     }
 
     public boolean isVulnerabilityAboveIncludeScoreThreshold(double score) {

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/model/aeaa/AeaaVulnerability.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/model/aeaa/AeaaVulnerability.java
@@ -37,6 +37,7 @@ import org.springframework.util.StringUtils;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.stream.Collectors;
 
@@ -455,6 +456,13 @@ public class AeaaVulnerability extends AeaaMatchableDetailsAmbDataClass<Vulnerab
 
     public void clearCvssSelectionResult() {
         this.cvssSelectionResult = null;
+    }
+
+    public void mapCvssSelectionResult(Function<CvssSelectionResult, CvssSelectionResult> mapper) {
+        if (this.cvssSelectionResult == null) {
+            throw new IllegalStateException("No cvss selection result available. Please call selectEffectiveCvssVectors() first, or use the getCvssSelectionResult(CentralSecurityPolicyConfiguration) method to select the effective cvss vectors on the fly.");
+        }
+        this.cvssSelectionResult = mapper.apply(this.cvssSelectionResult);
     }
 
     /* CLEANING DATA */

--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/macros/inventory-report-cert.vm
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/macros/inventory-report-cert.vm
@@ -40,10 +40,10 @@
                    $report.xmlEscapeString($securityAdvisory.getType())
                 </entry>
                 <entry>
-                   $report.xmlEscapeString($securityAdvisory.getCreateDateFormatted())
+                   $report.xmlEscapeString($securityAdvisory.getCreateDateFormattedDateLevel())
                 </entry>
                 <entry>
-                   $report.xmlEscapeString($securityAdvisory.getUpdateDateFormatted())
+                   $report.xmlEscapeString($securityAdvisory.getCreateDateFormattedDateLevel())
                 </entry>
             </row>
 #end

--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/macros/inventory-report-vulnerabilities.vm
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/macros/inventory-report-vulnerabilities.vm
@@ -56,6 +56,7 @@
             #set ($baseVulnerabilityStatus = $vulnerabilityAdapter.getBaseVulnerabilityStatus($vulnerability))
             ##
             #set ($allAdvisories = $vulnerabilityAdapter.getEffectiveSecurityAdvisoriesForVulnerability($vulnerability))
+            #set ($grouopedAdvisories = $vulnerabilityAdapter.groupSecurityAdvisoriesBySourceAndType($allAdvisories))
             ##
             #set ($moreRows = 1) ## vulnerable configurations row is always added
             #if (!$allAdvisories.isEmpty()) #set ($moreRows = $moreRows + 1) #end
@@ -78,10 +79,12 @@
         #if (!$allAdvisories.isEmpty())
         <row>
                 <entry namest="COLSPEC1" nameend="COLSPEC5">
-                    ## the labels can be CPEs, MS Product Ids, GHSA identifiers, etc.
+                    ## the labels can be CPEs, MS Product IDs, GHSA identifiers, etc.
                     ## the vulnerability matched via these identifiers
                     ## the following line must be exactly like this, otherwise the line breaks will be messed up
-                    #foreach ($advisory in $allAdvisories)#if ($velocityCount > 1), #end<xref href="$report.xmlEscapePreformattedContentString($advisory.getUrl())" type="html" scope="external">$report.xmlEscapeString($advisory.getId())</xref>#end
+#foreach ($advisoryCategory in $grouopedAdvisories)
+<p>#foreach ($advisory in $advisoryCategory)#if ($velocityCount > 1), #end<xref href="$report.xmlEscapePreformattedContentString($advisory.getUrl())" type="html" scope="external">$report.xmlEscapeString($advisory.getId())</xref>#end</p>
+#end
                 </entry>
         </row>
         #end

--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/tpc_inventory-cert.dita.vt
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/tpc_inventory-cert.dita.vt
@@ -88,20 +88,22 @@
         </section>
 #end
 ## unclassified
+#if (!$report.isFilterAdvisorySummary())
 #if (!$securityAdvisoriesUnreviewed.isEmpty())
         <section>
-            <title>Unclassified Security Advisories</title>
+            <title>Security Advisories Summary</title>
             <body>
                 <p>
-                    The following security advisories are not present in the query period, but have been added by
+                    The following security advisories are not present in the query period, but have been matched by
                     the affected components.
                     The advisories are listed to provide a comprehensible report.
                 </p>
                 <p>
-#securityAdvisoryOverviewTable("unclassified_cert", "Unclassified Security Advisories", $securityAdvisoriesUnreviewed)
+#securityAdvisoryOverviewTable("unclassified_cert", "Security Advisories Summary", $securityAdvisoriesUnreviewed)
                 </p>
             </body>
         </section>
+#end
 #end
 #end
     </body>

--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-statistics-vulnerability/tpc_inventory-vulnerability-statistics.dita.vt
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-statistics-vulnerability/tpc_inventory-vulnerability-statistics.dita.vt
@@ -6,6 +6,7 @@
     <title>$reportContext.combinedTitle("Vulnerability Statistics", true)</title>
 ##
 #set ($vulnerabilities = $vulnerabilityAdapter.getEffectiveVulnerabilitiesAll())
+#set ($initialVulnerabilities = $vulnerabilityAdapter.getEffectiveVulnerabilitiesInitialInventoryAll())
 ##
     <body>
         <p id="statistics-preface">
@@ -13,7 +14,7 @@
             in the statistics with their original unmodified severity.
         </p>
         <p id="statistics-table">
-#statisticsOverviewTable("vulnerabilities_statistics_table_unmodified_all", "Vulnerability Statistics$reportContext.inContextOf()", $vulnerabilities, "", false)
+#statisticsOverviewTable("vulnerabilities_statistics_table_unmodified_all", "Vulnerability Statistics$reportContext.inContextOf()", $initialVulnerabilities, "", false)
         </p>
 
 
@@ -27,7 +28,7 @@
             $advisoryName. The vulnerabilities are included in the statistics with their original unmodified severity.
         </p>
         <p id="statistics-table-$advisoryIdentifier">
-#statisticsOverviewTable("vulnerabilities_statistics_table_unmodified_$report.xmlEscapeStringAttribute($advisoryIdentifier.toLowerCase())", "Vulnerability Statistics with $report.xmlEscapeString($advisoryName) Advisories$reportContext.inContextOf()", $vulnerabilities, $advisory, false)
+#statisticsOverviewTable("vulnerabilities_statistics_table_unmodified_$report.xmlEscapeStringAttribute($advisoryIdentifier.toLowerCase())", "Vulnerability Statistics with $report.xmlEscapeString($advisoryName) Advisories$reportContext.inContextOf()", $initialVulnerabilities, $advisory, false)
         </p>
 #end
 

--- a/libraries/ae-security/src/test/java/org/metaeffekt/core/security/cvss/CvssSelectorTest.java
+++ b/libraries/ae-security/src/test/java/org/metaeffekt/core/security/cvss/CvssSelectorTest.java
@@ -340,4 +340,29 @@ public class CvssSelectorTest {
         CvssVector expectedNvdLowerAllPartsMacVector = nvdVector.clone().applyVectorAndReturn(assessmentLowerPartsMacVector).applyVectorAndReturn(assessmentAllPartsVector);
         assertEquals(expectedNvdLowerAllPartsMacVector.toString(), cvssSelectorEffectiveAbsence.selectVector(Arrays.asList(nvdVector, assessmentLowerPartsMacVector, assessmentAllPartsVector)).toString());
     }
+
+    @Test
+    public void applyLowerChangesOnlyIfPartAppliedTest() {
+        final CvssSelector selector = new CvssSelector(Arrays.asList(
+                new CvssRule(MergingMethod.ALL,
+                        // NIST NVD
+                        new SourceSelectorEntry(KnownCvssEntities.NVD, CvssIssuingEntityRole.CNA, KnownCvssEntities.NVD)
+                ),
+                // assessment
+                new CvssRule(MergingMethod.LOWER,
+                        Collections.singletonList(new SelectorStatsCollector("assessment", StatsCollectorProvider.APPLIED_PARTS_COUNT, StatsCollectorSetType.ADD)),
+                        Collections.emptyList(),
+                        new SourceSelectorEntry(KnownCvssEntities.ASSESSMENT, SourceSelectorEntry.ANY_ROLE, KnownCvssEntities.ASSESSMENT_LOWER))
+        ), Collections.singletonList(
+                new SelectorStatsEvaluator("assessment", StatsEvaluatorOperation.EQUAL, EvaluatorAction.RETURN_NULL, 0)
+        ), Collections.singletonList(
+                new SelectorVectorEvaluator(VectorEvaluatorOperation.IS_BASE_FULLY_DEFINED, true, EvaluatorAction.RETURN_NULL)
+        ));
+
+        final Cvss3P1 nvdVector = new Cvss3P1("CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", new CvssSource(KnownCvssEntities.NVD, CvssIssuingEntityRole.CNA, KnownCvssEntities.NVD, Cvss3P1.class));
+        final Cvss3P1 assessmentLowerPartsMavVector = new Cvss3P1("CVSS:3.1/MAV:A", new CvssSource(KnownCvssEntities.ASSESSMENT, KnownCvssEntities.ASSESSMENT_LOWER, Cvss3P1.class));
+
+        // the resulting vector is not lower, so the later check will return null
+        assertNull(selector.selectVector(Arrays.asList(nvdVector, assessmentLowerPartsMavVector)));
+    }
 }

--- a/plugins/ae-inventory-maven-plugin/src/main/java/org/metaeffekt/core/maven/inventory/mojo/AbstractInventoryReportCreationMojo.java
+++ b/plugins/ae-inventory-maven-plugin/src/main/java/org/metaeffekt/core/maven/inventory/mojo/AbstractInventoryReportCreationMojo.java
@@ -257,6 +257,11 @@ public abstract class AbstractInventoryReportCreationMojo extends AbstractProjec
     private boolean filterVulnerabilitiesNotCoveredByArtifacts;
 
     /**
+     * @parameter default-value="false"
+     */
+    private boolean filterAdvisorySummary;
+
+    /**
      * Comma seperated list of advisory providers. For every provider, an additional overview table will be generated
      * only evaluating the vulnerabilities containing the respecting provider.
      * If left empty, no additional table will be created.
@@ -347,6 +352,7 @@ public abstract class AbstractInventoryReportCreationMojo extends AbstractProjec
 
         report.setSecurityPolicy(securityPolicy);
         report.setFilterVulnerabilitiesNotCoveredByArtifacts(filterVulnerabilitiesNotCoveredByArtifacts);
+        report.setFilterAdvisorySummary(filterAdvisorySummary);
         report.addGenerateOverviewTablesForAdvisoriesByString(generateOverviewTablesForAdvisories);
 
         // diff settings


### PR DESCRIPTION
Final changes to be made to generation 3 before release.

Insignificant status

- CHANGE: use context score, then initial score
- CHANGE: use (score < threshold) instead of (score <= threshold)

include threshold

- CHANGE: use max(context, initial)


Advisor Periodic enrichment

- BUG: overview table in report still shows detailed timestamp for advisories
- NEW: add filterUnclassified parameter to remove the UNCLASSIFIED advisories
- CHANGE: rename the unclassified advisories category to 'Security Advisories Summary'

Inventory Report: Overview charts

- CHANGE: no longer use the VULNERABILITY_STATUS_DISPLAY_MAPPER_REVIEW_STATE for the overview charts, rather use the VULNERABILITY_STATUS_DISPLAY_MAPPER_UNMODIFIED for the vulnerabilityOverviewChartVulnerabilityStatus chart. (as it should have been done all along)
- CHANGE: also use the unmodified mapper for the vulnerabilityOverviewChartCvssSeverityContextByStatusInReview and vulnerabilityOverviewChartCvssSeverityContextByStatusReviewed charts. Use the applicable instead of the applicable + not applicable vulnerability counts for this. Rename the vulnerabilityOverviewChartCvssSeverityContextByStatusReviewed to vulnerabilityOverviewChartCvssSeverityContextByStatusApplicable.
- NEW: Add a parameter filterAdvisorySummary to not display the unclassified security advisories if set to true in the advisory overview.
- CHANGE: The unmodified overview table should, for calculating the effective status values, only use the initial CVSS vectors.
- CHANGE: The advisory (row) section in the vulnerability overview table should group advisory entries based on source and type and split into paragraphs. Sort them by the source first, then the type, then within the individual lists.
