### PR TITLE
AEAA-479: Added KEV Data to pdf report generation

### DIFF
--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/adapter/VulnerabilityReportAdapter.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/adapter/VulnerabilityReportAdapter.java
@@ -145,7 +145,9 @@ public class VulnerabilityReportAdapter {
 
         final Set<AeaaAdvisoryEntry> advisoryEntries = new HashSet<>(baseEntries);
         for (Collection<AeaaAdvisoryEntry> advisory : advisories) {
-            if (advisory == null) continue;
+            if (advisory == null) {
+                continue;
+            }
             advisoryEntries.removeAll(advisory);
         }
 
@@ -198,7 +200,9 @@ public class VulnerabilityReportAdapter {
      * @return The post-processed source string
      */
     public String postProcessCvssSource(String combinedSourceString) {
-        if (StringUtils.isBlank(combinedSourceString)) return "unknown";
+        if (StringUtils.isBlank(combinedSourceString)) {
+            return "unknown";
+        }
 
         if (combinedSourceString.contains(KnownCvssEntities.ASSESSMENT.getName() + "-" + KnownCvssEntities.ASSESSMENT_ALL.getName())) {
             combinedSourceString = combinedSourceString.replace(KnownCvssEntities.ASSESSMENT.getName() + "-" + KnownCvssEntities.ASSESSMENT_ALL.getName(), KnownCvssEntities.ASSESSMENT.getName());
@@ -247,7 +251,9 @@ public class VulnerabilityReportAdapter {
     /* MICROSOFT UTILITIES */
 
     protected Map<AeaaMsrcAdvisorEntry, List<AeaaMsrcRemediation>> getMsrcAdvisorEntriesWithRemediationInformation(AeaaVulnerability vulnerability, Collection<Artifact> artifacts) {
-        if (vulnerability == null) return Collections.emptyMap();
+        if (vulnerability == null) {
+            return Collections.emptyMap();
+        }
 
         final Map<AeaaMsrcAdvisorEntry, List<AeaaMsrcRemediation>> result = new LinkedHashMap<>();
 
@@ -265,7 +271,9 @@ public class VulnerabilityReportAdapter {
                         }
                     }
                 }
-                if (found) break;
+                if (found) {
+                    break;
+                }
             }
         }
 
@@ -324,8 +332,12 @@ public class VulnerabilityReportAdapter {
     }
 
     public Set<String> getMsrcProductIdsForArtifact(Artifact artifact) {
-        if (artifact == null) return Collections.emptySet();
-        if (artifact.get(AeaaInventoryAttribute.MS_PRODUCT_ID) == null) return Collections.emptySet();
+        if (artifact == null) {
+            return Collections.emptySet();
+        }
+        if (artifact.get(AeaaInventoryAttribute.MS_PRODUCT_ID) == null) {
+            return Collections.emptySet();
+        }
         return Arrays.stream(artifact.get(AeaaInventoryAttribute.MS_PRODUCT_ID).split(", ")).collect(Collectors.toSet());
     }
 
@@ -489,8 +501,12 @@ public class VulnerabilityReportAdapter {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
             DisplayStatusData that = (DisplayStatusData) o;
             return Objects.equals(normalized, that.normalized) && Objects.equals(capitalized, that.capitalized) && Objects.equals(asXmlId, that.asXmlId);
         }
@@ -508,7 +524,9 @@ public class VulnerabilityReportAdapter {
     }
 
     public List<Artifact> getArtifactsForComponent(String component) {
-        if (component == null) return Collections.emptyList();
+        if (component == null) {
+            return Collections.emptyList();
+        }
         return inventory.getArtifacts().stream()
                 .filter(a -> a.getComponent() != null && a.getComponent().equals(component))
                 .collect(Collectors.toList());
@@ -650,6 +668,24 @@ public class VulnerabilityReportAdapter {
         return maxLength;
     }
 
+    /* KEV */
+    public int totalOfKevEntries() {
+        return (int) getEffectiveVulnerabilitiesAll().stream().filter(e -> e.getKevData() != null).count();
+    }
+
+    public int totalOfNotKevEntries() {
+        return (int) getEffectiveVulnerabilitiesAll().stream().filter(e -> e.getKevData() == null).count();
+    }
+
+    public float percentageOfKev() {
+        int totalKev = totalOfKevEntries() + totalOfNotKevEntries();
+        return Math.round(((float) totalOfKevEntries() / totalKev) * 100);
+    }
+
+    public float percentageOfNotKev() {
+        return 100F - percentageOfKev();
+    }
+
     /* ADVISORIES */
 
     public String getAdvisoryHeader() {
@@ -665,11 +701,15 @@ public class VulnerabilityReportAdapter {
             sb.append("Alerts");
         }
         if (includeAdvisoryTypes.contains("notice")) {
-            if (sb.length() > 0) sb.append(" / ");
+            if (sb.length() > 0) {
+                sb.append(" / ");
+            }
             sb.append("Notices");
         }
         if (includeAdvisoryTypes.contains("news")) {
-            if (sb.length() > 0) sb.append(" / ");
+            if (sb.length() > 0) {
+                sb.append(" / ");
+            }
             sb.append("Updates");
         }
 
@@ -681,17 +721,23 @@ public class VulnerabilityReportAdapter {
         // Range End	Range Start
         // 2023-11-29	2023-06-01
         final InventoryInfo periodInfo = this.inventory.findInventoryInfo("cert-periodic-query");
-        if (periodInfo == null) return null;
+        if (periodInfo == null) {
+            return null;
+        }
 
         final String rangeEnd = periodInfo.get("Range End");
         final String rangeStart = periodInfo.get("Range Start");
-        if (rangeEnd == null || rangeStart == null) return null;
+        if (rangeEnd == null || rangeStart == null) {
+            return null;
+        }
 
         return rangeStart + " - " + rangeEnd;
     }
 
     public List<AeaaAdvisoryEntry> filterSecurityAdvisoriesForReviewStatus(List<AeaaAdvisoryEntry> securityAdvisories, String status) {
-        if (securityAdvisories == null) return Collections.emptyList();
+        if (securityAdvisories == null) {
+            return Collections.emptyList();
+        }
 
         return securityAdvisories.stream()
                 .filter(a -> a.getAdditionalAttribute(AdvisoryMetaData.Attribute.REVIEW_STATUS) != null)
@@ -702,14 +748,18 @@ public class VulnerabilityReportAdapter {
     /* COMPONENTS / ARTIFACTS */
 
     public List<AeaaVulnerability> getVulnerabilitiesForArtifact(Artifact artifact) {
-        if (artifact == null) return Collections.emptyList();
+        if (artifact == null) {
+            return Collections.emptyList();
+        }
         return this.getEffectiveVulnerabilitiesAll().stream()
                 .filter(v -> v.getAffectedArtifactsByDefaultKey().contains(artifact))
                 .collect(Collectors.toList());
     }
 
     public List<AeaaVulnerability> getVulnerabilitiesForComponent(String component) {
-        if (component == null) return Collections.emptyList();
+        if (component == null) {
+            return Collections.emptyList();
+        }
         return this.getArtifactsForComponent(component).stream()
                 .flatMap(a -> getVulnerabilitiesForArtifact(a).stream())
                 .distinct()
@@ -736,7 +786,9 @@ public class VulnerabilityReportAdapter {
     }
 
     public boolean fileExists(String path) {
-        if (path == null) return false;
+        if (path == null) {
+            return false;
+        }
         return new File(path).exists();
     }
 }

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/model/aeaa/AeaaInventoryAttribute.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/model/aeaa/AeaaInventoryAttribute.java
@@ -62,6 +62,8 @@ public enum AeaaInventoryAttribute implements AbstractModelBase.Attribute {
     VULNERABILITIES_FIXED_BY_KB("Vulnerability fixed by KB"),
     INAPPLICABLE_CVE("Inapplicable CVE"),
     ADDON_CVES("Addon CVEs"),
+    KEV_DATA("KEV Data")
+
     ;
 
     private final String key;

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/model/aeaa/AeaaKevData.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/model/aeaa/AeaaKevData.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2009-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.metaeffekt.core.inventory.processor.report.model.aeaa;
+
+import org.apache.commons.lang3.StringUtils;
+import org.json.JSONObject;
+
+import java.util.Date;
+import java.util.Map;
+
+public class AeaaKevData {
+    private String vulnerability;
+    private String vendor;
+    private String product;
+    private String summary;
+    private String description;
+    private String notes;
+    private String recommendation;
+    private Date publishDate;
+    private Date exploitDate;
+    private Date dueDate;
+    private RansomwareState ransomwareState;
+
+    public AeaaKevData() {
+    }
+
+    public JSONObject toJson() {
+        final JSONObject jsonObject = new JSONObject();
+        jsonObject.put("vulnerability", vulnerability);
+        jsonObject.put("vendor", vendor);
+        jsonObject.put("product", product);
+        jsonObject.put("summary", summary);
+        jsonObject.put("description", description);
+        jsonObject.put("recommendation", recommendation);
+        jsonObject.put("notes", notes);
+        jsonObject.put("publishDate", publishDate == null ? null : publishDate.getTime());
+        jsonObject.put("exploitDate", exploitDate == null ? null : exploitDate.getTime());
+        jsonObject.put("dueDate", dueDate == null ? null : dueDate.getTime());
+        jsonObject.put("knownRansomwareCampaignUse", ransomwareState);
+        return jsonObject;
+    }
+
+    public static AeaaKevData fromJson(JSONObject json) {
+        if (json == null) {
+            return null;
+        }
+        return fromInputMap(json.toMap());
+    }
+
+    public static AeaaKevData fromInputMap(Map<String, Object> map) {
+        final AeaaKevData aeaaKevData = new AeaaKevData();
+        aeaaKevData.setVulnerability((String) map.get("vulnerability"));
+        aeaaKevData.setVendor((String) map.get("vendor"));
+        aeaaKevData.setProduct((String) map.get("product"));
+        aeaaKevData.setSummary((String) map.get("summary"));
+        aeaaKevData.setDescription((String) map.get("description"));
+        aeaaKevData.setRecommendation((String) map.get("recommendation"));
+        aeaaKevData.setNotes((String) map.get("notes"));
+        aeaaKevData.setPublishDate(AeaaTimeUtils.tryParse(map.get("publishDate")));
+        aeaaKevData.setExploitDate(AeaaTimeUtils.tryParse(map.get("exploitDate")));
+        aeaaKevData.setDueDate(AeaaTimeUtils.tryParse(map.get("dueDate")));
+        if (map.containsKey("knownRansomwareCampaignUse")) {
+            aeaaKevData.setRansomwareState(RansomwareState.valueOf((String) map.get("knownRansomwareCampaignUse")));
+        }
+        return aeaaKevData;
+    }
+
+    public static AeaaKevData fromCisaKev(JSONObject json) {
+        final Map<String, Object> map = json.toMap();
+        final AeaaKevData aeaaKevData = new AeaaKevData();
+        aeaaKevData.setVulnerability((String) map.getOrDefault("cveID", null));
+        aeaaKevData.setVendor((String) map.getOrDefault("vendorProject", null));
+        aeaaKevData.setProduct((String) map.getOrDefault("product", null));
+        aeaaKevData.setSummary((String) map.getOrDefault("vulnerabilityName", null));
+        aeaaKevData.setRecommendation((String) map.getOrDefault("requiredAction", null));
+        aeaaKevData.setNotes((String) map.getOrDefault("notes", null));
+        aeaaKevData.setDescription((String) map.getOrDefault("shortDescription", null));
+        // publication date is not used as exploitation date, since CISA does not always publish KEV entries upon known exploitation,
+        // but also sometimes (often) retroactively adds 20-year-old vulnerabilities as exploited vulnerabilities.
+        // https://www.linkedin.com/pulse/epss-gaps-cisa-kev-real-world-examples-stack-aware-url2e/
+        aeaaKevData.setPublishDate(AeaaTimeUtils.tryParse((String) map.getOrDefault("dateAdded", null)));
+        aeaaKevData.setDueDate(AeaaTimeUtils.tryParse((String) map.getOrDefault("dueDate", null)));
+
+        String ransomwareKnown = (String) map.getOrDefault("knownRansomwareCampaignUse", null);
+        if (ransomwareKnown != null) {
+            switch (ransomwareKnown) {
+                case "Known":
+                    aeaaKevData.setRansomwareState(RansomwareState.KNOWN);
+                    break;
+                case "Unknown":
+                default:
+                    aeaaKevData.setRansomwareState(RansomwareState.UNKNOWN);
+            }
+        }
+        return aeaaKevData;
+    }
+
+    public String getFormatedPublishDate() {
+        return AeaaTimeUtils.formatNormalizedDateOnlyDate(publishDate);
+    }
+
+    public String getFormatedDueDate() {
+        return AeaaTimeUtils.formatNormalizedDateOnlyDate(dueDate);
+    }
+
+    private static String returnNullIfEmpty(String string) {
+        return StringUtils.isEmpty(string) ? null : string;
+    }
+
+    public enum RansomwareState {
+        UNKNOWN,
+        KNOWN
+    }
+
+    public String getVulnerability() {
+        return vulnerability;
+    }
+
+    public void setVulnerability(String vulnerability) {
+        this.vulnerability = vulnerability;
+    }
+
+    public String getVendor() {
+        return vendor;
+    }
+
+    public void setVendor(String vendor) {
+        this.vendor = vendor;
+    }
+
+    public String getProduct() {
+        return product;
+    }
+
+    public void setProduct(String product) {
+        this.product = product;
+    }
+
+    public String getSummary() {
+        return summary;
+    }
+
+    public void setSummary(String summary) {
+        this.summary = summary;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getNotes() {
+        return notes;
+    }
+
+    public void setNotes(String notes) {
+        this.notes = notes;
+    }
+
+    public String getRecommendation() {
+        return recommendation;
+    }
+
+    public void setRecommendation(String recommendation) {
+        this.recommendation = recommendation;
+    }
+
+    public Date getPublishDate() {
+        return publishDate;
+    }
+
+    public void setPublishDate(Date publishDate) {
+        this.publishDate = publishDate;
+    }
+
+    public Date getExploitDate() {
+        return exploitDate;
+    }
+
+    public void setExploitDate(Date exploitDate) {
+        this.exploitDate = exploitDate;
+    }
+
+    public Date getDueDate() {
+        return dueDate;
+    }
+
+    public void setDueDate(Date dueDate) {
+        this.dueDate = dueDate;
+    }
+
+    public RansomwareState getRansomwareState() {
+        return ransomwareState;
+    }
+
+    public void setRansomwareState(RansomwareState ransomwareState) {
+        this.ransomwareState = ransomwareState;
+    }
+}
+

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/model/aeaa/AeaaVulnerability.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/model/aeaa/AeaaVulnerability.java
@@ -84,6 +84,7 @@ public class AeaaVulnerability extends AeaaMatchableDetailsAmbDataClass<Vulnerab
     private final Set<AeaaAdvisoryEntry> securityAdvisories = new LinkedHashSet<>();
 
     private final Set<String> tags = new LinkedHashSet<>();
+    private AeaaKevData kevData;
 
     private AeaaVulnerabilityStatus vulnerabilityStatus;
 
@@ -332,6 +333,13 @@ public class AeaaVulnerability extends AeaaMatchableDetailsAmbDataClass<Vulnerab
                 .map(AeaaAdvisoryEntry::getEntrySource)
                 .collect(Collectors.toSet());
     }
+    public void setKevData(AeaaKevData kevData) {
+        this.kevData = kevData;
+    }
+
+    public AeaaKevData getKevData() {
+        return kevData;
+    }
 
     /* CVSS */
 
@@ -576,6 +584,9 @@ public class AeaaVulnerability extends AeaaMatchableDetailsAmbDataClass<Vulnerab
                 }
             }
         }
+        if (vmd.get(AeaaInventoryAttribute.KEV_DATA) != null) {
+            this.setKevData(AeaaKevData.fromJson(new JSONObject(vmd.get(AeaaInventoryAttribute.KEV_DATA))));
+        }
 
         final String tagsString = vmd.get(AeaaInventoryAttribute.TAGS.getKey());
         if (StringUtils.hasText(tagsString)) {
@@ -651,6 +662,12 @@ public class AeaaVulnerability extends AeaaMatchableDetailsAmbDataClass<Vulnerab
                 vmd.set(AeaaInventoryAttribute.VULNERABILITY_REFERENCED_CONTENT_IDS.getKey(), null);
             }
         }
+        if (this.kevData != null) {
+            vmd.set(AeaaInventoryAttribute.KEV_DATA, kevData.toJson().toString());
+        } else {
+            vmd.set(AeaaInventoryAttribute.KEV_DATA, null);
+        }
+
 
         if (!this.tags.isEmpty()) {
             vmd.set(AeaaInventoryAttribute.TAGS.getKey(), String.join(", ", this.tags));
@@ -690,6 +707,8 @@ public class AeaaVulnerability extends AeaaMatchableDetailsAmbDataClass<Vulnerab
 
         this.addReferences(dataClass.getReferences());
         this.addCwes(dataClass.getCwes());
+
+        this.setKevData(dataClass.getKevData());
 
         this.getReferencedContentIds().putAll(dataClass.getReferencedContentIds());
 

--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/macros/inventory-report-vulnerabilities.vm
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/macros/inventory-report-vulnerabilities.vm
@@ -695,3 +695,35 @@
     #end
 #end
 ##
+#macro (kevDataTable $kevData)
+    #if($kevData)
+        <table id="$id">
+            <tgroup cols="4">
+                <colspec colname="COLSPEC0" colnum="1" colwidth="52*" valign="middle"/>
+                <colspec colname="COLSPEC1" colnum="2" colwidth="12*" valign="middle"/>
+                <colspec colname="COLSPEC2" colnum="3" colwidth="10*" valign="middle"/>
+                <colspec colname="COLSPEC3" colnum="4" colwidth="26*" valign="middle"/>
+                <thead>
+                <row>
+                    <entry>Summary</entry>
+                    <entry>Publish Date</entry>
+                    <entry>Due Date</entry>
+                    <entry>Part of Ransomware Campaign</entry>
+                </row>
+                </thead>
+                <tbody>
+                <row>
+                    <entry>$kevData.getSummary()</entry>
+                    <entry>$kevData.getFormatedPublishDate()</entry>
+                    <entry>$kevData.getFormatedDueDate()</entry>
+                    <entry>$kevData.getRansomwareState()</entry>
+                </row>
+                </tbody>
+            </tgroup>
+        </table>
+    #else
+        <p>No KEV Data found.</p>
+    #end
+
+#end
+##

--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/tpc_inventory-vulnerability-details.dita.vt
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/tpc_inventory-vulnerability-details.dita.vt
@@ -32,7 +32,7 @@
     #set ($advisoriesNotices = $vulnerability.getRelatedAdvisoriesOfType("notice", $allAdvisories))
     #set ($advisoriesNews    = $vulnerability.getRelatedAdvisoriesOfType("news", $allAdvisories))
     #set ($otherAdvisories   = $vulnerabilityAdapter.getRelatedAdvisoriesExcluding($allAdvisories, $advisoriesAlerts, $advisoriesNotices, $advisoriesNews))
-
+    #set ($kevData           = $vulnerability.getKevData())
     <topic id="$vulnerabilityName">
         <title>$vulnerabilityName</title>
         <body>
@@ -81,6 +81,16 @@
             </section>
 
         </body>
+
+    <topic id="${vulnerabilityName}-advisories">
+        <title>KEV</title>
+        <body>
+        <section>
+            <p>#kevDataTable($kevData)</p>
+        </section>
+        </body>
+    </topic>
+
         <topic id="${vulnerabilityName}-advisories">
             <title>Advisories</title>
             <body>

--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-statistics-vulnerability/tpc_inventory-vulnerability-statistics.dita.vt
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-statistics-vulnerability/tpc_inventory-vulnerability-statistics.dita.vt
@@ -56,5 +56,37 @@
 #statisticsOverviewTable("vulnerabilities_statistics_table_modified_$report.xmlEscapeStringAttribute($advisoryIdentifier.toLowerCase())", "Context Vulnerability Statistics with $report.xmlEscapeString($advisoryName) Advisories$reportContext.inContextOf()", $vulnerabilities, $advisory, true)
         </p>
 #end
+    <p id="statistics-preface-modified-KEV">
+        The following table shows statistics for the identified vulnerabilities from CISA KEV
+    </p>
+    <p>
+        <table>
+            <title>CISA KEV vulnerabilities statistics</title>
+            <tgroup cols="3">
+                <colspec colname="COLSPEC0" colnum="1" colwidth="1*" valign="middle"/>
+                <colspec colname="COLSPEC1" colnum="2" colwidth="1*" valign="middle"/>
+                <colspec colname="COLSPEC2" colnum="3" colwidth="1*" valign="middle"/>
+                <thead>
+                <row>
+                    <entry>Exploited in the Wild</entry>
+                    <entry>Total</entry>
+                    <entry>Percentage</entry>
+                </row>
+                </thead>
+                <tbody>
+                <row>
+                    <entry>KNOWN</entry>
+                    <entry>$vulnerabilityAdapter.totalOfKevEntries()</entry>
+                    <entry>$vulnerabilityAdapter.percentageOfKev()%</entry>
+                </row>
+                <row>
+                    <entry>UNKNOWN</entry>
+                    <entry>$vulnerabilityAdapter.totalOfNotKevEntries()</entry>
+                    <entry>$vulnerabilityAdapter.percentageOfNotKev()%</entry>
+                </row>
+                </tbody>
+            </tgroup>
+        </table>
+    </p>
     </body>
 </topic>


### PR DESCRIPTION
vulnerability-details and vulnerability-statistics now contain CISA KEV information from inventory


<img width="902" alt="Screenshot 2024-05-10 at 09 44 29" src="https://github.com/org-metaeffekt/metaeffekt-core/assets/161820043/bc75ffa4-99da-4aba-8e78-5852f9d41133">
