### PR TITLE
AE-798: N/A vulnerabilities "insigificant" --> "in review"

### DIFF
--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/configuration/CentralSecurityPolicyConfiguration.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/configuration/CentralSecurityPolicyConfiguration.java
@@ -344,8 +344,8 @@ public class CentralSecurityPolicyConfiguration extends ProcessConfiguration {
         return this;
     }
 
-    public boolean isVulnerabilityInsignificant(CentralSecurityPolicyConfiguration securityPolicy, AeaaVulnerability vulnerability) {
-        final double insignificantThreshold = securityPolicy.getInsignificantThreshold();
+    public boolean isVulnerabilityInsignificant(AeaaVulnerability vulnerability) {
+        final double insignificantThreshold = this.getInsignificantThreshold();
         if (insignificantThreshold == -1.0) return true;
         final CvssVector vector = vulnerability.getCvssSelectionResult().getSelectedContextIfAvailableOtherwiseInitial();
         if (vector == null) {

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/configuration/CentralSecurityPolicyConfiguration.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/configuration/CentralSecurityPolicyConfiguration.java
@@ -344,11 +344,15 @@ public class CentralSecurityPolicyConfiguration extends ProcessConfiguration {
         return this;
     }
 
-    public boolean isVulnerabilityInsignificant(AeaaVulnerability vulnerability) {
+    public boolean isVulnerabilityInsignificant(CentralSecurityPolicyConfiguration securityPolicy, AeaaVulnerability vulnerability) {
+        final double insignificantThreshold = securityPolicy.getInsignificantThreshold();
         if (insignificantThreshold == -1.0) return true;
         final CvssVector vector = vulnerability.getCvssSelectionResult().getSelectedContextIfAvailableOtherwiseInitial();
-        final double score = vector == null ? 0.0 : vector.getOverallScore();
-        return score < insignificantThreshold;
+        if (vector == null) {
+            return false;
+        } else {
+            return vector.getOverallScore() < insignificantThreshold;
+        }
     }
 
     public double getIncludeScoreThreshold() {


### PR DESCRIPTION
See:

- https://github.com/org-metaeffekt/metaeffekt-artifact-analysis/pull/72

---

Vulnerabilities without score (N/A, caused by missing CVSS vectors) are currently considered `insigificant` if no other status is present.
This PR updates the responsible code to handle these missing CVSS vectors not as `0.0` but as `Integer.MAX_VALUE`, making them `in review` instead.