### PR TITLE
AE-773: Effective Security Advisory computation

### DIFF
--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/adapter/VulnerabilityReportAdapter.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/adapter/VulnerabilityReportAdapter.java
@@ -74,10 +74,12 @@ public class VulnerabilityReportAdapter {
         this.securityPolicy = securityPolicy;
 
         this.vInventory = AeaaVulnerabilityContextInventory.fromInventory(inventory);
+        this.vInventory.bakeEffectiveSecurityAdvisoriesOnVulnerabilities();
         this.vInventory.calculateEffectiveCvssVectorsForVulnerabilities(securityPolicy);
         this.vInventory.applyEffectiveVulnerabilityStatus(securityPolicy);
 
         this.vInitialInventory = AeaaVulnerabilityContextInventory.fromInventory(inventory);
+        this.vInitialInventory.bakeEffectiveSecurityAdvisoriesOnVulnerabilities();
         this.vInitialInventory.calculateEffectiveCvssVectorsForVulnerabilities(securityPolicy);
         this.vInitialInventory.getVulnerabilities()
                 .forEach(v -> v.mapCvssSelectionResult(CvssSelectionResult::deriveInitialOnlySelectionResult));

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/model/aeaa/AeaaVulnerability.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/model/aeaa/AeaaVulnerability.java
@@ -122,6 +122,33 @@ public class AeaaVulnerability extends AeaaMatchableDetailsAmbDataClass<Vulnerab
         return sourceIdentifier;
     }
 
+    /**
+     * <p>Compute the effective state of this instance based on the given other instance.
+     * The effective instances is either a new instance or the same instance, depending on the implementation.</p>
+     * <p><i>'Effective'</i> is defined as the state of the instance that is the result of the computation of the
+     * instance and the other instance. What this means specifically is up to the implementation.
+     * This method returns <code>this</code> instance (itself) by default.</p>
+     * <p>The effective instance should not be written back into an inventory, rather should be recalculated whenever
+     * access to the effective instance is required to ensure data is not duplicated or left unmaintained in
+     * inventories. Only use this to generate e.g. vulnerability-specific views on the VAD or other Reports.</p>
+     *
+     * @param other The other instance to compute the effective state from.
+     * @return A new effective instance or the same instance, depending on the implementation.
+     */
+    public AeaaVulnerability computeEffectiveState(AeaaAdvisoryEntry other) {
+        return this;
+    }
+
+    public void bakeEffectiveSecurityAdvisories() {
+        synchronized (this.securityAdvisories) {
+            final Set<AeaaAdvisoryEntry> effective = this.securityAdvisories.stream()
+                    .map(advisory -> advisory.computeEffectiveState(this))
+                    .collect(Collectors.toSet());
+            this.securityAdvisories.clear();
+            this.securityAdvisories.addAll(effective);
+        }
+    }
+
     @Override
     public Map<AeaaVulnerabilityTypeIdentifier<?>, Set<String>> getReferencedVulnerabilities() {
         return referencedVulnerabilities;

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/model/aeaa/AeaaVulnerabilityContextInventory.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/model/aeaa/AeaaVulnerabilityContextInventory.java
@@ -115,6 +115,26 @@ public class AeaaVulnerabilityContextInventory {
         }
     }
 
+    /**
+     * Calling this method will (potentially) fully replace the <code>AeaaVulnerability#securityAdvisories</code> set of
+     * each vulnerability with the effective security advisories.<br>
+     * The {@link AeaaVulnerabilityContextInventory#securityAdvisories} will potentially no longer match with the effective
+     * security advisories of the vulnerabilities after calling this method.<br>
+     * You should only call this method if you no longer want to write the inventory back to the original inventory
+     * instance, as the effective security advisories state should always be recalculated whenever access to them is
+     * needed.
+     * See the {@link AeaaAdvisoryEntry#computeEffectiveState(AeaaVulnerability)} method for more details.
+     */
+    public void bakeEffectiveSecurityAdvisoriesOnVulnerabilities() {
+        synchronized (this.vulnerabilities) {
+            for (AeaaVulnerability vulnerability : this.vulnerabilities) {
+                vulnerability.bakeEffectiveSecurityAdvisories();
+            }
+        }
+        // if this.reAssociateAdvisories() is called, the effective security advisories will be reset to the original
+        // security advisories, re-associating should not be done after calling this method
+    }
+
     /* DATA ACCESS */
 
     public void add(AeaaVulnerability vulnerability) {

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/model/aeaa/advisory/AeaaAdvisoryEntry.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/model/aeaa/advisory/AeaaAdvisoryEntry.java
@@ -135,6 +135,23 @@ public class AeaaAdvisoryEntry extends AeaaMatchableDetailsAmbDataClass<Advisory
         return sourceIdentifier;
     }
 
+    /**
+     * <p>Compute the effective state of this instance based on the given other instance.
+     * The effective instances is either a new instance or the same instance, depending on the implementation.</p>
+     * <p><i>'Effective'</i> is defined as the state of the instance that is the result of the computation of the
+     * instance and the other instance. What this means specifically is up to the implementation.
+     * This method returns <code>this</code> instance (itself) by default.</p>
+     * <p>The effective instance should not be written back into an inventory, rather should be recalculated whenever
+     * access to the effective instance is required to ensure data is not duplicated or left unmaintained in
+     * inventories. Only use this to generate e.g. vulnerability-specific views on the VAD or other Reports.</p>
+     *
+     * @param other The other instance to compute the effective state from.
+     * @return A new effective instance or the same instance, depending on the implementation.
+     */
+    public AeaaAdvisoryEntry computeEffectiveState(AeaaVulnerability other) {
+        return this;
+    }
+
     public AeaaAdvisoryEntry setSummary(String summary) {
         this.summary = summary;
         return this;


### PR DESCRIPTION
See also:
- https://github.com/org-metaeffekt/metaeffekt-artifact-analysis/pull/58

Added option for security advisors to overwrite a method `computeEffectiveState` that will be called from the VAD and Vulnerability Report, which will has the option to return an advisory that differs from the one that would have been displayed originally.

The modified advisory is and should not be used anywhere else, only for generating vulnerability-specific views of the advisory.

An example for this:

```java
@Override
public GhsaAdvisorEntry computeEffectiveState(Vulnerability other) {
    final GhsaAdvisorEntry effective = new GhsaAdvisorEntry();
    effective.setId(getId());
    effective.setSourceIdentifier(getSourceIdentifier());

    effective.setSummary("Effective state of " + getId() + " on " + other.getId());

    return effective;
}
```

will produce this output in the VAD:

<img width="638" alt="Screenshot 2024-09-30 at 11 24 58" src="https://github.com/user-attachments/assets/5cb3821b-fd88-46a6-b2ac-76b55980c9be">