### PR TITLE
AE-793: Parameter securityPolicyOverwriteJson

### DIFF
--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/configuration/ProcessConfiguration.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/configuration/ProcessConfiguration.java
@@ -163,6 +163,10 @@ public abstract class ProcessConfiguration {
 
     /* PROPERTY LOADING UTILITY METHODS */
 
+    protected <F, T> T optionalConversion(F value, Function<F, T> converter) {
+        return value != null ? converter.apply(value) : null;
+    }
+
     protected void loadStringProperty(Map<String, Object> properties, String key, Consumer<String> consumer) {
         try {
             if (properties != null && properties.containsKey(key)) {

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/configuration/CentralSecurityPolicyConfiguration.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/configuration/CentralSecurityPolicyConfiguration.java
@@ -527,8 +527,8 @@ public class CentralSecurityPolicyConfiguration extends ProcessConfiguration {
 
         configuration.put("cvssSeverityRanges", cvssSeverityRanges);
         configuration.put("priorityScoreSeverityRanges", priorityScoreSeverityRanges);
-        configuration.put("initialCvssSelector", initialCvssSelector);
-        configuration.put("contextCvssSelector", contextCvssSelector);
+        configuration.put("initialCvssSelector", super.optionalConversion(getInitialCvssSelector(), CvssSelector::toJson));
+        configuration.put("contextCvssSelector", super.optionalConversion(getContextCvssSelector(), CvssSelector::toJson));
         configuration.put("insignificantThreshold", insignificantThreshold);
         configuration.put("includeScoreThreshold", includeScoreThreshold);
         configuration.put("jsonSchemaValidationErrorsHandling", jsonSchemaValidationErrorsHandling);
@@ -686,6 +686,53 @@ public class CentralSecurityPolicyConfiguration extends ProcessConfiguration {
             throw new IOException("Failed to parse security policy configuration file as JSON object from: " + jsonFile.getAbsolutePath() + "\nWith content: " + json, e);
         }
 
+        return fromJson(jsonObject, jsonFile + " - " + json);
+    }
+
+    public static CentralSecurityPolicyConfiguration fromConfiguration(
+            CentralSecurityPolicyConfiguration baseConfiguration,
+            File jsonFile,
+            String jsonOverwrite
+    ) throws IOException {
+
+        if (baseConfiguration != null) {
+            return baseConfiguration;
+        }
+
+        if (jsonFile == null && jsonOverwrite == null) {
+            return new CentralSecurityPolicyConfiguration();
+        }
+
+        final JSONObject effectiveApplyJson = new JSONObject();
+
+        try {
+            if (jsonFile != null) {
+                LOG.info("Reading security policy from securityPolicyFile: file://{}", jsonFile.getAbsolutePath());
+                final JSONObject jsonFromFile = new JSONObject(FileUtils.readFileToString(jsonFile, StandardCharsets.UTF_8));
+                for (String key : jsonFromFile.keySet()) {
+                    effectiveApplyJson.put(key, jsonFromFile.get(key));
+                }
+            }
+        } catch (IOException e) {
+            throw new IOException("Failed to read security policy configuration file from: " + jsonFile.getAbsolutePath(), e);
+        }
+
+        try {
+            if (jsonOverwrite != null) {
+                LOG.info("Applying security policy from securityPolicyJson: {}", String.join("", jsonOverwrite.split("\n")));
+                final JSONObject jsonFromOverwrite = new JSONObject(jsonOverwrite);
+                for (String key : jsonFromOverwrite.keySet()) {
+                    effectiveApplyJson.put(key, jsonFromOverwrite.get(key));
+                }
+            }
+        } catch (Exception e) {
+            throw new IOException("Failed to parse security policy configuration from JSON: " + jsonOverwrite, e);
+        }
+
+        return fromJson(effectiveApplyJson, jsonFile + " - " + effectiveApplyJson);
+    }
+
+    private static CentralSecurityPolicyConfiguration fromJson(JSONObject jsonObject, String errorMessage) throws IOException {
         final CentralSecurityPolicyConfiguration configuration = new CentralSecurityPolicyConfiguration();
         final Map<String, Object> policyConfigurationMap = jsonObject.toMap();
         configuration.setProperties(new LinkedHashMap<>(policyConfigurationMap));
@@ -694,12 +741,11 @@ public class CentralSecurityPolicyConfiguration extends ProcessConfiguration {
         configuration.collectMisconfigurations(misconfigurations);
         if (!misconfigurations.isEmpty()) {
             throw new IOException(
-                    "Security policy configuration file contains a misconfiguration from: " + jsonFile.getAbsolutePath() +
-                            "\nWith content: " + json +
+                    "Security policy configuration file contains a misconfiguration from: " + errorMessage +
+                            "\nWith content: " + jsonObject +
                             "\nWith misconfigurations: " + misconfigurations.stream().map(ProcessMisconfiguration::toString).collect(Collectors.joining("\n"))
             );
         }
-
         return configuration;
     }
 

--- a/plugins/ae-inventory-maven-plugin/src/main/java/org/metaeffekt/core/maven/inventory/mojo/AbstractInventoryReportCreationMojo.java
+++ b/plugins/ae-inventory-maven-plugin/src/main/java/org/metaeffekt/core/maven/inventory/mojo/AbstractInventoryReportCreationMojo.java
@@ -245,11 +245,20 @@ public abstract class AbstractInventoryReportCreationMojo extends AbstractProjec
     private CentralSecurityPolicyConfiguration securityPolicy = new CentralSecurityPolicyConfiguration();
 
     /**
-     * If set, will overwrite the {@link #securityPolicy} with the contents of this file.
+     * If set, will overwrite the {@link #securityPolicy} with the contents of this file.<br>
+     * If the {@link #securityPolicyOverwriteJson} is set, the properties of both will be merged.
      *
      * @parameter
      */
     private File securityPolicyFile;
+
+    /**
+     * If set, will overwrite the {@link #securityPolicy} with the contents of this JSON string.<br>
+     * If the {@link #securityPolicyFile} is set, the properties of both will be merged.
+     *
+     * @parameter
+     */
+    private String securityPolicyOverwriteJson;
 
     /**
      * @parameter default-value="false"
@@ -346,13 +355,16 @@ public abstract class AbstractInventoryReportCreationMojo extends AbstractProjec
         report.setTargetComponentDir(targetComponentDir);
 
         // vulnerability settings
-        if (securityPolicyFile != null) {
-            try {
-                getLog().info("Reading security policy from securityPolicyFile: file://" + securityPolicyFile.getCanonicalPath());
-                securityPolicy = CentralSecurityPolicyConfiguration.fromFile(securityPolicyFile);
-            } catch (Exception e) {
-                throw new RuntimeException("Failed to read securityPolicyFile from file://" + securityPolicyFile.getAbsolutePath() + " " + e.getMessage(), e);
+        try {
+            if (securityPolicyOverwriteJson != null) {
+                getLog().info("Reading security policy from securityPolicyOverwriteJson: " + securityPolicyOverwriteJson);
             }
+            if (securityPolicyFile != null) {
+                getLog().info("Reading security policy from securityPolicyFile: file://" + securityPolicyFile.getCanonicalPath());
+            }
+            securityPolicy = CentralSecurityPolicyConfiguration.fromConfiguration(securityPolicy, securityPolicyFile, securityPolicyOverwriteJson);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to process security policy configuration: " + e.getMessage(), e);
         }
 
         // log the security policy only when it fits the context -->


### PR DESCRIPTION
Please view the Pull Request on Artifact Analysis for more examples and information on the concepts:

- https://github.com/org-metaeffekt/metaeffekt-artifact-analysis/pull/70

---

Added a parameter `securityPolicyOverwriteJson` to:

- `AbstractInventoryReportCreationMojo` (`create-inventory-report`)

It allows overwriting central security policy properties read from the JSON file using a JSON object defined in the xml plugin configuration.