### PR TITLE
AEAA-489: Added EPSS Data to pdf report generation

### DIFF
--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/model/aeaa/AeaaEpssData.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/model/aeaa/AeaaEpssData.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2009-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.metaeffekt.core.inventory.processor.report.model.aeaa;
+
+import org.json.JSONObject;
+
+
+public class AeaaEpssData {
+
+    private String vulnerability;
+    private float epssScore;
+    private float percentile;
+
+
+    public static AeaaEpssData fromJson(JSONObject jsonObject) {
+        if (jsonObject == null) {
+            return null;
+        }
+        final AeaaEpssData AeaaEpssData = new AeaaEpssData();
+        AeaaEpssData.setVulnerability((String) jsonObject.get("vulnerability"));
+        AeaaEpssData.setEpssScore(Float.parseFloat((String) jsonObject.get("epssScore")));
+        AeaaEpssData.setPercentile(Float.parseFloat((String) jsonObject.get("percentile")));
+        return AeaaEpssData;
+    }
+
+    public JSONObject toJson() {
+        final JSONObject jsonObject = new JSONObject();
+        jsonObject.put("vulnerability", vulnerability);
+        jsonObject.put("epssScore", String.format("%f", epssScore));
+        jsonObject.put("percentile", String.format("%f", percentile));
+        return jsonObject;
+    }
+
+
+    public void setVulnerability(String vulnerability) {
+        this.vulnerability = vulnerability;
+    }
+
+    public void setEpssScore(float epssScore) {
+        this.epssScore = epssScore;
+    }
+
+    public void setPercentile(float percentile) {
+        this.percentile = percentile;
+    }
+
+    public String getVulnerability(){
+        return vulnerability;
+    }
+
+    public float getEpssScore(){
+        return epssScore;
+    }
+
+    public float getPercentile() {
+        return percentile;
+    }
+}

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/model/aeaa/AeaaInventoryAttribute.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/model/aeaa/AeaaInventoryAttribute.java
@@ -63,7 +63,7 @@ public enum AeaaInventoryAttribute implements AbstractModelBase.Attribute {
     INAPPLICABLE_CVE("Inapplicable CVE"),
     ADDON_CVES("Addon CVEs"),
     KEV_DATA("KEV Data"),
-    EPSS_DATA("Epss Data")
+    EPSS_DATA("EPSS Data")
     ;
 
     private final String key;

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/model/aeaa/AeaaInventoryAttribute.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/model/aeaa/AeaaInventoryAttribute.java
@@ -62,8 +62,8 @@ public enum AeaaInventoryAttribute implements AbstractModelBase.Attribute {
     VULNERABILITIES_FIXED_BY_KB("Vulnerability fixed by KB"),
     INAPPLICABLE_CVE("Inapplicable CVE"),
     ADDON_CVES("Addon CVEs"),
-    KEV_DATA("KEV Data")
-
+    KEV_DATA("KEV Data"),
+    EPSS_DATA("Epss Data")
     ;
 
     private final String key;

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/model/aeaa/AeaaVulnerability.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/model/aeaa/AeaaVulnerability.java
@@ -86,6 +86,8 @@ public class AeaaVulnerability extends AeaaMatchableDetailsAmbDataClass<Vulnerab
     private final Set<String> tags = new LinkedHashSet<>();
     private AeaaKevData kevData;
 
+    private AeaaEpssData epssData;
+
     private AeaaVulnerabilityStatus vulnerabilityStatus;
 
     public AeaaVulnerability() {
@@ -341,6 +343,14 @@ public class AeaaVulnerability extends AeaaMatchableDetailsAmbDataClass<Vulnerab
         return kevData;
     }
 
+    public void setEpssData(AeaaEpssData epssData){
+           this.epssData = epssData;
+    }
+
+    public AeaaEpssData getEpssData(){
+        return epssData;
+    }
+
     /* CVSS */
 
     public CvssVectorSet getCvssVectors() {
@@ -588,6 +598,9 @@ public class AeaaVulnerability extends AeaaMatchableDetailsAmbDataClass<Vulnerab
             this.setKevData(AeaaKevData.fromJson(new JSONObject(vmd.get(AeaaInventoryAttribute.KEV_DATA))));
         }
 
+        if(vmd.get(AeaaInventoryAttribute.EPSS_DATA) != null){
+            this.setEpssData(AeaaEpssData.fromJson(new JSONObject(vmd.get(AeaaInventoryAttribute.EPSS_DATA))));
+        }
         final String tagsString = vmd.get(AeaaInventoryAttribute.TAGS.getKey());
         if (StringUtils.hasText(tagsString)) {
             this.addTags(Arrays.asList(tagsString.split(", ")));
@@ -667,6 +680,11 @@ public class AeaaVulnerability extends AeaaMatchableDetailsAmbDataClass<Vulnerab
         } else {
             vmd.set(AeaaInventoryAttribute.KEV_DATA, null);
         }
+        if(this.epssData != null) {
+            vmd.set(AeaaInventoryAttribute.EPSS_DATA, epssData.toJson().toString());
+        } else {
+            vmd.set(AeaaInventoryAttribute.EPSS_DATA, null);
+        }
 
 
         if (!this.tags.isEmpty()) {
@@ -709,6 +727,9 @@ public class AeaaVulnerability extends AeaaMatchableDetailsAmbDataClass<Vulnerab
         this.addCwes(dataClass.getCwes());
 
         this.setKevData(dataClass.getKevData());
+
+
+        this.setEpssData(dataClass.getEpssData());
 
         this.getReferencedContentIds().putAll(dataClass.getReferencedContentIds());
 

--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/macros/inventory-report-vulnerabilities.vm
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/macros/inventory-report-vulnerabilities.vm
@@ -727,3 +727,11 @@
 
 #end
 ##
+#macro(epssDataTable $epssData)
+    #if($epssData)
+        <p>This Vulnerability has a $String.format('%f', $epssData.getEpssScore())% chance of being exploited in the next 30 days according to FIRST. This Vulnerability ranks in the top $String.format('%.3f', $epssData.getPercentile())% of all Vulnerabilities</p>
+    #else
+        <p>No EPSS Data found.</p>
+    #end
+#end
+##

--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/tpc_inventory-vulnerability-details.dita.vt
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/tpc_inventory-vulnerability-details.dita.vt
@@ -33,6 +33,7 @@
     #set ($advisoriesNews    = $vulnerability.getRelatedAdvisoriesOfType("news", $allAdvisories))
     #set ($otherAdvisories   = $vulnerabilityAdapter.getRelatedAdvisoriesExcluding($allAdvisories, $advisoriesAlerts, $advisoriesNotices, $advisoriesNews))
     #set ($kevData           = $vulnerability.getKevData())
+    #set ($epssData          = $vulnerability.getEpssData())
     <topic id="$vulnerabilityName">
         <title>$vulnerabilityName</title>
         <body>
@@ -54,6 +55,13 @@
                 </body>
             </section>
 ##
+<section>
+    <title>EPSS</title>
+    <body>
+    #epssDataTable($epssData)
+    </body>
+</section>
+
 #if ($utils.notEmpty($vulnerability.getCweString()))
             <section>
                 <title>Weakness</title>


### PR DESCRIPTION
added available EPSS data to vulnerability-details.dita during report generation

<img width="1068" alt="Screenshot 2024-05-21 at 09 02 20" src="https://github.com/org-metaeffekt/metaeffekt-core/assets/161820043/c8c919fa-2c77-463b-ada6-851f33c0e5f6">
