### PR TITLE
AEAA-461: Added a parameter for setting a custom initial vector

### DIFF
--- a/libraries/ae-security/src/main/java/org/metaeffekt/core/security/cvss/processor/UniversalCvssCalculatorLinkGenerator.java
+++ b/libraries/ae-security/src/main/java/org/metaeffekt/core/security/cvss/processor/UniversalCvssCalculatorLinkGenerator.java
@@ -20,7 +20,6 @@ import org.json.JSONArray;
 import org.metaeffekt.core.security.cvss.CvssSource;
 import org.metaeffekt.core.security.cvss.CvssVector;
 import org.metaeffekt.core.security.cvss.KnownCvssEntities;
-import org.metaeffekt.core.security.cvss.v3.Cvss3P1;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,7 +41,7 @@ public class UniversalCvssCalculatorLinkGenerator {
 
     private String baseUrl = "https://metaeffekt.com/security/cvss/calculator";
 
-    private final List<UniversalCvssCalculatorEntry> entries = new ArrayList<>();
+    private final List<UniversalCvssCalculatorEntry<?>> entries = new ArrayList<>();
     private final Set<String> openSections = new LinkedHashSet<>();
     private final Set<String> cves = new LinkedHashSet<>();
     private CvssVector selectedVector;
@@ -50,33 +49,33 @@ public class UniversalCvssCalculatorLinkGenerator {
     public UniversalCvssCalculatorLinkGenerator() {
     }
 
-    public UniversalCvssCalculatorEntry addVectorNullThrowing(CvssVector cvssVector, String name, boolean visible) {
+    public <V extends CvssVector> UniversalCvssCalculatorEntry<V>  addVectorNullThrowing(V cvssVector, String name, boolean visible) {
         if (cvssVector == null) {
             throw new IllegalArgumentException("CVSS vector to be added must not be null.");
         }
-        final UniversalCvssCalculatorEntry entry = new UniversalCvssCalculatorEntry(cvssVector, name, visible);
+        final UniversalCvssCalculatorEntry<V> entry = new UniversalCvssCalculatorEntry<>(cvssVector, name, visible);
         entries.add(entry);
         return entry;
     }
 
-    public UniversalCvssCalculatorEntry addVectorNullThrowing(CvssVector cvssVector) {
+    public <V extends CvssVector> UniversalCvssCalculatorEntry<V>  addVectorNullThrowing(V cvssVector) {
         return addVectorNullThrowing(cvssVector, cvssVector == null ? "unknown" : cvssVector.getCombinedCvssSource(true).replace("CVSS:", ""), true);
     }
 
-    public UniversalCvssCalculatorEntry addVector(CvssVector cvssVector, String name, boolean visible) {
+    public <V extends CvssVector> UniversalCvssCalculatorEntry<V>  addVector(V cvssVector, String name, boolean visible) {
         if (cvssVector == null) {
-            return new UniversalCvssCalculatorEntry(new Cvss3P1(), name, visible);
+            return new UniversalCvssCalculatorEntry<>(null, name, visible);
         }
-        final UniversalCvssCalculatorEntry entry = new UniversalCvssCalculatorEntry(cvssVector, name, visible);
+        final UniversalCvssCalculatorEntry<V> entry = new UniversalCvssCalculatorEntry<>(cvssVector, name, visible);
         entries.add(entry);
         return entry;
     }
 
-    public UniversalCvssCalculatorEntry addVector(CvssVector cvssVector) {
+    public <V extends CvssVector> UniversalCvssCalculatorEntry<V>  addVector(V cvssVector) {
         return addVector(cvssVector, cvssVector == null ? "unknown" : cvssVector.getCombinedCvssSource(true).replace("CVSS:", ""), true);
     }
 
-    public UniversalCvssCalculatorEntry addVectorForVulnerability(CvssVector cvssVector, String vulnerabilityName) {
+    public <V extends CvssVector> UniversalCvssCalculatorEntry<V> addVectorForVulnerability(V cvssVector, String vulnerabilityName) {
         if (StringUtils.isEmpty(vulnerabilityName)) {
             return addVector(cvssVector);
         }
@@ -143,7 +142,7 @@ public class UniversalCvssCalculatorLinkGenerator {
     }
 
     public UniversalCvssCalculatorLinkGenerator setSelectedVectorNullThrowing(String selectedVector) {
-        final UniversalCvssCalculatorEntry foundVector = findVectorEntryByName(selectedVector);
+        final UniversalCvssCalculatorEntry<?> foundVector = findVectorEntryByName(selectedVector);
         if (foundVector == null) {
             throw new IllegalArgumentException("Selected vector must be added to the link generator first.");
         }
@@ -159,7 +158,7 @@ public class UniversalCvssCalculatorLinkGenerator {
     }
 
     public UniversalCvssCalculatorLinkGenerator setSelectedVector(String selectedVector) {
-        final UniversalCvssCalculatorEntry foundVector = findVectorEntryByName(selectedVector);
+        final UniversalCvssCalculatorEntry<?> foundVector = findVectorEntryByName(selectedVector);
         if (foundVector != null) {
             this.selectedVector = foundVector.getCvssVector();
         }
@@ -180,23 +179,23 @@ public class UniversalCvssCalculatorLinkGenerator {
         return entries.isEmpty() && cves.isEmpty();
     }
 
-    protected UniversalCvssCalculatorEntry findVectorEntryByVector(CvssVector searchVector) {
+    protected <V extends CvssVector> UniversalCvssCalculatorEntry<V> findVectorEntryByVector(V searchVector) {
         if (searchVector == null) {
             return null;
         }
-        for (UniversalCvssCalculatorEntry entry : entries) {
+        for (UniversalCvssCalculatorEntry<?> entry : entries) {
             if (entry.getCvssVector().equals(searchVector)) {
-                return entry;
+                return (UniversalCvssCalculatorEntry<V>) entry;
             }
         }
         return null;
     }
 
-    protected UniversalCvssCalculatorEntry findVectorEntryByName(String searchVectorName) {
+    protected UniversalCvssCalculatorEntry<?> findVectorEntryByName(String searchVectorName) {
         if (searchVectorName == null) {
             return null;
         }
-        for (UniversalCvssCalculatorEntry entry : entries) {
+        for (UniversalCvssCalculatorEntry<?> entry : entries) {
             if (entry.getName().equals(searchVectorName)) {
                 return entry;
             }
@@ -275,17 +274,7 @@ public class UniversalCvssCalculatorLinkGenerator {
 
         if (!entries.isEmpty()) {
             final JSONArray vectorArray = new JSONArray();
-            for (UniversalCvssCalculatorEntry entry : entries) {
-                final CvssVector cvssVector = entry.getCvssVector();
-
-                final JSONArray vectorEntry = new JSONArray();
-                vectorEntry.put(entry.getName());
-                vectorEntry.put(entry.isVisible());
-                vectorEntry.put(cvssVector.toString());
-                vectorEntry.put(cvssVector.getName());
-
-                vectorArray.put(vectorEntry);
-            }
+            entries.stream().map(UniversalCvssCalculatorEntry::generateCvssVectorArrayEntry).forEach(vectorArray::put);
             parameters.put("vector", vectorArray.toString());
         }
 
@@ -294,7 +283,7 @@ public class UniversalCvssCalculatorLinkGenerator {
         }
 
         if (selectedVector != null) {
-            final UniversalCvssCalculatorEntry selectedVectorEntry = findVectorEntryByVector(selectedVector);
+            final UniversalCvssCalculatorEntry<?> selectedVectorEntry = findVectorEntryByVector(selectedVector);
             if (selectedVectorEntry != null) {
                 parameters.put("selected", selectedVectorEntry.getName());
             }
@@ -323,12 +312,13 @@ public class UniversalCvssCalculatorLinkGenerator {
         return generateLink();
     }
 
-    public static class UniversalCvssCalculatorEntry {
-        private final CvssVector cvssVector;
+    public static class UniversalCvssCalculatorEntry<V extends CvssVector> {
+        private final V cvssVector;
+        private V initialCvssVector;
         private String name;
         private boolean visible;
 
-        public UniversalCvssCalculatorEntry(CvssVector cvssVector, String name, boolean visible) {
+        public UniversalCvssCalculatorEntry(V cvssVector, String name, boolean visible) {
             this.cvssVector = cvssVector;
             this.name = name;
             this.visible = visible;
@@ -338,22 +328,50 @@ public class UniversalCvssCalculatorLinkGenerator {
             return name;
         }
 
-        public UniversalCvssCalculatorEntry setName(String name) {
+        public UniversalCvssCalculatorEntry<V> setName(String name) {
             this.name = name;
             return this;
         }
 
-        public CvssVector getCvssVector() {
+        public UniversalCvssCalculatorEntry<V> setInitialCvssVector(V initialCvssVector) {
+            this.initialCvssVector = initialCvssVector;
+            return this;
+        }
+
+        public UniversalCvssCalculatorEntry<V> setInitialCvssVectorUnchecked(CvssVector initialCvssVectorUnchecked) {
+            this.initialCvssVector = (V) initialCvssVectorUnchecked;
+            return this;
+        }
+
+        public V getCvssVector() {
             return cvssVector;
+        }
+
+        public V getInitialCvssVector() {
+            return initialCvssVector;
         }
 
         public boolean isVisible() {
             return visible;
         }
 
-        public UniversalCvssCalculatorEntry setVisible(boolean visible) {
+        public UniversalCvssCalculatorEntry<V> setVisible(boolean visible) {
             this.visible = visible;
             return this;
+        }
+
+        public JSONArray generateCvssVectorArrayEntry() {
+            final JSONArray vectorEntry = new JSONArray();
+
+            vectorEntry.put(this.name);
+            vectorEntry.put(this.isVisible());
+            vectorEntry.put(this.cvssVector == null ? "" : this.cvssVector.toString());
+            vectorEntry.put(this.cvssVector == null ? "CVSS:2.0" : this.cvssVector.getName());
+
+            if (this.initialCvssVector != null) vectorEntry.put(this.initialCvssVector.toString());
+            else vectorEntry.put((String) null);
+
+            return vectorEntry;
         }
     }
 }

--- a/libraries/ae-security/src/test/java/org/metaeffekt/core/security/cvss/processor/UniversalCvssCalculatorLinkGeneratorTest.java
+++ b/libraries/ae-security/src/test/java/org/metaeffekt/core/security/cvss/processor/UniversalCvssCalculatorLinkGeneratorTest.java
@@ -31,7 +31,7 @@ public class UniversalCvssCalculatorLinkGeneratorTest {
 
         generator.addVector(new Cvss2("AV:L/AC:H/Au:S/C:C/I:P/A:N/E:U/RL:U/RC:C/CDP:LM/TD:M/CR:H/IR:H/AR:H")).setName("TEST-CVSS-001").setVisible(false);
         generator.addVector(new Cvss3P1("CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:L/A:H/E:F/RL:U/RC:R")).setName("TEST-CVSS-002").setVisible(true);
-        generator.addVector(new Cvss4P0("CVSS:4.0/AV:P/AC:L/AT:N/PR:N/UI:N/VC:H/VI:L/VA:L/SC:H/SI:H/SA:H")).setName("TEST-CVSS-003").setVisible(true);
+        generator.addVector(new Cvss4P0("CVSS:4.0/AV:P/AC:L/AT:N/PR:N/UI:N/VC:H/VI:L/VA:L/SC:H/SI:H/SA:H")).setName("TEST-CVSS-003").setVisible(true).setInitialCvssVector(new Cvss4P0("CVSS:4.0/AV:P/AC:H/AT:N/PR:N/UI:N/VC:H/VI:L/VA:L/SC:H/SI:H/SA:H"));
 
         generator.addCve("CVE-2020-1234");
         generator.addCve("CVE-2020-5678");
@@ -39,7 +39,7 @@ public class UniversalCvssCalculatorLinkGeneratorTest {
         generator.setSelectedVector("TEST-CVSS-002");
 
         Assert.assertEquals(
-                "https://metaeffekt.com/security/cvss/calculator/index.html?vector=%5B%5B%22TEST-CVSS-001%22%2Cfalse%2C%22AV%3AL%2FAC%3AH%2FAu%3AS%2FC%3AC%2FI%3AP%2FA%3AN%2FE%3AU%2FRL%3AU%2FRC%3AC%2FCDP%3ALM%2FTD%3AM%2FCR%3AH%2FIR%3AH%2FAR%3AH%22%2C%22CVSS%3A2.0%22%5D%2C%5B%22TEST-CVSS-002%22%2Ctrue%2C%22CVSS%3A3.1%2FAV%3AN%2FAC%3AL%2FPR%3AL%2FUI%3AN%2FS%3AC%2FC%3AH%2FI%3AL%2FA%3AH%2FE%3AF%2FRL%3AU%2FRC%3AR%22%2C%22CVSS%3A3.1%22%5D%2C%5B%22TEST-CVSS-003%22%2Ctrue%2C%22CVSS%3A4.0%2FAV%3AP%2FAC%3AL%2FAT%3AN%2FPR%3AN%2FUI%3AN%2FVC%3AH%2FVI%3AL%2FVA%3AL%2FSC%3AH%2FSI%3AH%2FSA%3AH%22%2C%22CVSS%3A4.0%22%5D%5D&selected=TEST-CVSS-002&cve=CVE-2020-1234%2CCVE-2020-5678",
+                "https://metaeffekt.com/security/cvss/calculator/index.html?vector=%5B%5B%22TEST-CVSS-001%22%2Cfalse%2C%22AV%3AL%2FAC%3AH%2FAu%3AS%2FC%3AC%2FI%3AP%2FA%3AN%2FE%3AU%2FRL%3AU%2FRC%3AC%2FCDP%3ALM%2FTD%3AM%2FCR%3AH%2FIR%3AH%2FAR%3AH%22%2C%22CVSS%3A2.0%22%2Cnull%5D%2C%5B%22TEST-CVSS-002%22%2Ctrue%2C%22CVSS%3A3.1%2FAV%3AN%2FAC%3AL%2FPR%3AL%2FUI%3AN%2FS%3AC%2FC%3AH%2FI%3AL%2FA%3AH%2FE%3AF%2FRL%3AU%2FRC%3AR%22%2C%22CVSS%3A3.1%22%2Cnull%5D%2C%5B%22TEST-CVSS-003%22%2Ctrue%2C%22CVSS%3A4.0%2FAV%3AP%2FAC%3AL%2FAT%3AN%2FPR%3AN%2FUI%3AN%2FVC%3AH%2FVI%3AL%2FVA%3AL%2FSC%3AH%2FSI%3AH%2FSA%3AH%22%2C%22CVSS%3A4.0%22%2C%22CVSS%3A4.0%2FAV%3AP%2FAC%3AH%2FAT%3AN%2FPR%3AN%2FUI%3AN%2FVC%3AH%2FVI%3AL%2FVA%3AL%2FSC%3AH%2FSI%3AH%2FSA%3AH%22%5D%5D&selected=TEST-CVSS-002&cve=CVE-2020-1234%2CCVE-2020-5678",
                 generator.generateLink()
         );
     }
@@ -52,7 +52,7 @@ public class UniversalCvssCalculatorLinkGeneratorTest {
 
         generator.addVector(new Cvss2("AV:L/AC:H/Au:S/C:C/I:P/A:N/E:U/RL:U/RC:C/CDP:LM/TD:M/CR:H/IR:H/AR:H")).setName("TEST-CVSS-001").setVisible(false);
         generator.addVector(new Cvss3P1("CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:L/A:H/E:F/RL:U/RC:R")).setName("TEST-CVSS-002").setVisible(true);
-        generator.addVector(new Cvss4P0("CVSS:4.0/AV:P/AC:L/AT:N/PR:N/UI:N/VC:H/VI:L/VA:L/SC:H/SI:H/SA:H")).setName("TEST-CVSS-003").setVisible(true);
+        generator.addVector(new Cvss4P0("CVSS:4.0/AV:P/AC:L/AT:N/PR:N/UI:N/VC:H/VI:L/VA:L/SC:H/SI:H/SA:H")).setName("TEST-CVSS-003").setVisible(true).setInitialCvssVector(new Cvss4P0("CVSS:4.0/AV:P/AC:H/AT:N/PR:N/UI:N/VC:H/VI:L/VA:L/SC:H/SI:H/SA:H"));
 
         generator.addCve("CVE-2020-1234");
         generator.addCve("CVE-2020-5678");
@@ -60,7 +60,7 @@ public class UniversalCvssCalculatorLinkGeneratorTest {
         generator.setSelectedVector("TEST-CVSS-002");
 
         Assert.assertEquals(
-                "https://metaeffekt.com/security/cvss/calculator/index.html?b64gzip=H4sIAAAAAAAAAGWQTQvCMAyG_0sPnrql6-YHgR1KnTiYY6xbL-JBtJ4EwU1_vwmKMry8JSV9nqTPcBpv93y_F13hush65yKlEiEvx-sQpDAeKzAWt2Ae6MCihRIbMFhDgT20FQff2nWD1Q66Ne7AttRfchgKIQVjUcdKHORUpIUc74_w6UjjBEhYs7CCpqXoSyod8xnJs9BZ4OZrbsXv8R8-neCzWDG-eeNNR2Ry1G-HZ4FngzcUjktXcpjfChmvcJgN4UrfFs75ZJXZ6Rly64tIK62iRKeZ_FbzxXL1AllZov9rAQAA",
+                "https://metaeffekt.com/security/cvss/calculator/index.html?b64gzip=H4sIAAAAAAAAAJWRwYrCMBCG3yUHT2knTbvuMtBDiBULtZSm5iI9iMZTUVDr8zuDi1Lcy16-MGHyf5nkHva38yXfbkVXuC6y3rlIqUTI4264BimMxwqMxRWYER1YtFBiAwZrKHADbcXgXbtosFpDt8A12Jb6S4YhCCk4FnWshDyNw9DLqU0LebuM4bctjRMga83WCpqWsCmpdCzhXL4QrQUuX_pWvA__7UgnjixW7GieDtNRPInqp8izxbPGG4Lj0pUM8x4m42E-w1b_C-v72TUM9AXhkE9eZLa_h9z6ItJKqyjRaSZf1df8--cB_HtTibcBAAA",
                 generator.generateBas64EncodedGzipCompressedLink()
         );
     }


### PR DESCRIPTION
Currently, a ‘diff vector’ can be copied by holding shift and clicking the ‘copy’ button. This diff vector contains only metrics that have been changed by the user since accessing the page.

However, since the modified vectors are already loaded in with their corresponding CVSS modifications, these changes can no longer be copied by clicking the button.

For this, a new parameter needs to be added that will control the initial vector, or be empty or null to use the previous behavior.

This PR updates the libraries/ae-security/src/main/java/org/metaeffekt/core/security/cvss/processor/UniversalCvssCalculatorLinkGenerator.java file to include this parameter.

For this, the PR https://github.com/org-metaeffekt/metaeffekt-universal-cvss-calculator/pull/7 must be merged and published first.