### PR TITLE
AE-765: Vulnerability Priority - Assessment status contributor

### DIFF
--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/adapter/VulnerabilityReportAdapter.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/adapter/VulnerabilityReportAdapter.java
@@ -785,6 +785,16 @@ public class VulnerabilityReportAdapter {
 
     /* PRIORITY SCORE */
 
+    public String getPriorityVulnerabilityStatusReasoning(AeaaVulnerabilityPriorityCalculator.AeaaPriorityScoreResult priorityScoreResult) {
+        if (priorityScoreResult.getCalculator().getVulnerabilityStatus() == null || StringUtils.isEmpty(priorityScoreResult.getCalculator().getVulnerabilityStatus().getStatus())) {
+            return "No vulnerability status available.";
+        }
+
+        final String status = priorityScoreResult.getCalculator().getVulnerabilityStatus().getStatus();
+
+        return "The vulnerability status is <b>" + status + "</b>.";
+    }
+
     public VrEolDisplayInformation getEolReasoning(AeaaVulnerabilityPriorityCalculator.AeaaPriorityScoreResult priorityScoreResult) {
         if (priorityScoreResult.getCalculator().getEolData() == null || priorityScoreResult.getCalculator().getEolData().isEmpty() || priorityScoreResult.getSelectedEolData() == null) {
             return null;

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/configuration/VulnerabilityPriorityScoreConfiguration.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/configuration/VulnerabilityPriorityScoreConfiguration.java
@@ -17,6 +17,7 @@ package org.metaeffekt.core.inventory.processor.report.configuration;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.extern.slf4j.Slf4j;
 import org.json.JSONObject;
 import org.metaeffekt.core.inventory.processor.configuration.ProcessConfiguration;
 import org.metaeffekt.core.inventory.processor.configuration.ProcessMisconfiguration;
@@ -46,6 +47,7 @@ import java.util.Map;
  * <p>
  * Each of these components contributes linearly to the overall vulnerability priority score.
  */
+@Slf4j
 @Data
 @EqualsAndHashCode(callSuper = true)
 public class VulnerabilityPriorityScoreConfiguration extends ProcessConfiguration {
@@ -344,7 +346,14 @@ public class VulnerabilityPriorityScoreConfiguration extends ProcessConfiguratio
 
             public static Entry fromJson(JSONObject json) {
                 final Entry entry = new Entry();
-                json.toMap().forEach((key, value) -> entry.getValues().put(key, (Double) value));
+                json.toMap().forEach((key, value) -> {
+                    if (value instanceof Number) {
+                        entry.setValue(key, ((Number) value).doubleValue());
+                    } else {
+                        log.warn("Invalid value [{}] for vulnerability status score inside vulnerability priority score configuration: {}", value, json);
+                        entry.setValue(key, null);
+                    }
+                });
                 return entry;
             }
         }

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/configuration/VulnerabilityPriorityScoreConfiguration.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/configuration/VulnerabilityPriorityScoreConfiguration.java
@@ -21,8 +21,10 @@ import org.json.JSONObject;
 import org.metaeffekt.core.inventory.processor.configuration.ProcessConfiguration;
 import org.metaeffekt.core.inventory.processor.configuration.ProcessMisconfiguration;
 
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Configuration class responsible for calculating the vulnerability priority score.
@@ -39,8 +41,9 @@ import java.util.List;
  *             <li>With extended support: SUPPORT_VALID=1, SUPPORT_ENDING_SOON=2, EXTENDED_SUPPORT_VALID=3, EXTENDED_SUPPORT_ENDING_SOON=4, EXTENDED_SUPPORT_EXPIRED=5</li>
  *         </ul>
  *         The highest applicable score is selected and added to the priority score.</li>
+ *     <li>The vulnerability status section can be configured to add or set scores for specific status values. This can be used to deescalate <code>void</code> vulnerabilities.</li>
  * </ol>
- *
+ * <p>
  * Each of these components contributes linearly to the overall vulnerability priority score.
  */
 @Data
@@ -50,12 +53,14 @@ public class VulnerabilityPriorityScoreConfiguration extends ProcessConfiguratio
     private EpssConfiguration epss = new EpssConfiguration();
     private KevConfiguration kev = new KevConfiguration();
     private EolConfiguration eol = new EolConfiguration();
+    private VulnerabilityStatusConfiguration vulnerabilityStatus = new VulnerabilityStatusConfiguration();
 
     public JSONObject toJson() {
         return new JSONObject()
                 .put("epss", epss.toJson())
                 .put("kev", kev.toJson())
-                .put("eol", eol.toJson());
+                .put("eol", eol.toJson())
+                .put("vulnerabilityStatus", vulnerabilityStatus.toJson());
     }
 
     private void appendFromJson(JSONObject json) {
@@ -67,6 +72,9 @@ public class VulnerabilityPriorityScoreConfiguration extends ProcessConfiguratio
         }
         if (json.has("eol")) {
             this.setEol(EolConfiguration.fromJson(json.getJSONObject("eol")));
+        }
+        if (json.has("vulnerabilityStatus")) {
+            this.setVulnerabilityStatus(VulnerabilityStatusConfiguration.fromJson(json.getJSONObject("vulnerabilityStatus")));
         }
     }
 
@@ -127,6 +135,7 @@ public class VulnerabilityPriorityScoreConfiguration extends ProcessConfiguratio
         private double f = 0.5;
         private double F = 1.0;
 
+        // do not use lombok annotations for getter/setter, cannot handle lowercase/uppercase naming
         public void setf(double f) {
             this.f = f;
         }
@@ -265,6 +274,78 @@ public class VulnerabilityPriorityScoreConfiguration extends ProcessConfiguratio
                         .put("extendedSupportValid", extendedSupportValid)
                         .put("extendedSupportEndingSoon", extendedSupportEndingSoon)
                         .put("extendedSupportExpired", extendedSupportExpired);
+            }
+        }
+    }
+
+    /**
+     * Configuration class for including vulnerability status in the calculation of the priority score.
+     * <p>
+     * The contribution of the vulnerability status to the priority score is optional and disabled by default (no modification).
+     * The configuration consists of two sections: add and set.
+     * Each section is represented by an object that contains a map of status names to their corresponding scores.
+     * These configured values are used to contribute to the overall priority score.
+     * </p>
+     */
+    @Data
+    public static class VulnerabilityStatusConfiguration {
+        private Entry add = new Entry();
+        private Entry set = new Entry();
+
+        public void clear() {
+            add.getValues().clear();
+            set.getValues().clear();
+        }
+
+        public JSONObject toJson() {
+            return new JSONObject()
+                    .put("add", add.toJson())
+                    .put("set", set.toJson());
+        }
+
+        public static VulnerabilityStatusConfiguration fromJson(JSONObject json) {
+            final VulnerabilityStatusConfiguration configuration = new VulnerabilityStatusConfiguration();
+            if (json.has("add")) configuration.setAdd(Entry.fromJson(json.getJSONObject("add")));
+            if (json.has("set")) configuration.setSet(Entry.fromJson(json.getJSONObject("set")));
+            return configuration;
+        }
+
+        @Data
+        public static class Entry {
+            private Map<String, Double> values = new HashMap<>();
+
+            public void setValue(String key, Double value) {
+                values.put(key.toLowerCase(), value);
+            }
+
+            public Double getValue(String key) {
+                if (key == null) {
+                    if (values.containsKey("null")) {
+                        return values.get("null");
+                    } else if (values.containsKey("none")) {
+                        return values.get("none");
+                    } else {
+                        return null;
+                    }
+                }
+
+                if (values.containsKey(key)) {
+                    return values.get(key);
+                } else if (values.containsKey(key.toLowerCase())) {
+                    return values.get(key.toLowerCase());
+                } else {
+                    return null;
+                }
+            }
+
+            public JSONObject toJson() {
+                return new JSONObject(values);
+            }
+
+            public static Entry fromJson(JSONObject json) {
+                final Entry entry = new Entry();
+                json.toMap().forEach((key, value) -> entry.getValues().put(key, (Double) value));
+                return entry;
             }
         }
     }

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/model/aeaa/score/AeaaVulnerabilityPriorityCalculator.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/model/aeaa/score/AeaaVulnerabilityPriorityCalculator.java
@@ -15,6 +15,7 @@
  */
 package org.metaeffekt.core.inventory.processor.report.model.aeaa.score;
 
