### PR TITLE
Feature/system scripts container runuser

### DIFF
--- a/libraries/ae-system-analysis-scripts/src/main/resources/ae-system-analysis-scripts/appliance-extraction/alpine-extractor.sh
+++ b/libraries/ae-system-analysis-scripts/src/main/resources/ae-system-analysis-scripts/appliance-extraction/alpine-extractor.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+
+#
+# Copyright 2020 metaeffekt GmbH.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+echo "Executing alpine-extractor.sh"
+
+# some variables
+# outDir MUST NOT end in space or newline characters due to how this script functions
+outDir="/var/opt/metaeffekt/extraction/analysis"
+
+# define required functions
+#INCLUDESOURCEHERE-portable
+
+# check that the libraries are there
+checkPortableFunctionsPresent || { echo "missing required portable functions. quitting" 1>&2 ; exit 1; }
+
+# check the input flags
+processArguments "$@"
+
+# create folder structure in analysis folder (assuming sufficient permissions)
+mkOutputDirs "${outDir}"
+
+# write machineTag
+printf "%s\n" "$machineTag" > "${outDir}"/machine-tag.txt
+
+# disable pathname expansion so find gets the patterns raw
+set -f
+
+# generate list of all files
+dumpFilepaths "${outDir}" "${findExcludes}"
+
+# analyse symbolic links
+analyseSymbolicLinks "${outDir}"
+
+# reenable pathname expansion
+set +f
+
+# examine distributions metadata
+uname -a > "${outDir}"/uname.txt
+cat /etc/issue > "${outDir}"/issue.txt
+cat /etc/alpine-release > "${outDir}"/release.txt
+
+# list packages names (no version included)
+apk info | sort > "${outDir}"/packages_apk.txt
+
+# query package metadata and covered files
+packagenames=`cat "${outDir}"/packages_apk.txt`
+SEP=$'\n'
+for package in $packagenames
+do
+  apk info --license -d -w -t $package > "${outDir}"/package-meta/${package}_apk.txt
+  apk info -L $package > "${outDir}"/package-files/${package}_files.txt
+done
+
+# if docker is installed dump the image list
+dumpDockerIfPresent "${outDir}"
+
+# if podman is installed, dump the image list (might return the same as docker with present docker -> podman symlinks)
+dumpPodmanIfPresent "${outDir}"

--- a/libraries/ae-system-analysis-scripts/src/main/resources/ae-system-analysis-scripts/extraction-scripts-lib/portable-functions.sh
+++ b/libraries/ae-system-analysis-scripts/src/main/resources/ae-system-analysis-scripts/extraction-scripts-lib/portable-functions.sh
@@ -182,6 +182,11 @@ dumpDockerWithDroppedPrivs()
       echo "No user given for docker dump with dropped privileges."
       exit 1
     fi
+    if [ ! "$(command -v runuser)" ]
+    then
+      printf "Executable runuser not installed. Can't dump docker with dropped privileges for user [%s].\n" "${2}"
+      return 1
+    fi
 
   runuser -u "${2}" -- docker image list --no-trunc --digests > "${1}"/docker-images-user.txt || true
   runuser -u "${2}" -- docker ps --no-trunc --all > "${1}"/docker-ps-user.txt || true
@@ -253,6 +258,11 @@ dumpPodmanWithDroppedPrivs()
   then
     echo "No user given for podman dump with dropped privileges."
     exit 1
+  fi
+  if [ ! "$(command -v runuser)" ]
+  then
+    printf "Executable runuser missing: can't dump podman with dropped privileges for user [%s].\n" "${2}"
+    return 1
   fi
 
   runuser -u "${2}" -- podman image list --no-trunc --digests > "${1}"/podman-images-user.txt || true


### PR DESCRIPTION
Use `runuser` to drop privileges to list docker/podman images as a user.

Also adds code for the requested alpine appliance extractor.