### PR TITLE
AEAA-463: Allow upper OR lower bound on CVSS Severity Ranges to be undefined

### DIFF
--- a/libraries/ae-security/src/main/java/org/metaeffekt/core/security/cvss/CvssSeverityRanges.java
+++ b/libraries/ae-security/src/main/java/org/metaeffekt/core/security/cvss/CvssSeverityRanges.java
@@ -91,13 +91,21 @@ public class CvssSeverityRanges {
             if (!matcher.matches()) {
                 throw new IllegalArgumentException("Range pattern does not match format [NAME:COLOR:FLOOR:CEIL] in " + input);
             }
+
             this.name = matcher.group(1).trim();
             this.color = ColorScheme.getColor(matcher.group(2));
             if (this.color == null) {
                 throw new IllegalArgumentException("Range color unknown in [" + input + "]. available colors are [" + getAvailableColors() + "]");
             }
-            this.floor = Double.parseDouble(matcher.group(3).trim());
-            this.ceil = Double.parseDouble(matcher.group(4).trim());
+
+            final String floorStr = matcher.group(3).trim();
+            final String ceilStr = matcher.group(4).trim();
+            this.floor = StringUtils.isEmpty(floorStr) ? -Double.MAX_VALUE : Double.parseDouble(floorStr);
+            this.ceil = StringUtils.isEmpty(ceilStr) ? Double.MAX_VALUE : Double.parseDouble(ceilStr);
+
+            if (floorStr.isEmpty() && ceilStr.isEmpty()) {
+                throw new IllegalArgumentException("Both floor and ceil cannot be empty in [" + input + "]");
+            }
             if (this.floor > this.ceil) {
                 throw new IllegalArgumentException("Range floor [" + this.floor + "] must be smaller than range ceil [" + this.ceil + "] in [" + input + "]");
             }
@@ -129,7 +137,7 @@ public class CvssSeverityRanges {
             return index;
         }
 
-        private final static Pattern RANGE_PATTERN = Pattern.compile("([^:]+):([^:]+):([^:]+):([^:]+)");
+        private final static Pattern RANGE_PATTERN = Pattern.compile("([^:]+):([^:]+):([^:]*):([^:]*)");
 
         @Override
         public int compareTo(SeverityRange o) {
@@ -149,8 +157,9 @@ public class CvssSeverityRanges {
 
     public final static SeverityRange UNDEFINED_SEVERITY_RANGE = new SeverityRange("Undefined:strong-gray:-100.0:100.0", -1);
 
-    public static final CvssSeverityRanges CVSS_2_SEVERITY_RANGES = new CvssSeverityRanges("Low:strong-yellow:0.0:3.9,Medium:strong-light-orange:4.0:6.9,High:strong-red:7.0:10.0");
-    public static final CvssSeverityRanges CVSS_3_SEVERITY_RANGES = new CvssSeverityRanges("None:pastel-gray:0.0:0.0,Low:strong-yellow:0.1:3.9,Medium:strong-light-orange:4.0:6.9,High:strong-dark-orange:7.0:8.9,Critical:strong-red:9.0:10.0");
+    public static final CvssSeverityRanges CVSS_2_SEVERITY_RANGES = new CvssSeverityRanges("Low:strong-yellow::3.9,Medium:strong-light-orange:4.0:6.9,High:strong-red:7.0:");
+    public static final CvssSeverityRanges CVSS_3_SEVERITY_RANGES = new CvssSeverityRanges("None:pastel-gray::0.0,Low:strong-yellow:0.1:3.9,Medium:strong-light-orange:4.0:6.9,High:strong-dark-orange:7.0:8.9,Critical:strong-red:9.0:");
+
 
     private static String getAvailableColors() {
         StringJoiner colors = new StringJoiner(", ");

--- a/libraries/ae-security/src/test/java/org/metaeffekt/core/security/cvss/CvssSeverityRangesTest.java
+++ b/libraries/ae-security/src/test/java/org/metaeffekt/core/security/cvss/CvssSeverityRangesTest.java
@@ -28,6 +28,8 @@ public class CvssSeverityRangesTest {
         new CvssSeverityRanges("Undefined:strong-gray:-100.0:100.0");
         new CvssSeverityRanges("Low:strong-red:0.0:3.9,Medium:strong-red:4.0:6.9,High:strong-red:7.0:10.0");
         new CvssSeverityRanges("Low:strong-yellow:0.0:2.9,Average:strong-light-orange:3.0:6.9,Strong:strong-dark-orange:7.0:8.9,Maximum:strong-red:9.0:10.0");
+        new CvssSeverityRanges("Low:strong-red:0.0:3.9,Medium:strong-red:4.0:6.9,High:strong-red::10.0");
+        new CvssSeverityRanges("Low:strong-red:0.0:3.9,Medium:strong-red:4.0:6.9,High:strong-red:7.0:");
         parseMustFail("Color should not have existed", "Undefined:dummy-color:-100.0:100.0");
         parseMustFail("Range should not have been valid", "Undefined:strong-gray:3.5:2.1");
         parseMustFail("Too few parts", "Undefined:strong-gray:-100.0");
@@ -38,8 +40,7 @@ public class CvssSeverityRangesTest {
         parseMustFail("Wrong delimiter ';'", "Low:strong-red;0.0:3.9,Medium:strong-red:4.0:6.9,High:strong-red:7.0:10.0");
         parseMustFail("Empty part", "Low:strong-red:0.0:3.9,Medium:strong-red:4.0:6.9,:strong-red:7.0:10.0");
         parseMustFail("Empty part", "Low:strong-red:0.0:3.9,Medium:strong-red:4.0:6.9,High::7.0:10.0");
-        parseMustFail("Empty part", "Low:strong-red:0.0:3.9,Medium:strong-red:4.0:6.9,High:strong-red::10.0");
-        parseMustFail("Empty part", "Low:strong-red:0.0:3.9,Medium:strong-red:4.0:6.9,High:strong-red:7.0:");
+        parseMustFail("Range delimiters both empty", "Low:strong-red:0.0:3.9,Medium:strong-red:4.0:6.9,High:strong-red::");
     }
 
     private void parseMustFail(String message, String rangeString) {
@@ -75,8 +76,8 @@ public class CvssSeverityRangesTest {
 
     @Test
     public void scoreTest() {
-        Assert.assertEquals("Undefined", CvssSeverityRanges.CVSS_2_SEVERITY_RANGES.getRange(-10.0).getName());
-        Assert.assertEquals("Undefined", CvssSeverityRanges.CVSS_2_SEVERITY_RANGES.getRange(-0.1).getName());
+        Assert.assertEquals("Low", CvssSeverityRanges.CVSS_2_SEVERITY_RANGES.getRange(-10.0).getName());
+        Assert.assertEquals("Low", CvssSeverityRanges.CVSS_2_SEVERITY_RANGES.getRange(-0.1).getName());
         Assert.assertEquals("Low", CvssSeverityRanges.CVSS_2_SEVERITY_RANGES.getRange(0.0).getName());
         Assert.assertEquals("Low", CvssSeverityRanges.CVSS_2_SEVERITY_RANGES.getRange(3.9).getName());
         Assert.assertEquals("Medium", CvssSeverityRanges.CVSS_2_SEVERITY_RANGES.getRange(4.0).getName());
@@ -85,9 +86,10 @@ public class CvssSeverityRangesTest {
         Assert.assertEquals("High", CvssSeverityRanges.CVSS_2_SEVERITY_RANGES.getRange(7.0).getName());
         Assert.assertEquals("High", CvssSeverityRanges.CVSS_2_SEVERITY_RANGES.getRange(8.2).getName());
         Assert.assertEquals("High", CvssSeverityRanges.CVSS_2_SEVERITY_RANGES.getRange(10.0).getName());
+        Assert.assertEquals("High", CvssSeverityRanges.CVSS_2_SEVERITY_RANGES.getRange(12020.0).getName());
 
-        Assert.assertEquals("Undefined", CvssSeverityRanges.CVSS_3_SEVERITY_RANGES.getRange(-10.0).getName());
-        Assert.assertEquals("Undefined", CvssSeverityRanges.CVSS_3_SEVERITY_RANGES.getRange(-0.1).getName());
+        Assert.assertEquals("None", CvssSeverityRanges.CVSS_3_SEVERITY_RANGES.getRange(-10.0).getName());
+        Assert.assertEquals("None", CvssSeverityRanges.CVSS_3_SEVERITY_RANGES.getRange(-0.1).getName());
         Assert.assertEquals("None", CvssSeverityRanges.CVSS_3_SEVERITY_RANGES.getRange(0.0).getName());
         Assert.assertEquals("Low", CvssSeverityRanges.CVSS_3_SEVERITY_RANGES.getRange(0.1).getName());
         Assert.assertEquals("Low", CvssSeverityRanges.CVSS_3_SEVERITY_RANGES.getRange(3.9).getName());
@@ -100,5 +102,6 @@ public class CvssSeverityRangesTest {
         Assert.assertEquals("Critical", CvssSeverityRanges.CVSS_3_SEVERITY_RANGES.getRange(9.0).getName());
         Assert.assertEquals("Critical", CvssSeverityRanges.CVSS_3_SEVERITY_RANGES.getRange(9.5).getName());
         Assert.assertEquals("Critical", CvssSeverityRanges.CVSS_3_SEVERITY_RANGES.getRange(10.0).getName());
+        Assert.assertEquals("Critical", CvssSeverityRanges.CVSS_3_SEVERITY_RANGES.getRange(12020.0).getName());
     }
 }


### PR DESCRIPTION
Adjusted the CVSS Severity Ranges parsing process to allow for one of the two bounding numbers of each range to be undefined, represented by an empty string (`::`).

The following default parameter values (CVSS 2.0 and 3.1) have been updated to use this change to allow values that are negative/larger than 10.0 to be properly parsed into a range, even though it would technically not fit in the range.


    Low:strong-yellow::3.9,Medium:strong-light-orange:4.0:6.9,High:strong-red:7.0:
    None:pastel-gray::0.0,Low:strong-yellow:0.1:3.9,Medium:strong-light-orange:4.0:6.9,High:strong-dark-orange:7.0:8.9,Critical:strong-red:9.0:

This is required because of e.g. the priority score, which regularly grows larger than 10.0.