+import lombok.Data;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.ObjectUtils;
@@ -32,6 +33,8 @@ import org.metaeffekt.core.inventory.processor.report.model.aeaa.eol.export.Aeaa
 import org.metaeffekt.core.inventory.processor.report.model.aeaa.eol.export.AeaaExportedCycleState;
 import org.metaeffekt.core.inventory.processor.report.model.aeaa.keywords.AeaaKeywordSet;
 import org.metaeffekt.core.inventory.processor.report.model.aeaa.keywords.AeaaVulnerabilityKeywords;
+import org.metaeffekt.core.inventory.processor.report.model.aeaa.vulnerabilitystatus.AeaaVulnerabilityStatus;
+import org.metaeffekt.core.inventory.processor.report.model.aeaa.vulnerabilitystatus.AeaaVulnerabilityStatusHistoryEntry;
 import org.metaeffekt.core.security.cvss.CvssSeverityRanges;
 import org.metaeffekt.core.security.cvss.CvssVector;
 import org.metaeffekt.core.security.cvss.processor.CvssSelectionResult;
@@ -48,6 +51,7 @@ public class AeaaVulnerabilityPriorityCalculator {
     private AeaaKevData kevData;
     private List<AeaaExportedCycleState> eolData;
     private AeaaVulnerabilityKeywords keywords;
+    private AeaaVulnerabilityStatusHistoryEntry vulnerabilityStatus;
 
     public void contribute(CvssVector initialCvss, CvssVector contextCvss) {
         this.baseCvssVector = ObjectUtils.firstNonNull(contextCvss, initialCvss);
@@ -78,6 +82,14 @@ public class AeaaVulnerabilityPriorityCalculator {
         this.keywords = keywords;
     }
 
+    public void contribute(AeaaVulnerabilityStatusHistoryEntry vulnerabilityStatus) {
+        this.vulnerabilityStatus = vulnerabilityStatus;
+    }
+
+    public void contribute(AeaaVulnerabilityStatus vulnerabilityStatus) {
+        this.vulnerabilityStatus = vulnerabilityStatus.getLatestActiveStatusHistoryEntry();
+    }
+
     public AeaaVulnerabilityPriorityCalculator contribute(AeaaVulnerability vulnerability) {
         final CvssSelectionResult cvssSelectionResult = vulnerability.getCvssSelectionResult();
         if (cvssSelectionResult != null) {
@@ -98,6 +110,9 @@ public class AeaaVulnerabilityPriorityCalculator {
         this.keywords = new AeaaVulnerabilityKeywords();
         this.keywords.addKeywords(keywordSets);
 
+        final AeaaVulnerabilityStatus vulnerabilityStatus = vulnerability.getOrCreateNewVulnerabilityStatus();
+        this.vulnerabilityStatus = vulnerabilityStatus.getLatestActiveStatusHistoryEntry();
+
         return this;
     }
 
@@ -112,48 +127,69 @@ public class AeaaVulnerabilityPriorityCalculator {
         private final double resultingScore;
         private final CvssSeverityRanges.SeverityRange resultingSeverityRange;
 
-        private final double cvssScore;
-        private final double keywordScore;
-        private final double epssScore;
-        private final double kevScore;
-        private final double eolScore;
+        private final AeaaScoreContributor cvssScore;
+        private final AeaaScoreContributor keywordScore;
+        private final AeaaScoreContributor epssScore;
+        private final AeaaScoreContributor kevScore;
+        private final AeaaScoreContributor eolScore;
+        private final AeaaScoreContributor vulnerabilityStatusScore;
 
         private String keywordReasoning;
         private String epssReasoning;
         private String kevReasoning;
         private String eolReasoning;
+        private String vulnerabilityStatusReasoning;
 
         private AeaaExportedCycleState selectedEolData;
 
         public AeaaPriorityScoreResult(AeaaVulnerabilityPriorityCalculator calculator, CentralSecurityPolicyConfiguration securityPolicy) {
             this.calculator = calculator;
 
-            this.cvssScore = this.round(this.calculateCvssScore(securityPolicy));
-            this.keywordScore = this.round(this.calculateKeywordScore(securityPolicy));
-            this.epssScore = this.round(this.calculateEpssScore(securityPolicy));
-            this.kevScore = this.round(this.calculateKevScore(securityPolicy));
-            this.eolScore = this.round(this.calculateEolScore(securityPolicy));
+            this.cvssScore = this.calculateCvssScore(securityPolicy);
+            this.keywordScore = this.calculateKeywordScore(securityPolicy);
+            this.epssScore = this.calculateEpssScore(securityPolicy);
+            this.kevScore = this.calculateKevScore(securityPolicy);
+            this.eolScore = this.calculateEolScore(securityPolicy);
+            this.vulnerabilityStatusScore = this.calculateVulnerabilityStatusScore(securityPolicy);
 
-            this.resultingScore = this.round(this.sumIfNotNan(this.cvssScore, this.keywordScore, this.epssScore, this.kevScore, this.eolScore));
+            this.resultingScore = this.round(AeaaScoreContributor.apply(0.0,
+                    this.cvssScore, this.keywordScore, this.epssScore,
+                    this.kevScore, this.eolScore, this.vulnerabilityStatusScore
+            ));
+
             this.resultingSeverityRange = securityPolicy.getPriorityScoreSeverityRanges().getRange(this.resultingScore);
         }
 
         public boolean isElevated() {
-            return Double.isNaN(cvssScore) || cvssScore < resultingScore;
+            final boolean resultingIsHigherThanBase = this.cvssScore.getScore() < this.resultingScore;
+            final boolean resultingIsZero = this.resultingScore == 0.0;
+
+            if (resultingIsZero) {
+                return false;
+            }
+
+            if (resultingIsHigherThanBase) {
+                return true;
+            }
+
+            return false;
         }
 
         public JSONObject toJson() {
             return new JSONObject()
-                    .put("cvssScore", toJsonNum(this.cvssScore))
-                    .put("keywordScore", toJsonNum(this.keywordScore))
-                    .put("epssScore", toJsonNum(this.epssScore))
-                    .put("kevScore", toJsonNum(this.kevScore))
-                    .put("eolScore", toJsonNum(this.eolScore))
-                    .put("resultingScore", toJsonNum(this.resultingScore))
+                    .put("cvssScore", this.cvssScore.toJson())
+                    .put("keywordScore", this.keywordScore.toJson())
+                    .put("epssScore", this.epssScore.toJson())
+                    .put("kevScore", this.kevScore.toJson())
+                    .put("eolScore", this.eolScore.toJson())
+                    .put("resultingScore", Double.isNaN(this.resultingScore) ? 0.0 : this.resultingScore)
+                    .put("vulnerabilityStatusScore", this.vulnerabilityStatusScore.toJson())
                     .put("eolReasoning", this.eolReasoning)
                     .put("epssReasoning", this.epssReasoning)
                     .put("kevReasoning", this.kevReasoning)
-                    .put("keywordReasoning", this.keywordReasoning);
+                    .put("keywordReasoning", this.keywordReasoning)
+                    .put("vulnerabilityStatusReasoning", this.vulnerabilityStatusReasoning)
+                    ;
         }
 
         public List<String> toPrintTable() {
@@ -163,6 +199,7 @@ public class AeaaVulnerabilityPriorityCalculator {
             rows.add(constructMap("Type", "EPSS", "Score", String.valueOf(this.epssScore), "Reasoning", this.epssReasoning));
             rows.add(constructMap("Type", "KEV", "Score", String.valueOf(this.kevScore), "Reasoning", this.kevReasoning));
             rows.add(constructMap("Type", "EOL", "Score", String.valueOf(this.eolScore), "Reasoning", this.eolReasoning));
+            rows.add(constructMap("Type", "Vulnerability Status", "Score", String.valueOf(this.vulnerabilityStatusScore), "Reasoning", this.vulnerabilityStatusReasoning));
             rows.add(constructMap("Type", "Sum", "Score", String.valueOf(this.resultingScore)));
             return Inventory.mapAttributesToHorizontalTable(rows);
         }
@@ -179,28 +216,34 @@ public class AeaaVulnerabilityPriorityCalculator {
             return map;
         }
 
-        private double calculateCvssScore(CentralSecurityPolicyConfiguration securityPolicy) {
-            return applyOrNan(this.calculator.getBaseCvssVector(), CvssVector::getOverallScore);
+        private AeaaScoreContributor calculateCvssScore(CentralSecurityPolicyConfiguration securityPolicy) {
+            return applyOrDefault(this.calculator.getBaseCvssVector(),
+                    (CvssVector cvssVector) -> AeaaScoreContributor.AeaaContributionMode.ADD.create(cvssVector.getOverallScore()),
+                    AeaaScoreContributor.AeaaContributionMode.empty()
+            );
         }
 
-        private double calculateKeywordScore(CentralSecurityPolicyConfiguration securityPolicy) {
-            return applyOrNan(this.calculator.getKeywords(), keywords -> {
+        private AeaaScoreContributor calculateKeywordScore(CentralSecurityPolicyConfiguration securityPolicy) {
+            return applyOrDefault(this.calculator.getKeywords(), keywords -> {
                 this.keywordReasoning = keywords.getKeywordSets().stream().filter(set -> set.getScore() != null).map(set -> {
                     final String title = ObjectUtils.firstNonNull(set.getName(), set.getCategory(), "untitled");
                     return set.getScore() + " (" + title + ")";
                 }).collect(Collectors.joining(" + "));
-                return keywords.getKeywordSets().stream().filter(set -> set.getScore() != null).mapToDouble(AeaaKeywordSet::getScore).sum();
-            });
+
+                final double score = keywords.getKeywordSets().stream().filter(set -> set.getScore() != null).mapToDouble(AeaaKeywordSet::getScore).sum();
+
+                return AeaaScoreContributor.AeaaContributionMode.ADD.create(score);
+            }, AeaaScoreContributor.AeaaContributionMode.empty());
         }
 
-        private double calculateEpssScore(CentralSecurityPolicyConfiguration securityPolicy) {
-            return applyOrNan(this.calculator.getEpssData(), epss -> {
+        private AeaaScoreContributor calculateEpssScore(CentralSecurityPolicyConfiguration securityPolicy) {
+            return applyOrDefault(this.calculator.getEpssData(), epss -> {
                 final double p = epss.getEpssScore();
                 final VulnerabilityPriorityScoreConfiguration.EpssConfiguration epssConfig = securityPolicy.getPriorityScoreConfiguration().getEpss();
 
                 if (p < epssConfig.getMin()) {
                     this.epssReasoning = "The EPSS score is below the minimum threshold (" + epssConfig.getMin() + ")";
-                    return 0.0;
+                    return AeaaScoreContributor.AeaaContributionMode.ADD.create(0.0);
                 }
 
                 final double min = epssConfig.getMin();
@@ -209,24 +252,25 @@ public class AeaaVulnerabilityPriorityCalculator {
 
                 this.epssReasoning = "The EPSS score " + p + " (with min: " + min + ", f: " + f + ", F: " + F + ")" + " is used in [" + f + " + ((" + p + " - " + min + ") / (1.0 - " + min + ")) * (" + F + " - " + f + ")]";
 
-                return f + ((p - min) / (1.0 - min)) * (F - f);
-            });
+                return AeaaScoreContributor.AeaaContributionMode.ADD.create(f + ((p - min) / (1.0 - min)) * (F - f));
+            }, AeaaScoreContributor.AeaaContributionMode.empty());
         }
 
         public static String getEpssFormula() {
             return "f + ((p - min) / (1.0 - min)) * (F - f)";
         }
 
-        private double calculateKevScore(CentralSecurityPolicyConfiguration securityPolicy) {
-            return applyOrNan(this.calculator.getKevData(), kev -> {
+        private AeaaScoreContributor calculateKevScore(CentralSecurityPolicyConfiguration securityPolicy) {
+            return applyOrDefault(this.calculator.getKevData(), kev -> {
                 final VulnerabilityPriorityScoreConfiguration.KevConfiguration kevConfig = securityPolicy.getPriorityScoreConfiguration().getKev();
                 this.kevReasoning = "An exploit is known (" + kevConfig.getExploit() + ")" + (kev.getRansomwareState() == AeaaKevData.RansomwareState.KNOWN ? " + a ransomware campaign is known (" + kevConfig.getRansomware() + ")" : "");
-                return kevConfig.getExploit() + (kev.getRansomwareState() == AeaaKevData.RansomwareState.KNOWN ? kevConfig.getRansomware() : 0.0);
-            });
+                final double score = kevConfig.getExploit() + (kev.getRansomwareState() == AeaaKevData.RansomwareState.KNOWN ? kevConfig.getRansomware() : 0.0);
+                return AeaaScoreContributor.AeaaContributionMode.ADD.create(score);
+            }, AeaaScoreContributor.AeaaContributionMode.empty());
         }
 
-        private double calculateEolScore(CentralSecurityPolicyConfiguration securityPolicy) {
-            return applyOrNan(this.calculator.getEolData(), eolData -> {
+        private AeaaScoreContributor calculateEolScore(CentralSecurityPolicyConfiguration securityPolicy) {
+            return applyOrDefault(this.calculator.getEolData(), eolData -> {
                 final VulnerabilityPriorityScoreConfiguration.EolConfiguration eolConfig = securityPolicy.getPriorityScoreConfiguration().getEol();
 
                 final VulnerabilityPriorityScoreConfiguration.EolConfiguration.NoExtendedSupportConfiguration noExtendedSupportConfig = eolConfig.getNoExtendedSupport();
@@ -303,20 +347,43 @@ public class AeaaVulnerabilityPriorityCalculator {
 
                 if (worseCaseState < 0) {
                     this.eolReasoning = "No EOL data available";
-                    return 0.0;
+                    return AeaaScoreContributor.AeaaContributionMode.empty();
                 }
-                return worseCaseState;
-            });
+                return AeaaScoreContributor.AeaaContributionMode.ADD.create(worseCaseState);
+            }, AeaaScoreContributor.AeaaContributionMode.empty());
         }
 
-        private <T> double applyOrNan(T value, Function<T, Double> function) {
+        private AeaaScoreContributor calculateVulnerabilityStatusScore(CentralSecurityPolicyConfiguration securityPolicy) {
+            return applyOrDefault(this.calculator.getVulnerabilityStatus(), status -> {
+                final VulnerabilityPriorityScoreConfiguration.VulnerabilityStatusConfiguration statusConfig = securityPolicy.getPriorityScoreConfiguration().getVulnerabilityStatus();
+
+                final String statusName = status.getStatus();
+                final Double add = statusConfig.getAdd().getValue(statusName);
+                final Double set = statusConfig.getSet().getValue(statusName);
+
+                if (set != null) {
+                    this.vulnerabilityStatusReasoning = "The status is set to " + statusName + " (" + set + ")";
+                    return AeaaScoreContributor.AeaaContributionMode.SET.create(this.round(set));
+                }
+
+                if (add != null) {
+                    this.vulnerabilityStatusReasoning = "The status is " + statusName + " (" + add + ")";
+                    return AeaaScoreContributor.AeaaContributionMode.ADD.create(this.round(add));
+                }
+
+                this.vulnerabilityStatusReasoning = "The status is " + statusName + " (no score)";
+                return AeaaScoreContributor.AeaaContributionMode.ADD.create(0.0);
+            }, AeaaScoreContributor.AeaaContributionMode.ADD.create(Double.NaN));
+        }
+
+        private <T, R> R applyOrDefault(T value, Function<T, R> function, R defaultValue) {
             if (value == null) {
-                return Double.NaN;
+                return defaultValue;
             }
             if (value instanceof Collection) {
                 final Collection<?> collection = (Collection<?>) value;
                 if (collection.isEmpty()) {
-                    return Double.NaN;
+                    return defaultValue;
                 }
             }
             return function.apply(value);
@@ -326,11 +393,12 @@ public class AeaaVulnerabilityPriorityCalculator {
             return Math.round(d * 10.0) / 10.0;
         }
 
-        private double toJsonNum(Double num) {
-            if (Double.isNaN(num)) {
-                return 0.0;
-            }
-            return num;
+        private static double toJsonNum(AeaaScoreContributor num) {
+            return num.isEmpty() ? 0.0 : num.getScore();
+        }
+
+        private static double toJsonNum(Double num) {
+            return Double.isNaN(num) ? 0.0 : num;
         }
 
         private double sumIfNotNan(Double... values) {
@@ -341,6 +409,81 @@ public class AeaaVulnerabilityPriorityCalculator {
                 }
             }
             return sum;
+        }
+
+        @Data
+        public static class AeaaScoreContributor {
+            private final Double score;
+            private final AeaaContributionMode mode;
+
+            public Double apply(Double score) {
+                if (this.score != null && !Double.isNaN(this.score)) {
+                    switch (this.mode) {
+                        case ADD:
+                            return score + this.score;
+                        case SUBTRACT:
+                            return score - this.score;
+                        case SET:
+                            return this.score;
+                    }
+                }
+
+                return score;
+            }
+
+            public boolean isEmpty() {
+                return Double.isNaN(this.score) || this.score == 0.0;
+            }
+
+            public boolean hasEffect() {
+                return !isEmpty() || this.mode == AeaaContributionMode.SET;
+            }
+
+            public JSONObject toJson() {
+                return new JSONObject()
+                        .put("score", toJsonNum(this.score))
+                        .put("mode", this.mode.name());
+            }
+
+            public static AeaaScoreContributor fromJson(JSONObject json) {
+                return new AeaaScoreContributor(json.getDouble("score"), AeaaContributionMode.valueOf(json.getString("mode")));
+            }
+
+            public static Double apply(double score, AeaaScoreContributor... contributors) {
+                double result = score;
+                for (AeaaScoreContributor contributor : contributors) {
+                    result = contributor.apply(result);
+                }
+                return result;
+            }
+
+            @Override
+            public String toString() {
+                switch (this.mode) {
+                    case ADD:
+                        return isEmpty() ? "0.0" : String.valueOf(this.score);
+                    case SUBTRACT:
+                        return "-" + this.score;
+                    case SET:
+                        return "= " + this.score;
+                }
+
+                return String.valueOf(this.score);
+            }
+
+            public enum AeaaContributionMode {
+                ADD,
+                SUBTRACT,
+                SET;
+
+                public AeaaScoreContributor create(double score) {
+                    return new AeaaScoreContributor(score, this);
+                }
+
+                public static AeaaScoreContributor empty() {
+                    return new AeaaScoreContributor(Double.NaN, ADD);
+                }
+            }
         }
     }
 }

--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/macros/inventory-report-vulnerabilities.vm
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/macros/inventory-report-vulnerabilities.vm
@@ -827,6 +827,19 @@ $eolReasoning.getExtendedSupportEndInfo()</lines>
                     </entry>
                 #end
             </row>
+            <row>
+                <entry>Assessment</entry>
+                #set ($statusReasoning = $vulnerabilityAdapter.getPriorityVulnerabilityStatusReasoning($priorityData))
+                #if ($statusReasoning)
+                    <entry>
+                        $statusReasoning
+                    </entry>
+                #else
+                    <entry>
+                        No assessment information available.
+                    </entry>
+                #end
+            </row>
             </tbody>
         </tgroup>
     </table>


### PR DESCRIPTION
## Vulnerability Priority - Assessment status contributor

The effective vulnerability status can now be evaluated in the priority section to contribute to the priority score of the vulnerability.

The configuration has two properties `add` and `set`.
Each can have any status defined inside them, case does not matter, together with a score modification that should be applied if the status is the latest/effective status on the vulnerability.

An example for this can be seen below, where the vulnerability with a status of `void` is set to `0.0`.

```json
"vulnerabilityStatus": {
  "set": {
    "void": 0.0
  },
  "add":{
    "applicable": 2.0
  }
}
```

<img width="1219" alt="Screenshot 2024-09-20 at 11 18 49" src="https://github.com/user-attachments/assets/2a28cc3c-76da-4535-8949-1342e70ffe76">

On a technical level, this introduces another change: any priority score contributor can now technically not only add, but also set the total priority score. In practice, this only happens with this new provider.