### PR TITLE
AEAA-442: Include further attributes in generated vulnerability-report.properties file

### DIFF
--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/StatisticsOverviewTable.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/StatisticsOverviewTable.java
@@ -186,6 +186,10 @@ public class StatisticsOverviewTable {
         return row.getCount(status);
     }
 
+    public int getStatusCount(String status) {
+        return rows.stream().mapToInt(row -> row.getCount(status)).sum();
+    }
+
     public List<String> getTableRowValues(String severity) {
         final SeverityToStatusRow row = findRowBySeverity(severity);
         if (row == null) return Collections.emptyList();

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/adapter/VulnerabilityReportAdapter.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/adapter/VulnerabilityReportAdapter.java
@@ -165,6 +165,15 @@ public class VulnerabilityReportAdapter {
         return StatisticsOverviewTable.buildTableStrFilterAdvisor(this.securityPolicy, vulnerabilities, filterAdvisory, useEffectiveSeverityScores);
     }
 
+    public StatisticsOverviewTable generateOverviewTable(List<AeaaVulnerability> vulnerabilities, boolean useEffectiveSeverityScores, String filterAdvisory, String vulnerabilityStatusMapper) {
+        final JSONObject securityPolicyJson = new JSONObject(this.securityPolicy.getProperties());
+        final CentralSecurityPolicyConfiguration clonedSecurityPolicy = new CentralSecurityPolicyConfiguration();
+        clonedSecurityPolicy.setProperties(new LinkedHashMap<>(securityPolicyJson.toMap()));
+        clonedSecurityPolicy.setVulnerabilityStatusDisplayMapper(vulnerabilityStatusMapper);
+
+        return StatisticsOverviewTable.buildTableStrFilterAdvisor(clonedSecurityPolicy, vulnerabilities, filterAdvisory, useEffectiveSeverityScores);
+    }
+
     /* CVSS */
 
     public CvssSeverityRanges.SeverityRange getSeverityForVectorScore(double score) {

--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/vulnerability-report.properties.vt
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/vulnerability-report.properties.vt
@@ -1,5 +1,8 @@
-#set($vulnerabilitiesAll = $vulnerabilityAdapter.getEffectiveVulnerabilitiesAll())
-#set($vulnerabilitiesForDetailsReport = $vulnerabilityAdapter.getEffectiveVulnerabilitiesForDetails())
+# access several different versions of the vulnerability list for different use-cases
+#set ($vulnerabilitiesAll = $vulnerabilityAdapter.getEffectiveVulnerabilitiesAll())
+#set ($ulnerabilitiesInitial = $vulnerabilityAdapter.getEffectiveVulnerabilitiesInitialInventoryAll())
+#set ($vulnerabilitiesForDetailsReport = $vulnerabilityAdapter.getEffectiveVulnerabilitiesForDetails())
+#
 # Switch to be used on overview level.
 #   In case no vulnerabilities are available the switch will have the value 'none'; 'report' otherwise.
 ae.vulnerability.report.overview.switch=#if ($vulnerabilitiesAll.isEmpty())
@@ -24,3 +27,75 @@ ae.vulnerability.report.details.root.switch=#if ($vulnerabilitiesForDetailsRepor
 #else
 gen/
 #end
+
+# vulnerability statistics
+#set ($overviewTableContextAbstractedAllVulnerabilities = $vulnerabilityAdapter.generateOverviewTable($vulnerabilitiesAll, true, "", "abstracted"))
+#set ($overviewTableContextUnmodifiedAllVulnerabilities = $vulnerabilityAdapter.generateOverviewTable($vulnerabilitiesAll, true, "", "unmodified"))
+
+#set ($overviewTableInitialAbstractedAllVulnerabilities = $vulnerabilityAdapter.generateOverviewTable($ulnerabilitiesInitial, true, "", "abstracted"))
+#set ($overviewTableInitialUnmodifiedAllVulnerabilities = $vulnerabilityAdapter.generateOverviewTable($ulnerabilitiesInitial, true, "", "unmodified"))
+# status mapper:          abstracted
+# cvss selection:         context
+# status:                 per property
+# cvss severity category: any
+ae.vulnerability.report.count.context.abstracted.affected=$overviewTableContextAbstractedAllVulnerabilities.getStatusCount("affected")
+ae.vulnerability.report.count.context.abstracted.not-affected=$overviewTableContextAbstractedAllVulnerabilities.getStatusCount("not affected")
+ae.vulnerability.report.count.context.abstracted.potentially-affected=$overviewTableContextAbstractedAllVulnerabilities.getStatusCount("potentially affected")
+
+# status mapper:          unmodified
+# cvss selection:         context
+# status:                 per property
+# cvss severity category: any
+ae.vulnerability.report.count.context.unmodified.applicable=$overviewTableContextUnmodifiedAllVulnerabilities.getStatusCount("applicable")
+ae.vulnerability.report.count.context.unmodified.not-applicable=$overviewTableContextUnmodifiedAllVulnerabilities.getStatusCount("not applicable")
+ae.vulnerability.report.count.context.unmodified.in-review=$overviewTableContextUnmodifiedAllVulnerabilities.getStatusCount("in review")
+ae.vulnerability.report.count.context.unmodified.insignificant=$overviewTableContextUnmodifiedAllVulnerabilities.getStatusCount("insignificant")
+ae.vulnerability.report.count.context.unmodified.void=$overviewTableContextUnmodifiedAllVulnerabilities.getStatusCount("void")
+
+# status mapper:          abstracted
+# cvss selection:         context
+# status:                 affected + potentially affected
+# cvss severity category: per property
+#set ($count = $overviewTableContextAbstractedAllVulnerabilities.getIntersectionCount("critical", "affected") + $overviewTableContextAbstractedAllVulnerabilities.getIntersectionCount("critical", "potentially affected"))
+ae.vulnerability.report.count.context.abstracted.all-affected.critical=$count
+#set ($count = $overviewTableContextAbstractedAllVulnerabilities.getIntersectionCount("high", "affected") + $overviewTableContextAbstractedAllVulnerabilities.getIntersectionCount("high", "potentially affected"))
+ae.vulnerability.report.count.context.abstracted.all-affected.high=$count
+#set ($count = $overviewTableContextAbstractedAllVulnerabilities.getIntersectionCount("medium", "affected") + $overviewTableContextAbstractedAllVulnerabilities.getIntersectionCount("medium", "potentially affected"))
+ae.vulnerability.report.count.context.abstracted.all-affected.medium=$count
+#set ($count = $overviewTableContextAbstractedAllVulnerabilities.getIntersectionCount("low", "affected") + $overviewTableContextAbstractedAllVulnerabilities.getIntersectionCount("low", "potentially affected"))
+ae.vulnerability.report.count.context.abstracted.all-affected.low=$count
+#set ($count = $overviewTableContextAbstractedAllVulnerabilities.getIntersectionCount("none", "affected") + $overviewTableContextAbstractedAllVulnerabilities.getIntersectionCount("none", "potentially affected"))
+ae.vulnerability.report.count.context.abstracted.all-affected.none=$count
+
+# status mapper:          abstracted
+# cvss selection:         initial
+# status:                 per property
+# cvss severity category: any
+ae.vulnerability.report.count.initial.abstracted.affected=$overviewTableInitialAbstractedAllVulnerabilities.getStatusCount("affected")
+ae.vulnerability.report.count.initial.abstracted.not-affected=$overviewTableInitialAbstractedAllVulnerabilities.getStatusCount("not affected")
+ae.vulnerability.report.count.initial.abstracted.potentially-affected=$overviewTableInitialAbstractedAllVulnerabilities.getStatusCount("potentially affected")
+
+# status mapper:          unmodified
+# cvss selection:         initial
+# status:                 per property
+# cvss severity category: any
+ae.vulnerability.report.count.initial.unmodified.applicable=$overviewTableInitialUnmodifiedAllVulnerabilities.getStatusCount("applicable")
+ae.vulnerability.report.count.initial.unmodified.not-applicable=$overviewTableInitialUnmodifiedAllVulnerabilities.getStatusCount("not applicable")
+ae.vulnerability.report.count.initial.unmodified.in-review=$overviewTableInitialUnmodifiedAllVulnerabilities.getStatusCount("in review")
+ae.vulnerability.report.count.initial.unmodified.insignificant=$overviewTableInitialUnmodifiedAllVulnerabilities.getStatusCount("insignificant")
+ae.vulnerability.report.count.initial.unmodified.void=$overviewTableInitialUnmodifiedAllVulnerabilities.getStatusCount("void")
+
+# status mapper:          abstracted
+# cvss selection:         initial
+# status:                 affected + potentially affected
+# cvss severity category: per property
+#set ($count = $overviewTableInitialAbstractedAllVulnerabilities.getIntersectionCount("critical", "affected") + $overviewTableInitialAbstractedAllVulnerabilities.getIntersectionCount("critical", "potentially affected"))
+ae.vulnerability.report.count.initial.abstracted.all-affected.critical=$count
+#set ($count = $overviewTableInitialAbstractedAllVulnerabilities.getIntersectionCount("high", "affected") + $overviewTableInitialAbstractedAllVulnerabilities.getIntersectionCount("high", "potentially affected"))
+ae.vulnerability.report.count.initial.abstracted.all-affected.high=$count
+#set ($count = $overviewTableInitialAbstractedAllVulnerabilities.getIntersectionCount("medium", "affected") + $overviewTableInitialAbstractedAllVulnerabilities.getIntersectionCount("medium", "potentially affected"))
+ae.vulnerability.report.count.initial.abstracted.all-affected.medium=$count
+#set ($count = $overviewTableInitialAbstractedAllVulnerabilities.getIntersectionCount("low", "affected") + $overviewTableInitialAbstractedAllVulnerabilities.getIntersectionCount("low", "potentially affected"))
+ae.vulnerability.report.count.initial.abstracted.all-affected.low=$count
+#set ($count = $overviewTableInitialAbstractedAllVulnerabilities.getIntersectionCount("none", "affected") + $overviewTableInitialAbstractedAllVulnerabilities.getIntersectionCount("none", "potentially affected"))
+ae.vulnerability.report.count.initial.abstracted.all-affected.none=$count


### PR DESCRIPTION
In addition to the report overview switches, the `vulnerability-report.properties` file now also contains several properties that make the values from the overview table (`tpc_inventory-vulnerability-statistics.dita.vt`) available via the properties file in all available combinations of status mappers and cvss selection policies.

See below for an example of the generated properties:

```
# status mapper:          abstracted
# cvss selection:         context
# status:                 per property
# cvss severity category: any
ae.vulnerability.report.count.context.abstracted.affected=2
ae.vulnerability.report.count.context.abstracted.not-affected=0
ae.vulnerability.report.count.context.abstracted.potentially-affected=40

# status mapper:          unmodified
# cvss selection:         context
# status:                 per property
# cvss severity category: any
ae.vulnerability.report.count.context.unmodified.applicable=2
ae.vulnerability.report.count.context.unmodified.not-applicable=0
ae.vulnerability.report.count.context.unmodified.in-review=3
ae.vulnerability.report.count.context.unmodified.insignificant=37
ae.vulnerability.report.count.context.unmodified.void=0

# status mapper:          abstracted
# cvss selection:         context
# status:                 affected + potentially affected
# cvss severity category: per property
ae.vulnerability.report.count.context.abstracted.all-affected.critical=0
ae.vulnerability.report.count.context.abstracted.all-affected.high=5
ae.vulnerability.report.count.context.abstracted.all-affected.medium=31
ae.vulnerability.report.count.context.abstracted.all-affected.low=3
ae.vulnerability.report.count.context.abstracted.all-affected.none=3

# status mapper:          abstracted
# cvss selection:         initial
# status:                 per property
# cvss severity category: any
ae.vulnerability.report.count.initial.abstracted.affected=2
ae.vulnerability.report.count.initial.abstracted.not-affected=0
ae.vulnerability.report.count.initial.abstracted.potentially-affected=40

# status mapper:          unmodified
# cvss selection:         initial
# status:                 per property
# cvss severity category: any
ae.vulnerability.report.count.initial.unmodified.applicable=2
ae.vulnerability.report.count.initial.unmodified.not-applicable=0
ae.vulnerability.report.count.initial.unmodified.in-review=18
ae.vulnerability.report.count.initial.unmodified.insignificant=22
ae.vulnerability.report.count.initial.unmodified.void=0

# status mapper:          abstracted
# cvss selection:         initial
# status:                 affected + potentially affected
# cvss severity category: per property
ae.vulnerability.report.count.initial.abstracted.all-affected.critical=2
ae.vulnerability.report.count.initial.abstracted.all-affected.high=18
ae.vulnerability.report.count.initial.abstracted.all-affected.medium=18
ae.vulnerability.report.count.initial.abstracted.all-affected.low=1
ae.vulnerability.report.count.initial.abstracted.all-affected.none=3
```

<img width="1279" alt="Screenshot 2024-02-12 at 15 17 17" src="https://github.com/org-metaeffekt/metaeffekt-core/assets/37689635/fc2b6200-95c3-449a-8a37-88100ce7a725">

<img width="1278" alt="Screenshot 2024-02-12 at 15 18 55" src="https://github.com/org-metaeffekt/metaeffekt-core/assets/37689635/5eaf5f8a-2486-49b5-bbbe-8f61a15b7c86">
