### PR TITLE
fix: change DocumentDescriptor validation for targetReportDir

### DIFF
--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/document/model/DocumentDescriptor.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/document/model/DocumentDescriptor.java
@@ -93,11 +93,11 @@ public class DocumentDescriptor {
         if (targetReportDir == null) {
             throw new IllegalStateException("The target report directory must be specified.");
         }
-        // check if the targetReportDir is actually a directory
+        // check if the targetReportDir is actually a directory, the targetReportDir may not exist when initialising the
+        // Descriptor, if it does not exist, then the dita generation process for the document creates the directory
         if (targetReportDir.exists() && !targetReportDir.isDirectory()) {
             throw new IllegalStateException("The target report directory must be a directory.");
         }
-        //TODO: revise validation of targetReportDir, what do we anticipate of the targetReportDir?
 
         // validate each inventoryContext
         Set<String> identifiers = new HashSet<>();

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/document/model/DocumentDescriptor.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/document/model/DocumentDescriptor.java
@@ -94,13 +94,13 @@ public class DocumentDescriptor {
             throw new IllegalStateException("The target report directory must be specified.");
         }
         // check if the targetReportDir is actually a directory
-        if (!targetReportDir.isDirectory()) {
+        if (targetReportDir.exists() && !targetReportDir.isDirectory()) {
             throw new IllegalStateException("The target report directory must be a directory.");
         }
         // check if the targetReportDir exists
-        if(!targetReportDir.exists()) {
+      /*  if(!targetReportDir.exists()) {
             throw new IllegalStateException("The target report directory does not exist.");
-        }
+        }*/
 
         // validate each inventoryContext
         Set<String> identifiers = new HashSet<>();

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/document/model/DocumentDescriptor.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/document/model/DocumentDescriptor.java
@@ -97,10 +97,7 @@ public class DocumentDescriptor {
         if (targetReportDir.exists() && !targetReportDir.isDirectory()) {
             throw new IllegalStateException("The target report directory must be a directory.");
         }
-        // check if the targetReportDir exists
-      /*  if(!targetReportDir.exists()) {
-            throw new IllegalStateException("The target report directory does not exist.");
-        }*/
+        //TODO: revise validation of targetReportDir, what do we anticipate of the targetReportDir?
 
         // validate each inventoryContext
         Set<String> identifiers = new HashSet<>();


### PR DESCRIPTION
Quick fix for targetReportDir validation in DocumentDescriptor.java

What do we anticipate when validating the DocumentDescriptor?

a) the targetReportDir must already exist -->  create the targetReportDir in AssetDescriptorDocumentReport

b) the targetReprtDir must not already exist --> remove targetReportDir validation from DocumentDescriptor (currently we rely on produceDita() in InventoryReport.java to create the targetReportDir, the DocumentDescriptor validation is happening earlier, thus failing the check for an existing targetReportDir