### PR TITLE
AEAA-433: Vulnerability Overview HTML Report

### DIFF
--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/model/AssetMetaData.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/model/AssetMetaData.java
@@ -51,6 +51,7 @@ public class AssetMetaData extends AbstractModelBase {
         NAME("Name"),
         VERSION("Version"),
         ASSESSMENT_ID("Assessment Id"),
+        ROLE("Role"),
         ASSESSMENT("Assessment");
 
         private String key;

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/configuration/CentralSecurityPolicyConfiguration.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/configuration/CentralSecurityPolicyConfiguration.java
@@ -524,6 +524,14 @@ public class CentralSecurityPolicyConfiguration extends ProcessConfiguration {
     }
 
     public static CentralSecurityPolicyConfiguration fromFile(File jsonFile) throws IOException {
+        if (jsonFile == null) {
+            throw new IllegalArgumentException("Security policy configuration file must not be null");
+        } else if (!jsonFile.exists()) {
+            throw new IOException("Security policy configuration file does not exist: " + jsonFile.getAbsolutePath());
+        } else if (!jsonFile.isFile()) {
+            throw new IOException("Security policy configuration file is not a file: " + jsonFile.getAbsolutePath());
+        }
+
         LOG.info("Loading security policy configuration from: {}", jsonFile.getAbsolutePath());
 
         final String json;
@@ -837,6 +845,10 @@ public class CentralSecurityPolicyConfiguration extends ProcessConfiguration {
             VULNERABILITY_STATUS_DISPLAY_MAPPER_ABSTRACTED,
             VULNERABILITY_STATUS_DISPLAY_MAPPER_REVIEW_STATE
     );
+
+    public static List<VulnerabilityStatusMapper> getRegisteredVulnerabilityStatusDisplayMappers() {
+        return Collections.unmodifiableList(REGISTERED_VULNERABILITY_STATUS_DISPLAY_MAPPERS);
+    }
 
     public static VulnerabilityStatusMapper getStatusMapperByName(String name) {
         return REGISTERED_VULNERABILITY_STATUS_DISPLAY_MAPPERS.stream()


### PR DESCRIPTION
In preparation for the single-page Vulnerability Overview HTML Report, a few changes need to be applied to the assessment and asset logic.

- Added support for an "Assessment Id" field on assets.
- Added getter for registered status mappers.

A `deriveAssessmentId` method has been added that will either return an existing `Assessment Id` from the `AssetMetaData`, or set the attribute to a value derived from either the `Asset Id` or `Name`, with a seeded random suffix based on attributes containing asset information.

These attributes are, where the first existing is picked:

- inventory info --> inventory-enrichment --> Steps --> Vulnerability Status | Vulnerability Keywords --> configuration --> yamlFiles
- inventory info --> inventory-enrichment --> Vulnerability Inventory Status --> cvss2 | cvss3 | cvss4
- fully random
