### PR TITLE
Generation 3 cleanup (again)

### DIFF
--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/model/Inventory.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/model/Inventory.java
@@ -1966,6 +1966,29 @@ public class Inventory implements Serializable {
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1, LinkedHashMap::new));
     }
 
+    public String getInventorySizePrintString() {
+        final StringJoiner inventoryPrintString = new StringJoiner(", ", "[", "]");
+
+        inventoryPrintString.add(String.format("art: %d", artifacts.size()));
+        inventoryPrintString.add(String.format("lmd: %d", licenseMetaData.size()));
+        inventoryPrintString.add(String.format("cpd: %d", componentPatternData.size()));
+        inventoryPrintString.add(String.format("ld: %d", licenseData.size()));
+
+        final StringJoiner vulnerabilityMetaDataPrintString = new StringJoiner(", ", "vmd: [", "]");
+        vulnerabilityMetaDataPrintString.setEmptyValue("vmd: 0  ");
+        for (String context : vulnerabilityMetaData.keySet()) {
+            vulnerabilityMetaDataPrintString.add(String.format("%s: %d", context, vulnerabilityMetaData.get(context).size()));
+        }
+        inventoryPrintString.add(vulnerabilityMetaDataPrintString.toString());
+
+        inventoryPrintString.add(String.format("admd: %d", advisoryMetaData.size()));
+        inventoryPrintString.add(String.format("ii: %d", inventoryInfo.size()));
+        inventoryPrintString.add(String.format("rd: %d", reportData.size()));
+        inventoryPrintString.add(String.format("asmd: %d", assetMetaData.size()));
+
+        return inventoryPrintString.toString();
+    }
+
     /**
      * Component data. Please note that the component per-se does not have a version, but a license.
      * Artifacts (with various versions) can be added to the component. When evaluating the

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/reader/XlsxInventoryReader.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/reader/XlsxInventoryReader.java
@@ -20,6 +20,7 @@ import org.apache.poi.xssf.usermodel.XSSFRow;
 import org.apache.poi.xssf.usermodel.XSSFSheet;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.metaeffekt.core.inventory.processor.model.*;
+import org.metaeffekt.core.inventory.processor.writer.InventoryWriter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -99,7 +100,8 @@ public class XlsxInventoryReader extends AbstractInventoryReader {
 
     protected void readVulnerabilityMetaData(XSSFWorkbook workbook, Inventory inventory) {
         workbook.sheetIterator().forEachRemaining(sheet -> {
-            if (sheet.getSheetName().startsWith(WORKSHEET_NAME_VULNERABILITY_DATA)) {
+            if (sheet.getSheetName().startsWith(WORKSHEET_NAME_VULNERABILITY_DATA) ||
+                    sheet.getSheetName().startsWith(InventoryWriter.VULNERABILITY_ASSESSMENT_WORKSHEET_PREFIX)) {
                 readVulnerabilityMetaData(workbook, inventory, sheet.getSheetName());
             }
         });

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/InventoryReport.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/InventoryReport.java
@@ -262,6 +262,8 @@ public class InventoryReport {
             diffInventory = new InventoryReader().readInventory(diffInventoryFile);
         }
 
+        LOG.debug("Constructing project inventory from local inventory {} and global inventory {}", globalInventory.getInventorySizePrintString(), localInventory.getInventorySizePrintString());
+
         final Inventory projectInventory = new Inventory();
         this.lastProjectInventory = projectInventory;
 
@@ -531,9 +533,12 @@ public class InventoryReport {
         // transfer available asset information
         projectInventory.inheritAssetMetaData(globalInventory, false);
 
+        LOG.debug("Project inventory constructed: {}", projectInventory.getInventorySizePrintString());
+
         // filter the vulnerability metadata to only cover the items remaining in the inventory
         if (filterVulnerabilitiesNotCoveredByArtifacts) {
             projectInventory.filterVulnerabilityMetaData();
+            LOG.debug("Project inventory after filtering using [filterVulnerabilitiesNotCoveredByArtifacts]: {}", projectInventory.getInventorySizePrintString());
         }
 
         // write reports

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/adapter/VulnerabilityReportAdapter.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/adapter/VulnerabilityReportAdapter.java
@@ -534,6 +534,14 @@ public class VulnerabilityReportAdapter {
                     result.add("GHSA");
                 }
 
+            } else if (matchReason instanceof AeaaDataSourceIndicator.AnyArtifactOverwriteSourceReason) {
+                final AeaaDataSourceIndicator.AnyArtifactOverwriteSourceReason reason = ((AeaaDataSourceIndicator.AnyArtifactOverwriteSourceReason) matchReason);
+                if (reason.overwriteSource() != null) {
+                    result.add(reason.overwriteSource() + " (" + reason.getArtifactId() + ")");
+                } else {
+                    result.add(reason.getArtifactId());
+                }
+
             } else if (matchReason instanceof AeaaDataSourceIndicator.AnyArtifactReason) {
                 final AeaaDataSourceIndicator.AnyArtifactReason anyArtifactReason = ((AeaaDataSourceIndicator.AnyArtifactReason) matchReason);
                 result.add(anyArtifactReason.getArtifactId());

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/model/aeaa/AeaaVulnerabilityContextInventory.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/model/aeaa/AeaaVulnerabilityContextInventory.java
@@ -107,7 +107,7 @@ public class AeaaVulnerabilityContextInventory {
 
                 vulnerabilityStatus.reorderChronologically(vulnerability, isInsignificant, securityPolicy.getInsignificantThreshold());
 
-                if (vulnerabilityStatus.getStatusHistory().isEmpty()) {
+                if (vulnerabilityStatus.getStatusHistory().stream().noneMatch(AeaaVulnerabilityStatusHistoryEntry::isActive)) {
                     vulnerabilityStatus.addHistoryEntry(AeaaVulnerabilityStatusHistoryEntry.IN_REVIEW);
                 }
             }

--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/macros/inventory-report-vulnerabilities.vm
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/macros/inventory-report-vulnerabilities.vm
@@ -638,11 +638,8 @@
                         #if($msRemediationUrlDescription.size() > 0)
                             <p>
                                 ## must be lowest indentation, otherwise CSV will not work
-                                #set ($indexCounter = 0)
-                                #foreach($entry in $msRemediationUrlDescription.entrySet())
-                                    #if ($indexCounter != 0), #end<xref href="$entry.getKey()" type="html" scope="external">$entry.getValue()</xref>
-                                    #set ($indexCounter = $indexCounter + 1)
-                                #end
+#set ($indexCounter = 0)
+#foreach($entry in $msRemediationUrlDescription.entrySet())#if ($indexCounter != 0), #end<xref href="$entry.getKey()" type="html" scope="external">$entry.getValue()</xref>#set ($indexCounter = $indexCounter + 1)#end
                             </p>
                         #end
                     </entry>

--- a/plugins/ae-inventory-maven-plugin/src/main/java/org/metaeffekt/core/maven/inventory/mojo/InventoryReportCreationMojo.java
+++ b/plugins/ae-inventory-maven-plugin/src/main/java/org/metaeffekt/core/maven/inventory/mojo/InventoryReportCreationMojo.java
@@ -16,6 +16,7 @@
 package org.metaeffekt.core.maven.inventory.mojo;
 
 import org.apache.maven.plugin.MojoExecutionException;
+import org.metaeffekt.core.inventory.processor.model.Inventory;
 import org.metaeffekt.core.inventory.processor.reader.InventoryReader;
 import org.metaeffekt.core.inventory.processor.report.InventoryReport;
 
@@ -44,7 +45,9 @@ public class InventoryReportCreationMojo extends AbstractInventoryReportCreation
 
         try {
             getLog().info("Starting inventory report creation for " + inventory.getAbsolutePath());
-            report.setInventory(new InventoryReader().readInventory(inventory));
+            final Inventory readInventory = new InventoryReader().readInventory(inventory);
+            getLog().debug("Parsed inventory data: " + readInventory.getInventorySizePrintString());
+            report.setInventory(readInventory);
         } catch (IOException e) {
             throw new MojoExecutionException("Cannot create inventory report.", e);
         }

--- a/tests/ae-inventory-subjects-itest/src/test/java/org/metaeffekt/core/itest/inventory/dsl/ArtifactListAsserts.java
+++ b/tests/ae-inventory-subjects-itest/src/test/java/org/metaeffekt/core/itest/inventory/dsl/ArtifactListAsserts.java
@@ -1,6 +1,20 @@
+/*
+ * Copyright 2009-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.metaeffekt.core.itest.inventory.dsl;
 
-import org.assertj.core.api.Condition;
 import org.metaeffekt.core.inventory.processor.model.Artifact;
 import org.metaeffekt.core.itest.inventory.dsl.predicates.NamedArtifactPredicate;
 


### PR DESCRIPTION
- Added "Addon CVEs" vulnerability source tracking to prevent them becoming void vulnerabilities when shown in the VAD.
- Fixed NPE in status history check.
- Inactive assessments will no longer show up as effective assessments if no others are present.