### PR TITLE
Several Report fixes

### DIFF
--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/adapter/AssessmentReportAdapter.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/adapter/AssessmentReportAdapter.java
@@ -65,7 +65,7 @@ public class AssessmentReportAdapter {
 
     /* counting and grouping assets */
 
-    public List<GroupedAssetsVulnerabilityCounts> groupAssetsByAssetGroup(Collection<AssetMetaData> assets) {
+    public List<GroupedAssetsVulnerabilityCounts> groupAssetsByAssetGroup(Collection<AssetMetaData> assets, boolean useEffectiveSeverity) {
         return assets.stream()
                 .sorted(Comparator.comparing(this::assetGroupDisplayName, (s, str) -> {
                     // "Other Assets" should be last
@@ -78,7 +78,7 @@ public class AssessmentReportAdapter {
 
                     final List<GroupedAssetVulnerabilityCounts> groupedAssetVulnerabilityCounts = entry.getValue().stream()
                             .map(asset -> {
-                                final VulnerabilityCounts counts = countVulnerabilities(asset, true);
+                                final VulnerabilityCounts counts = countVulnerabilities(asset, useEffectiveSeverity);
                                 final GroupedAssetVulnerabilityCounts groupedAssetCounts = new GroupedAssetVulnerabilityCounts();
                                 groupedAssetCounts.setAsset(asset);
                                 groupedAssetCounts.setAssetGroupDisplayName(entry.getKey());

--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/assessment-report/macros/assessment-report.vm
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/assessment-report/macros/assessment-report.vm
@@ -2,7 +2,7 @@
 ## this will result in the empty lines appearing at the head of the document, which is not allowed in XML.
 ##
 #macro (assetAssessmentSummary $id $assets, $useModifiedSeverity)
-    #set ($assetGroups = $assessmentReportAdapter.groupAssetsByAssetGroup($assets))
+    #set ($assetGroups = $assessmentReportAdapter.groupAssetsByAssetGroup($assets, $useModifiedSeverity))
     #foreach ($group in $assetGroups)
         #assetAssessmentSummaryTable($id $group)
     #end

--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/macros/inventory-report-vulnerabilities.vm
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/en/inventory-report-vulnerability/macros/inventory-report-vulnerabilities.vm
@@ -790,13 +790,13 @@ It ranks in the top <b>$priorityData.getCalculator().getEpssData().getTopRatedPe
                 <entry>
                     #set ($kev = $priorityData.getCalculator().getKevData())
                     #if ($kev)
-                        <lines>This vulnerability, affecting <b>${kev.getVendor()} ${kev.getProduct()}</b>, has been <b>confirmed to have been exploited in the wild</b>.</lines>
+                        <lines>This vulnerability, affecting <b>${$report.xmlEscapeString($kev.getVendor())} ${$report.xmlEscapeString($kev.getProduct())}</b>, has been <b>confirmed to have been exploited in the wild</b>.</lines>
                         #if ($kev.getRansomwareState() == "KNOWN")
                             <lines>Furthermore, it has been <b>identified in ransomware campaigns</b>.</lines>
                         #end
-<lines>  #if ($kev.getSummary())<b>Summary:</b> $kev.getSummary(). #end#if ($kev.getRecommendation())$kev.getRecommendation()#end</lines>
+<lines>  #if ($kev.getSummary())<b>Summary:</b> $report.xmlEscapeString($kev.getSummary()). #end#if ($kev.getRecommendation())$report.xmlEscapeString($kev.getRecommendation())#end</lines>
                         #if ($kev.getNotes())
-                            <lines>  <b>Notes:</b> $kev.getNotes()</lines>
+                            <lines>  <b>Notes:</b> $report.xmlEscapeString($kev.getNotes())</lines>
                         #end
                         #if ($kev.getDueDate())
                             <lines>  <b>Due Date:</b> $vulnerabilityAdapter.formatDate($kev.getDueDate())</lines>

--- a/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/report/adapter/AssessmentReportAdapterTest.java
+++ b/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/report/adapter/AssessmentReportAdapterTest.java
@@ -86,7 +86,7 @@ public class AssessmentReportAdapterTest {
 
         final AssessmentReportAdapter adapter = new AssessmentReportAdapter(testInventory, new CentralSecurityPolicyConfiguration());
 
-        final List<AssessmentReportAdapter.GroupedAssetsVulnerabilityCounts> grouped = adapter.groupAssetsByAssetGroup(testInventory.getAssetMetaData());
+        final List<AssessmentReportAdapter.GroupedAssetsVulnerabilityCounts> grouped = adapter.groupAssetsByAssetGroup(testInventory.getAssetMetaData(), true);
 
         /*for (AssessmentReportAdapter.GroupedAssetsVulnerabilityCounts group : grouped) {
             group.log();


### PR DESCRIPTION
- Grouped asset overview table now properly shows the initial/context severities instead of always the context.
- KEV data is now properly escaped.