### PR TITLE
Report generation Mojo security policy initialization

### DIFF
--- a/plugins/ae-inventory-maven-plugin/src/main/java/org/metaeffekt/core/maven/inventory/mojo/AbstractInventoryReportCreationMojo.java
+++ b/plugins/ae-inventory-maven-plugin/src/main/java/org/metaeffekt/core/maven/inventory/mojo/AbstractInventoryReportCreationMojo.java
@@ -242,7 +242,7 @@ public abstract class AbstractInventoryReportCreationMojo extends AbstractProjec
     /**
      * @parameter
      */
-    private CentralSecurityPolicyConfiguration securityPolicy = new CentralSecurityPolicyConfiguration();
+    private CentralSecurityPolicyConfiguration securityPolicy;
 
     /**
      * If set, will overwrite the {@link #securityPolicy} with the contents of this file.<br>


### PR DESCRIPTION
Removed default security policy initialization from report generation mojo to prevent file and overwrite properties from being ignored.