### PR TITLE
AEAA-474: CERT-EU and generalization of security advisory handling

### DIFF
--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/InventoryReport.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/InventoryReport.java
@@ -1345,7 +1345,7 @@ public class InventoryReport {
 
     public void addGenerateOverviewTablesForAdvisories(Collection<AeaaContentIdentifiers> providers) {
         if (providers.contains(AeaaContentIdentifiers.UNKNOWN)) {
-            LOG.warn("Unknown vulnerability advisory provider [{}], must be one of {}", providers, Arrays.toString(AeaaContentIdentifiers.values()));
+            LOG.warn("Unknown vulnerability advisory provider [{}], must be one of {}", providers, AeaaContentIdentifiers.values());
         }
 
         providers.stream()

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/adapter/VulnerabilityReportAdapter.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/adapter/VulnerabilityReportAdapter.java
@@ -131,7 +131,7 @@ public class VulnerabilityReportAdapter {
                 .collect(Collectors.groupingBy(a -> a.getEntrySource() + " " + a.getType()))
                 .entrySet().stream().sorted(Map.Entry.comparingByKey())
                 .map(Map.Entry::getValue)
-                .map(l -> l.stream().sorted(Comparator.comparing(AeaaAdvisoryEntry::getEntrySource)).collect(Collectors.toList()))
+                .map(l -> l.stream().sorted(Comparator.comparing(e -> e.getEntrySource().name())).collect(Collectors.toList()))
                 .collect(Collectors.toList());
     }
 

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/configuration/CentralSecurityPolicyConfiguration.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/configuration/CentralSecurityPolicyConfiguration.java
@@ -544,7 +544,7 @@ public class CentralSecurityPolicyConfiguration extends ProcessConfiguration {
             if (provider == null) {
                 misconfigurations.add(new ProcessMisconfiguration("includeVulnerabilitiesWithAdvisoryProviders", "Advisory provider must not be null"));
             } else if (!CentralSecurityPolicyConfiguration.isAny(provider) && AeaaContentIdentifiers.fromName(provider) == AeaaContentIdentifiers.UNKNOWN) {
-                misconfigurations.add(new ProcessMisconfiguration("includeVulnerabilitiesWithAdvisoryProviders", "Unknown advisory provider: " + provider + ", must be one of " + Arrays.toString(AeaaContentIdentifiers.values())));
+                misconfigurations.add(new ProcessMisconfiguration("includeVulnerabilitiesWithAdvisoryProviders", "Unknown advisory provider: " + provider + ", must be one of " + AeaaContentIdentifiers.values().stream().map(AeaaContentIdentifiers::name).collect(Collectors.joining(", "))));
             }
         }
 
@@ -560,7 +560,7 @@ public class CentralSecurityPolicyConfiguration extends ProcessConfiguration {
             if (provider == null) {
                 misconfigurations.add(new ProcessMisconfiguration("includeAdvisoryProviders", "Advisory provider must not be null"));
             } else if (!CentralSecurityPolicyConfiguration.isAny(provider) && AeaaContentIdentifiers.fromName(provider) == AeaaContentIdentifiers.UNKNOWN) {
-                misconfigurations.add(new ProcessMisconfiguration("includeAdvisoryProviders", "Unknown advisory provider: " + provider + ", must be one of " + Arrays.toString(AeaaContentIdentifiers.values())));
+                misconfigurations.add(new ProcessMisconfiguration("includeAdvisoryProviders", "Unknown advisory provider: " + provider + ", must be one of " + AeaaContentIdentifiers.values().stream().map(AeaaContentIdentifiers::name).collect(Collectors.joining(", "))));
             }
         }
 

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/model/aeaa/AeaaContentIdentifiers.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/model/aeaa/AeaaContentIdentifiers.java
@@ -207,11 +207,19 @@ public class AeaaContentIdentifiers {
             }
         }
 
-        // well formed name will replace underscores/dashes with spaces and capitalize the first letter of each word
-        final String wellFormedName = WordUtils.capitalize(name.toLowerCase().replaceAll("[-_]", " "));
+        final String wellFormedName = createWellFormedNameFromBaseName(name);
         final AeaaContentIdentifiers createdIdentifier = new AeaaContentIdentifiers(name, wellFormedName, Pattern.compile("UNDEFINED"), AeaaGeneralAdvisorEntry.class, AeaaGeneralAdvisorEntry::new);
         AeaaContentIdentifiers.registerContentIdentifier(createdIdentifier);
         return createdIdentifier;
+    }
+
+    private static String createWellFormedNameFromBaseName(String name) {
+        name = name.toLowerCase().replaceAll("[-_]", " ");
+        if (name.startsWith("cert ")) {
+            return name.replaceFirst("cert ", "CERT-").toUpperCase();
+        } else {
+            return WordUtils.capitalize(name);
+        }
     }
 
     public static void registerContentIdentifier(AeaaContentIdentifiers contentIdentifier) {

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/model/aeaa/AeaaContentIdentifiers.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/model/aeaa/AeaaContentIdentifiers.java
@@ -15,6 +15,7 @@
  */
 package org.metaeffekt.core.inventory.processor.report.model.aeaa;
 
+import org.apache.commons.lang.WordUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.json.JSONObject;
 import org.metaeffekt.core.inventory.processor.model.AdvisoryMetaData;
@@ -35,32 +36,52 @@ import java.util.stream.Collectors;
  * Mirrors structure of <code>com.metaeffekt.mirror.contents.ContentIdentifiers</code>
  * until separation of inventory report generation from ae core inventory processor.
  */
-public enum AeaaContentIdentifiers {
-    CERT_FR("CERT-FR", Pattern.compile("((?:CERTFR|CERTA)-\\d+-(?:ACT|AVI|ALE|INF)-\\d+(?:-\\d+)?)", Pattern.CASE_INSENSITIVE), AeaaCertFrAdvisorEntry.class, AeaaCertFrAdvisorEntry::new),
-    CERT_SEI("CERT-SEI", Pattern.compile("(VU#(\\d+))", Pattern.CASE_INSENSITIVE), AeaaCertSeiAdvisorEntry.class, AeaaCertSeiAdvisorEntry::new),
-    MSRC("MSRC", Pattern.compile("(MSRC-(?:CVE|CAN)-([0-9]{4})-([0-9]{4,})|ADV(\\d+))", Pattern.CASE_INSENSITIVE), AeaaMsrcAdvisorEntry.class, AeaaMsrcAdvisorEntry::new),
+public class AeaaContentIdentifiers {
+
+    private final static Logger LOG = LoggerFactory.getLogger(AeaaContentIdentifiers.class);
+
+    public final static AeaaContentIdentifiers CERT_FR = new AeaaContentIdentifiers("CERT_FR", "CERT-FR", Pattern.compile("((?:CERTFR|CERTA)-\\d+-(?:ACT|AVI|ALE|INF)-\\d+(?:-\\d+)?)", Pattern.CASE_INSENSITIVE), AeaaCertFrAdvisorEntry.class, AeaaCertFrAdvisorEntry::new);
+    public final static AeaaContentIdentifiers CERT_SEI = new AeaaContentIdentifiers("CERT_SEI", "CERT-SEI", Pattern.compile("(VU#(\\d+))", Pattern.CASE_INSENSITIVE), AeaaCertSeiAdvisorEntry.class, AeaaCertSeiAdvisorEntry::new);
+    public final static AeaaContentIdentifiers CERT_EU = new AeaaContentIdentifiers("CERT_EU", "CERT-EU", Pattern.compile("(CERT-EU-(\\d+))", Pattern.CASE_INSENSITIVE), AeaaCertEuAdvisorEntry.class, AeaaCertEuAdvisorEntry::new);
+    public final static AeaaContentIdentifiers MSRC = new AeaaContentIdentifiers("MSRC", "MSRC", Pattern.compile("(MSRC-(?:CVE|CAN)-([0-9]{4})-([0-9]{4,})|ADV(\\d+))", Pattern.CASE_INSENSITIVE), AeaaMsrcAdvisorEntry.class, AeaaMsrcAdvisorEntry::new);
     /**
-     * <a href="https://github.com/github/advisory-database">
-     * Pattern source</a>.
+     * <a href="https://github.com/github/advisory-database">Pattern source</a>.
      */
-    GHSA("GHSA", Pattern.compile("GHSA(-[23456789cfghjmpqrvwx]{4}){3}"), AeaaGhsaAdvisorEntry.class, AeaaGhsaAdvisorEntry::new),
-    CVE("CVE", Pattern.compile("((?:CVE|CAN)-([0-9]{4})-([0-9]{4,}))", Pattern.CASE_INSENSITIVE), null, null),
-    CWE("CWE", Pattern.compile("(CWE-\\d+)", Pattern.CASE_INSENSITIVE), null, null),
-    CPE("CPE", Pattern.compile("UNDEFINED", Pattern.CASE_INSENSITIVE), null, null),
-    NVD("NVD", Pattern.compile("UNDEFINED", Pattern.CASE_INSENSITIVE), null, null),
-    ASSESSMENT_STATUS("Assessment Status", Pattern.compile("UNDEFINED", Pattern.CASE_INSENSITIVE), null, null),
-    UNKNOWN("UNKNOWN", Pattern.compile("UNKNOWN", Pattern.CASE_INSENSITIVE), null, null);
+    public final static AeaaContentIdentifiers GHSA = new AeaaContentIdentifiers("GHSA", "GHSA", Pattern.compile("GHSA(-[23456789cfghjmpqrvwx]{4}){3}"), AeaaGhsaAdvisorEntry.class, AeaaGhsaAdvisorEntry::new);
+    public final static AeaaContentIdentifiers CVE = new AeaaContentIdentifiers("CVE", "CVE", Pattern.compile("((?:CVE|CAN)-([0-9]{4})-([0-9]{4,}))", Pattern.CASE_INSENSITIVE), null, null);
+    public final static AeaaContentIdentifiers CWE = new AeaaContentIdentifiers("CWE", "CWE", Pattern.compile("(CWE-\\d+)", Pattern.CASE_INSENSITIVE), null, null);
+    public final static AeaaContentIdentifiers CPE = new AeaaContentIdentifiers("CPE", "CPE", Pattern.compile("UNDEFINED", Pattern.CASE_INSENSITIVE), null, null);
+    public final static AeaaContentIdentifiers NVD = new AeaaContentIdentifiers("NVD", "NVD", Pattern.compile("UNDEFINED", Pattern.CASE_INSENSITIVE), null, null);
+    public final static AeaaContentIdentifiers ASSESSMENT_STATUS = new AeaaContentIdentifiers("ASSESSMENT_STATUS", "Assessment Status", Pattern.compile("UNDEFINED", Pattern.CASE_INSENSITIVE), null, null);
+    public final static AeaaContentIdentifiers UNKNOWN = new AeaaContentIdentifiers("UNKNOWN", "UNKNOWN", Pattern.compile("UNKNOWN", Pattern.CASE_INSENSITIVE), null, null);
+    public final static AeaaContentIdentifiers UNKNOWN_ADVISORY = new AeaaContentIdentifiers("UNKNOWN_ADVISORY", "Unknown Advisory", Pattern.compile("UNKNOWN", Pattern.CASE_INSENSITIVE), AeaaGeneralAdvisorEntry.class, AeaaGeneralAdvisorEntry::new);
 
-    private static final Logger LOG = LoggerFactory.getLogger(AeaaContentIdentifiers.class);
+    public static final List<AeaaContentIdentifiers> REGISTERED_CONTENT_IDENTIFIERS = new ArrayList<>(Arrays.asList(
+            CERT_FR, CERT_SEI, CERT_EU, MSRC, GHSA,
+            NVD, CVE, CPE, CWE,
+            ASSESSMENT_STATUS,
+            UNKNOWN, UNKNOWN_ADVISORY
+    ));
 
+    /**
+     * This class used to be an enum, but was converted to a class to allow for dynamic instantiation of new identifiers.
+     * This method adds support for the old enum-like <code>value</code> method.
+     *
+     * @return a list of all known content identifiers.
+     */
+    public static List<AeaaContentIdentifiers> values() {
+        return REGISTERED_CONTENT_IDENTIFIERS;
+    }
+
+    private final String name;
     private final String wellFormedName;
     private final Pattern pattern;
     private final boolean isAdvisorProvider;
-
     private final Class<? extends AeaaAdvisoryEntry> advisoryEntryClass;
     private final Supplier<AeaaAdvisoryEntry> advisoryEntryFactory;
 
-    AeaaContentIdentifiers(String wellFormedName, Pattern pattern, Class<? extends AeaaAdvisoryEntry> advisoryEntryClass, Supplier<AeaaAdvisoryEntry> advisoryEntryFactory) {
+    public AeaaContentIdentifiers(String name, String wellFormedName, Pattern pattern, Class<? extends AeaaAdvisoryEntry> advisoryEntryClass, Supplier<AeaaAdvisoryEntry> advisoryEntryFactory) {
+        this.name = name;
         this.wellFormedName = wellFormedName;
         this.pattern = pattern;
 
@@ -78,57 +99,64 @@ public enum AeaaContentIdentifiers {
         return isAdvisorProvider;
     }
 
+    /**
+     * This method is used to provide a similar API to the old enum-like <code>valueOf</code> method.
+     *
+     * @return the content identifier with the given name.
+     */
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+
     public String normalizeEntryIdentifier(String id) {
         if (id == null) {
             return null;
         }
 
-        switch (this) {
-            case CERT_FR:
-                id = baseNormalizeIdentifier(id);
-                if (id.matches("\\d+.+")) {
-                    id = id.replaceAll("\\d+(.+)", "$1");
-                }
-                if (id.contains("FR")) {
-                    id = id.replaceAll("CERT[-–_ ]*FR-?", "");
-                    id = "CERTFR-" + id;
-                } else if (id.contains("CERTA")) {
-                    id = id.replaceAll("CERTA-?", "");
-                    id = "CERTA-" + id;
-                }
-                return id.replaceAll("-+", "-");
-
-            case CERT_SEI:
-                id = baseNormalizeIdentifier(id);
-                return id.replaceAll("\\D*(\\d+)\\D*", "VU#$1");
-
-            case CVE:
-                id = baseNormalizeIdentifier(id);
-                id = id.replaceAll("(CVE|CAN)-?", "")
-                        .replaceAll(".*?(\\d{1,4})-(\\d+).*", "$1-$2");
-                id = "CVE-" + id;
-                return id.replaceAll("-+", "-");
-
-            case MSRC:
-                id = baseNormalizeIdentifier(id);
-                final boolean isAdv = id.contains("ADV");
-                id = id.replaceAll("(MSRC-)?(CVE|CAN)-?", "")
-                        .replaceAll(".*?(\\d{1,4})-(\\d+).*", "$1-$2")
-                        .replace("ADV", "");
-                id = isAdv ? "ADV" + id : "MSRC-CVE-" + id;
-                return id.replaceAll("-+", "-");
-
-            case GHSA:
-                id = baseNormalizeIdentifier(id);
-                return id.replaceAll("-+", "-").toLowerCase();
-
-            case CWE:
-                id = baseNormalizeIdentifier(id);
-                return id.replaceAll("CWE-?", "CWE-");
-
-            default:
-                return id;
+        if (this == CERT_FR) {
+            id = baseNormalizeIdentifier(id);
+            if (id.matches("\\d+.+")) {
+                id = id.replaceAll("\\d+(.+)", "$1");
+            }
+            if (id.contains("FR")) {
+                id = id.replaceAll("CERT[-–_ ]*FR-?", "");
+                id = "CERTFR-" + id;
+            } else if (id.contains("CERTA")) {
+                id = id.replaceAll("CERTA-?", "");
+                id = "CERTA-" + id;
+            }
+            return id.replaceAll("-+", "-");
+        } else if (this == CERT_SEI) {
+            id = baseNormalizeIdentifier(id);
+            return id.replaceAll("\\D*(\\d+)\\D*", "VU#$1");
+        } else if (this == CVE) {
+            id = baseNormalizeIdentifier(id);
+            id = id.replaceAll("(CVE|CAN)-?", "")
+                    .replaceAll(".*?(\\d{1,4})-(\\d+).*", "$1-$2");
+            id = "CVE-" + id;
+            return id.replaceAll("-+", "-");
+        } else if (this == MSRC) {
+            id = baseNormalizeIdentifier(id);
+            final boolean isAdv = id.contains("ADV");
+            id = id.replaceAll("(MSRC-)?(CVE|CAN)-?", "")
+                    .replaceAll(".*?(\\d{1,4})-(\\d+).*", "$1-$2")
+                    .replace("ADV", "");
+            id = isAdv ? "ADV" + id : "MSRC-CVE-" + id;
+            return id.replaceAll("-+", "-");
+        } else if (this == GHSA) {
+            id = baseNormalizeIdentifier(id);
+            return id.replaceAll("-+", "-").toLowerCase();
+        } else if (this == CWE) {
+            id = baseNormalizeIdentifier(id);
+            return id.replaceAll("CWE-?", "CWE-");
         }
+
+        return id;
     }
 
     public String getWellFormedName() {
@@ -165,10 +193,108 @@ public enum AeaaContentIdentifiers {
         }
     }
 
+    public static AeaaContentIdentifiers findOrCreateGenericNamedAdvisory(String name) {
+        if (StringUtils.isEmpty(name)) {
+            throw new IllegalArgumentException("Name must not be empty.");
+        }
+
+        final AeaaContentIdentifiers existingIdentifier = AeaaContentIdentifiers.fromName(name);
+        if (existingIdentifier != UNKNOWN) {
+            if (existingIdentifier.isAdvisoryProvider()) {
+                return existingIdentifier;
+            } else {
+                LOG.error("Existing content identifier [{}#{}] is not an advisory provider, but was requested as such. Removing existing identifier.", existingIdentifier, existingIdentifier.hashCode());
+            }
+        }
+
+        // well formed name will replace underscores/dashes with spaces and capitalize the first letter of each word
+        final String wellFormedName = WordUtils.capitalize(name.toLowerCase().replaceAll("[-_]", " "));
+        final AeaaContentIdentifiers createdIdentifier = new AeaaContentIdentifiers(name, wellFormedName, Pattern.compile("UNDEFINED"), AeaaGeneralAdvisorEntry.class, AeaaGeneralAdvisorEntry::new);
+        AeaaContentIdentifiers.registerContentIdentifier(createdIdentifier);
+        return createdIdentifier;
+    }
+
+    public static void registerContentIdentifier(AeaaContentIdentifiers contentIdentifier) {
+        if (contentIdentifier == null) {
+            throw new IllegalArgumentException("Content identifier must not be null.");
+        }
+
+        final AeaaContentIdentifiers found = AeaaContentIdentifiers.fromName(contentIdentifier.name());
+        if (found != UNKNOWN) {
+            if (found == contentIdentifier) {
+                return;
+            }
+            throw new IllegalArgumentException("Content identifier [" + contentIdentifier + "] is already registered as [" + found + "].");
+        }
+
+        LOG.info("Registering content identifier [{}] with attributes [wellFormedName={}, pattern={}, advisoryClass={}].", contentIdentifier, contentIdentifier.getWellFormedName(), contentIdentifier.getPattern(), contentIdentifier.getAdvisoryEntryClass());
+        REGISTERED_CONTENT_IDENTIFIERS.add(contentIdentifier);
+    }
+
+    public static AeaaContentIdentifiers extractAdvisorySourceFromSourceOrName(String name, String source) {
+        final AeaaContentIdentifiers parsedSource;
+        if (source != null) {
+            parsedSource = AeaaContentIdentifiers.fromName(source);
+        } else if (name != null) {
+            LOG.warn("Security Advisory source attribute [{}] should not be empty when parsing advisory entry [{}], falling back to parsing from name",
+                    AdvisoryMetaData.Attribute.SOURCE, name);
+            parsedSource = AeaaContentIdentifiers.fromEntryIdentifier(name);
+        } else {
+            LOG.warn("Security Advisory source attribute [{}] and name attribute [{}] are empty, falling back to [{}]",
+                    AdvisoryMetaData.Attribute.SOURCE, AdvisoryMetaData.Attribute.NAME, AeaaContentIdentifiers.UNKNOWN.name());
+            parsedSource = UNKNOWN;
+        }
+        if (parsedSource == null || parsedSource == UNKNOWN) {
+            if (StringUtils.isNotEmpty(source)) {
+                final AeaaContentIdentifiers createdIdentifier = findOrCreateGenericNamedAdvisory(source);
+                LOG.warn("Could not infer source from source [{}], created source [{}]", source, createdIdentifier);
+                return createdIdentifier;
+            } else {
+                // LOG.warn("Could not infer or create source from source [{}], using [{}]", source, UNKNOWN_ADVISORY);
+                return UNKNOWN_ADVISORY;
+            }
+        } else {
+            return parsedSource;
+        }
+    }
+
     public static AeaaContentIdentifiers extractSourceFromJson(JSONObject json) {
         final String source = json.optString("source", "unknown");
         final AeaaContentIdentifiers parsedSource = AeaaContentIdentifiers.fromName(source);
         return parsedSource == null ? UNKNOWN : parsedSource;
+    }
+
+    public static AeaaContentIdentifiers extractSourceFromAdvisor(AeaaAdvisoryEntry advisory) {
+        if (advisory == null) {
+            return UNKNOWN;
+        }
+
+        for (AeaaContentIdentifiers sourceIdentifier : AeaaContentIdentifiers.values()) {
+            if (sourceIdentifier.isAdvisoryProvider() && sourceIdentifier.getAdvisoryEntryClass() == advisory.getClass()) {
+                return sourceIdentifier;
+            }
+        }
+
+        final String source = advisory.getAdditionalAttribute(AdvisoryMetaData.Attribute.SOURCE);
+        final String id = advisory.getId();
+
+        final AeaaContentIdentifiers parsedSource = extractAdvisorySourceFromSourceOrName(id, source);
+
+        if (parsedSource != AeaaContentIdentifiers.UNKNOWN) {
+            return parsedSource;
+        }
+
+        if (!advisory.getDataSources().isEmpty()) {
+            LOG.warn("Could not infer source of [{}] from id: {}", advisory.getClass().getSimpleName(), id);
+            return advisory.getDataSources().iterator().next();
+        } else if (source != null) {
+            final AeaaContentIdentifiers createdIdentifier = findOrCreateGenericNamedAdvisory(source);
+            LOG.warn("Could not infer source of [{}] from id [{}] and no data sources are set, created source [{}]", advisory.getClass().getSimpleName(), id, createdIdentifier);
+            return createdIdentifier;
+        } else {
+            LOG.warn("Could not infer source of [{}] from id [{}] and no data sources are set, using [{}]", advisory.getClass().getSimpleName(), id, AeaaContentIdentifiers.UNKNOWN);
+            return AeaaContentIdentifiers.UNKNOWN_ADVISORY;
+        }
     }
 
     public static AeaaContentIdentifiers extractSourceFromAdvisor(AdvisoryMetaData amd) {
@@ -232,8 +358,8 @@ public enum AeaaContentIdentifiers {
         final List<String> listNames = Arrays.asList(names);
 
         if (CentralSecurityPolicyConfiguration.containsAny(listNames)) {
-            return Arrays.stream(AeaaContentIdentifiers.values())
-                    .filter(id -> !UNKNOWN.equals(id))
+            return AeaaContentIdentifiers.values().stream()
+                    .filter(id -> UNKNOWN != id)
                     .collect(Collectors.toList());
         }
 

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/model/aeaa/AeaaDataSourceIndicator.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/model/aeaa/AeaaDataSourceIndicator.java
@@ -59,7 +59,7 @@ public class AeaaDataSourceIndicator {
 
     public static AeaaDataSourceIndicator fromJson(JSONObject json) {
         return new AeaaDataSourceIndicator(
-                AeaaContentIdentifiers.valueOf(json.getString("source")),
+                AeaaContentIdentifiers.fromName(json.getString("source")),
                 Reason.fromJson(json.getJSONObject("matches"))
         );
     }

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/model/aeaa/AeaaVulnerability.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/model/aeaa/AeaaVulnerability.java
@@ -250,13 +250,13 @@ public class AeaaVulnerability extends AeaaMatchableDetailsAmbDataClass<Vulnerab
         }
     }
 
-    public void addReferencedAeaaContentIdentifiers(Map<AeaaContentIdentifiers, Set<String>> ids) {
-        for (Map.Entry<AeaaContentIdentifiers, Set<String>> referencedEntry : ids.entrySet()) {
+    public <T extends Collection<String>> void addReferencedContentIdentifiers(Map<AeaaContentIdentifiers, T> ids) {
+        for (Map.Entry<AeaaContentIdentifiers, T> referencedEntry : ids.entrySet()) {
             this.addReferencedContentIdentifier(referencedEntry.getKey(), referencedEntry.getValue());
         }
     }
 
-    protected void addReferencedContentIdentifier(AeaaContentIdentifiers type, String id) {
+    public void addReferencedContentIdentifier(AeaaContentIdentifiers type, String id) {
         synchronized (this.referencedContentIds) {
             this.referencedContentIds.computeIfAbsent(type, e -> new HashSet<>()).add(id);
         }
@@ -559,10 +559,20 @@ public class AeaaVulnerability extends AeaaMatchableDetailsAmbDataClass<Vulnerab
 
         if (StringUtils.hasText(vmd.get(AeaaInventoryAttribute.VULNERABILITY_REFERENCED_CONTENT_IDS))) {
             final JSONObject referencedIds = new JSONObject(vmd.get(AeaaInventoryAttribute.VULNERABILITY_REFERENCED_CONTENT_IDS));
+
             for (String key : referencedIds.keySet()) {
+                final AeaaContentIdentifiers type = AeaaContentIdentifiers.fromName(key);
+                final AeaaContentIdentifiers effectiveType;
+                if (type != AeaaContentIdentifiers.UNKNOWN) {
+                    effectiveType = type;
+                } else {
+                    // assume that the source is an advisory source
+                    effectiveType = AeaaContentIdentifiers.findOrCreateGenericNamedAdvisory(key);
+                }
+
                 final JSONArray ids = referencedIds.getJSONArray(key);
                 for (int i = 0; i < ids.length(); i++) {
-                    this.addReferencedContentIdentifier(ids.getString(i));
+                    this.addReferencedContentIdentifier(effectiveType, ids.getString(i));
                 }
             }
         }
@@ -721,9 +731,21 @@ public class AeaaVulnerability extends AeaaMatchableDetailsAmbDataClass<Vulnerab
 
         if (input.containsKey("referencedIds")) {
             final Map<String, Collection<String>> parsedReferencedIds = (Map<String, Collection<String>>) input.get("referencedIds");
-            parsedReferencedIds.values().stream()
-                    .flatMap(Collection::stream)
-                    .forEach(this::addReferencedContentIdentifier);
+
+            for (Map.Entry<String, Collection<String>> entry : parsedReferencedIds.entrySet()) {
+                final String key = entry.getKey();
+
+                final AeaaContentIdentifiers type = AeaaContentIdentifiers.fromName(key);
+                final AeaaContentIdentifiers effectiveType;
+                if (type != AeaaContentIdentifiers.UNKNOWN) {
+                    effectiveType = type;
+                } else {
+                    // assume that the source is an advisory source
+                    effectiveType = AeaaContentIdentifiers.findOrCreateGenericNamedAdvisory(key);
+                }
+
+                entry.getValue().forEach(e -> this.addReferencedContentIdentifier(effectiveType, e));
+            }
         }
 
         for (String cwe : ((Collection<String>) input.getOrDefault("cwe", Collections.EMPTY_SET))) {

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/model/aeaa/AeaaVulnerabilityContextInventory.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/model/aeaa/AeaaVulnerabilityContextInventory.java
@@ -337,16 +337,60 @@ public class AeaaVulnerabilityContextInventory {
         vulnerability.getSecurityAdvisories().clear();
 
         synchronized (vulnerability.getReferencedContentIds()) {
+            final Map<AeaaAdvisoryEntry, AeaaContentIdentifiers> advisoryReplacementContentIds = new HashMap<>();
+
             for (Map.Entry<AeaaContentIdentifiers, Set<String>> refEntry : vulnerability.getReferencedContentIds().entrySet()) {
                 final AeaaContentIdentifiers source = refEntry.getKey();
                 final Set<String> ids = refEntry.getValue();
 
-                if (source.isAdvisoryProvider()) {
+                final boolean isSourceAdvisoryProvider = source.isAdvisoryProvider();
+                final boolean isSourceUnknown = source == AeaaContentIdentifiers.UNKNOWN || source == AeaaContentIdentifiers.UNKNOWN_ADVISORY;
+
+                if (isSourceUnknown) {
+                    // in this case, the source string was not yet known to the system when parsing the vulnerability.
+                    // if an advisory with that Id can be found, it is clear that the referenced source must be an
+                    // advisory source and can be created as such.
+
+                    for (String id : ids) {
+                        final Optional<AeaaAdvisoryEntry> optAdvisoryEntry = findAdvisoryEntryByName(id);
+                        if (optAdvisoryEntry.isPresent()) {
+                            AeaaAdvisoryEntry advisoryEntry = optAdvisoryEntry.get();
+                            final AeaaContentIdentifiers replacementSource = advisoryEntry.getEntrySource();
+                            advisoryReplacementContentIds.put(advisoryEntry, replacementSource);
+
+                            vulnerability.addSecurityAdvisory(advisoryEntry);
+                        }
+                    }
+                } else if (isSourceAdvisoryProvider) {
                     ids.stream()
                             .map(this::findAdvisoryEntryByName)
                             .filter(Optional::isPresent).map(Optional::get)
-                            .forEach(vulnerability::addSecurityAdvisory);
+                            .forEach(securityAdvisory -> {
+                                if (securityAdvisory.getEntrySource() != source) {
+                                    LOG.warn("Overwriting source for advisory [{}] from [{}] to [{}] due to more detailed information on vulnerability [{}]",
+                                            securityAdvisory.getId(), securityAdvisory.getEntrySource(), source, vulnerability.getId());
+                                    securityAdvisory.setSource(source);
+                                }
+                                vulnerability.addSecurityAdvisory(securityAdvisory);
+                            });
                 }
+            }
+
+            // remove the known replaced advisory entries from the referenced content ids and create new ones
+            for (Map.Entry<AeaaAdvisoryEntry, AeaaContentIdentifiers> entry : advisoryReplacementContentIds.entrySet()) {
+                final AeaaAdvisoryEntry advisoryEntry = entry.getKey();
+                final AeaaContentIdentifiers replacementSource = entry.getValue();
+
+                LOG.info("Replaced unknown advisory source [{}] with [{}] for vulnerability [{}]",
+                        AeaaContentIdentifiers.UNKNOWN, replacementSource, vulnerability.getId());
+
+                vulnerability.getReferencedContentIds().entrySet().stream()
+                        .filter(e -> e.getKey() == AeaaContentIdentifiers.UNKNOWN)
+                        .filter(e -> e.getValue().contains(advisoryEntry.getId()))
+                        .forEach(e -> {
+                            e.getValue().remove(advisoryEntry.getId());
+                            vulnerability.addReferencedContentIdentifier(replacementSource, advisoryEntry.getId());
+                        });
             }
         }
     }

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/model/aeaa/advisory/AeaaCertEuAdvisorEntry.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/model/aeaa/advisory/AeaaCertEuAdvisorEntry.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2009-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.metaeffekt.core.inventory.processor.report.model.aeaa.advisory;
+
+import org.json.JSONObject;
+import org.metaeffekt.core.inventory.processor.model.AdvisoryMetaData;
+import org.metaeffekt.core.inventory.processor.report.model.AdvisoryUtils;
+import org.metaeffekt.core.inventory.processor.report.model.aeaa.AeaaContentIdentifiers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class AeaaCertEuAdvisorEntry extends AeaaAdvisoryEntry {
+
+    private final static Logger LOG = LoggerFactory.getLogger(AeaaCertEuAdvisorEntry.class);
+
+    protected final static Set<String> CONVERSION_KEYS_AMB = new HashSet<String>(AeaaAdvisoryEntry.CONVERSION_KEYS_AMB) {{
+    }};
+
+    protected final static Set<String> CONVERSION_KEYS_MAP = new HashSet<String>(AeaaAdvisoryEntry.CONVERSION_KEYS_MAP) {{
+    }};
+
+
+    public AeaaCertEuAdvisorEntry() {
+        super(AeaaContentIdentifiers.CERT_EU);
+    }
+
+    public AeaaCertEuAdvisorEntry(String id) {
+        super(AeaaContentIdentifiers.CERT_EU, id);
+    }
+
+    @Override
+    public String getUrl() {
+        return "https://cert.europa.eu/publications/security-advisories/" + id.replace("CERT-EU-", "");
+    }
+
+    @Override
+    public String getType() {
+        return AdvisoryUtils.normalizeType("alert");
+    }
+
+    @Override
+    protected Set<String> conversionKeysAmb() {
+        return CONVERSION_KEYS_AMB;
+    }
+
+    @Override
+    protected Set<String> conversionKeysMap() {
+        return CONVERSION_KEYS_MAP;
+    }
+
+    public static AeaaCertEuAdvisorEntry fromAdvisoryMetaData(AdvisoryMetaData amd) {
+        return AeaaAdvisoryEntry.fromAdvisoryMetaData(amd, AeaaCertEuAdvisorEntry::new);
+    }
+
+    public static AeaaCertEuAdvisorEntry fromInputMap(Map<String, Object> map) {
+        return AeaaAdvisoryEntry.fromInputMap(map, AeaaCertEuAdvisorEntry::new);
+    }
+
+    public static AeaaCertEuAdvisorEntry fromJson(JSONObject json) {
+        return AeaaAdvisoryEntry.fromJson(json, AeaaCertEuAdvisorEntry::new);
+    }
+
+    @Override
+    public void appendFromBaseModel(AdvisoryMetaData amd) {
+        super.appendFromBaseModel(amd);
+    }
+
+    @Override
+    public void appendToBaseModel(AdvisoryMetaData amd) {
+        super.appendToBaseModel(amd);
+    }
+
+    @Override
+    public void appendFromMap(Map<String, Object> map) {
+        super.appendFromMap(map);
+    }
+
+    @Override
+    public void appendToJson(JSONObject json) {
+        super.appendToJson(json);
+    }
+}

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/model/aeaa/advisory/AeaaGeneralAdvisorEntry.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/model/aeaa/advisory/AeaaGeneralAdvisorEntry.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2009-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.metaeffekt.core.inventory.processor.report.model.aeaa.advisory;
+
+import org.json.JSONObject;
+import org.metaeffekt.core.inventory.processor.model.AdvisoryMetaData;
+import org.metaeffekt.core.inventory.processor.report.model.AdvisoryUtils;
+import org.metaeffekt.core.inventory.processor.report.model.aeaa.AeaaContentIdentifiers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class AeaaGeneralAdvisorEntry extends AeaaAdvisoryEntry {
+
+    private final static Logger LOG = LoggerFactory.getLogger(AeaaGeneralAdvisorEntry.class);
+
+    protected final static Set<String> CONVERSION_KEYS_AMB = new HashSet<String>(AeaaAdvisoryEntry.CONVERSION_KEYS_AMB) {{
+    }};
+
+    protected final static Set<String> CONVERSION_KEYS_MAP = new HashSet<String>(AeaaAdvisoryEntry.CONVERSION_KEYS_MAP) {{
+    }};
+
+
+    public AeaaGeneralAdvisorEntry() {
+        super(AeaaContentIdentifiers.UNKNOWN_ADVISORY);
+    }
+
+    public AeaaGeneralAdvisorEntry(String id) {
+        super(AeaaContentIdentifiers.UNKNOWN_ADVISORY, id);
+    }
+
+    @Override
+    public String getUrl() {
+        return "";
+    }
+
+    @Override
+    public String getType() {
+        return AdvisoryUtils.normalizeType("alert");
+    }
+
+    /* TYPE CONVERSION METHODS */
+
+    @Override
+    protected Set<String> conversionKeysAmb() {
+        return CONVERSION_KEYS_AMB;
+    }
+
+    @Override
+    protected Set<String> conversionKeysMap() {
+        return CONVERSION_KEYS_MAP;
+    }
+
+    public static AeaaGeneralAdvisorEntry fromAdvisoryMetaData(AdvisoryMetaData amd) {
+        return AeaaAdvisoryEntry.fromAdvisoryMetaData(amd, AeaaGeneralAdvisorEntry::new);
+    }
+
+    public static AeaaGeneralAdvisorEntry fromInputMap(Map<String, Object> map) {
+        return AeaaAdvisoryEntry.fromInputMap(map, AeaaGeneralAdvisorEntry::new);
+    }
+
+    public static AeaaGeneralAdvisorEntry fromJson(JSONObject json) {
+        return AeaaAdvisoryEntry.fromJson(json, AeaaGeneralAdvisorEntry::new);
+    }
+
+    protected static String stringOrNull(Object obj) {
+        if (obj == null) {
+            return null;
+        }
+        return obj.toString();
+    }
+
+    protected void inferSourceFromInput(String source) {
+        final AeaaContentIdentifiers inferredSource = AeaaContentIdentifiers.extractAdvisorySourceFromSourceOrName(this.getId(), source);
+        if (LOG.isDebugEnabled() && !inferredSource.name().equals(this.source)) {
+            LOG.debug("Inferred source differs from originally assigned [{}] --> [{}]", this.source, inferredSource.name());
+        }
+        this.source = inferredSource.name();
+    }
+
+    @Override
+    public void appendFromBaseModel(AdvisoryMetaData amd) {
+        super.appendFromBaseModel(amd);
+        this.inferSourceFromInput(amd.get(AdvisoryMetaData.Attribute.SOURCE));
+    }
+
+    @Override
+    public void appendToBaseModel(AdvisoryMetaData amd) {
+        super.appendToBaseModel(amd);
+    }
+
+    @Override
+    public void appendFromMap(Map<String, Object> map) {
+        super.appendFromMap(map);
+        this.inferSourceFromInput(stringOrNull(map.get(AdvisoryMetaData.Attribute.SOURCE.getKey())));
+    }
+
+    @Override
+    public void appendToJson(JSONObject json) {
+        super.appendToJson(json);
+    }
+
+}

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/model/aeaa/vulnerabilitystatus/AeaaVulnerabilityStatus.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/model/aeaa/vulnerabilitystatus/AeaaVulnerabilityStatus.java
@@ -214,7 +214,7 @@ public class AeaaVulnerabilityStatus {
     public List<AeaaVulnerabilityStatusReviewedEntry> getReviewedAdvisories(AeaaContentIdentifiers type) {
         return reviewedAdvisories.stream()
                 .filter(a -> a.getAdvisor() == type)
-                .sorted((Comparator.comparing(AeaaVulnerabilityStatusReviewedEntry::getAdvisor)))
+                .sorted((Comparator.comparing(a -> a.getAdvisor().name())))
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
Applied changes made in Artifact Analysis related to vulnerability management back onto core.
This includes:

- Added CERT-EU security advisory class.
- Generalized handling of security advisories. `AeaaContentIdentifiers` is now a class instead of an enum that will create new instances of advisory sources at runtime to support any advisory source, without making the process crash/ignore others/have other side effects.
- Integrated changes into report.

This needs to be merged with https://github.com/org-metaeffekt/metaeffekt-artifact-analysis/pull/9 together.

---

<img width="774" alt="Screenshot 2024-05-01 at 11 46 38" src="https://github.com/org-metaeffekt/metaeffekt-core/assets/37689635/a12dba41-b0e4-4791-82db-e99d17faf535">

<img width="780" alt="Screenshot 2024-05-01 at 11 43 33" src="https://github.com/org-metaeffekt/metaeffekt-core/assets/37689635/cba1a4d1-c401-4cd2-b42e-d0781dbdbf0a">

---

By the way, we should really pull out the vulnerability related classes into some other module so that they can be grouped together... sometime.
It was really unsatisfying to apply the AEAA changes back onto the existing Aeaa-Prefixed classes in core.

But I don't have any great solution right now for this that would not include massively changing the architecture of our projects.