### PR TITLE
AE-806: AssessmentInventoryMerger now includes security advisories

### DIFF
--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/model/VulnerabilityMetaData.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/model/VulnerabilityMetaData.java
@@ -73,6 +73,9 @@ public class VulnerabilityMetaData extends AbstractModelBase {
         SCORE_BASE("CVSS Initial Base"),
         SCORE_EXPLOITABILITY("CVSS Initial Exploitability"),
         SCORE_IMPACT("CVSS Initial Impact"),
+        // toJson variants of the selected cvss vectors
+        SCORE_INITIAL_SELECTION("CVSS Initial Selection"),
+        SCORE_CONTEXT_SELECTION("CVSS Context Selection"),
 
         WEAKNESS("Weakness"),
         PRODUCT_URIS("Product URIs"),

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/AssessmentInventoryMerger.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/AssessmentInventoryMerger.java
@@ -16,6 +16,7 @@
 package org.metaeffekt.core.inventory.processor.report;
 
 import org.apache.commons.lang3.StringUtils;
+import org.metaeffekt.core.inventory.processor.model.AdvisoryMetaData;
 import org.metaeffekt.core.inventory.processor.model.AssetMetaData;
 import org.metaeffekt.core.inventory.processor.model.Inventory;
 import org.metaeffekt.core.inventory.processor.reader.InventoryReader;
@@ -104,6 +105,17 @@ public class AssessmentInventoryMerger {
                 final Inventory singleInventory = assessmentInventoryMap.get(localUniqueAssessmentId);
                 if (singleInventory != null) {
                     outputInventory.getVulnerabilityMetaData(localUniqueAssessmentId).addAll(singleInventory.getVulnerabilityMetaData());
+                }
+            }
+        }
+
+        // add all security advisories to the output inventory, only once
+        final Set<String> knownAdvisoryIds = new LinkedHashSet<>();
+        for (Inventory inputInventory : collectedInventories.keySet()) {
+            for (AdvisoryMetaData securityAdvisory : inputInventory.getAdvisoryMetaData()) {
+                final String advisoryId = securityAdvisory.get(AdvisoryMetaData.Attribute.NAME);
+                if (knownAdvisoryIds.add(advisoryId)) {
+                    outputInventory.getAdvisoryMetaData().add(securityAdvisory);
                 }
             }
         }


### PR DESCRIPTION
The `AssessmentInventoryMerger` previously did not include the security advisories in the target inventory.
This is an issue for the effective CVSS calculation, since the advisories potentially contain CVSS vectors that need to be applied to the vulnerability CVSS vectors.

This PR changes this to collect a set of unique advisories from all inventories and put them into the target inventory.

---

Added `cvss`, `epssData` and `kevData` fields to conversion keys in vulnerability to remove them from the inventory columns.