### PR TITLE
Updated "no vulnerabilities" text to "with the active configuration"

### DIFF
--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/tpc_inventory-vulnerability-report.dita.vt
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/tpc_inventory-vulnerability-report.dita.vt
@@ -34,7 +34,7 @@
             <title>$status.getCapitalized()</title>
             <body>
         <p>
-            The following vulnerabilities are considered <codeph>$status.getCapitalized()</codeph> in the given context:
+            The following vulnerabilities are considered <codeph>$status.getCapitalized()</codeph> with the active configuration:
         </p>
         <p>
 #vulnerabilityOverview($status.getAsXmlId(), "$report.xmlEscapeString($status.getCapitalized()) Category$reportContext.inContextOf()", $vulnerabilitiesByStatus.get($status), $status.shouldModifiedCvssBeDisplayed())
@@ -46,7 +46,7 @@
             <title>$status.getCapitalized()</title>
             <body>
         <p>
-            No vulnerabilities are considered <codeph>$report.xmlEscapeString($status.getCapitalized())</codeph> in the given context.
+            No vulnerabilities are considered <codeph>$report.xmlEscapeString($status.getCapitalized())</codeph> with the active configuration.
         </p>
             </body>
         </topic>

--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/tpc_inventory-vulnerability-report.dita.vt
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/tpc_inventory-vulnerability-report.dita.vt
@@ -34,7 +34,7 @@
             <title>$status.getCapitalized()</title>
             <body>
         <p>
-            The following vulnerabilities are considered <codeph>$status.getCapitalized()</codeph> with the active configuration:
+            The following vulnerabilities are considered <codeph>$status.getCapitalized()</codeph> with the given configuration:
         </p>
         <p>
 #vulnerabilityOverview($status.getAsXmlId(), "$report.xmlEscapeString($status.getCapitalized()) Category$reportContext.inContextOf()", $vulnerabilitiesByStatus.get($status), $status.shouldModifiedCvssBeDisplayed())
@@ -46,7 +46,7 @@
             <title>$status.getCapitalized()</title>
             <body>
         <p>
-            No vulnerabilities are considered <codeph>$report.xmlEscapeString($status.getCapitalized())</codeph> with the active configuration.
+            No vulnerabilities are considered <codeph>$report.xmlEscapeString($status.getCapitalized())</codeph> with the given configuration.
         </p>
             </body>
         </topic>


### PR DESCRIPTION
    No vulnerabilities are considered <codeph>$report.xmlEscapeString($status.getCapitalized())</codeph> with the active configuration.
    The following vulnerabilities are considered <codeph>$status.getCapitalized()</codeph> with the active configuration: