### PR TITLE
AE-975-review-report-changes

### DIFF
--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/adapter/AssetReportAdapter.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/adapter/AssetReportAdapter.java
@@ -23,6 +23,8 @@ import org.metaeffekt.core.inventory.processor.model.Artifact;
 import org.metaeffekt.core.inventory.processor.model.AssetMetaData;
 import org.metaeffekt.core.inventory.processor.model.Constants;
 import org.metaeffekt.core.inventory.processor.model.Inventory;
+import org.metaeffekt.core.inventory.processor.report.InventoryReport;
+import org.metaeffekt.core.inventory.processor.report.configuration.ReportConfigurationParameters;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -96,5 +98,22 @@ public class AssetReportAdapter {
             }
         }
         return defaultKeyList;
+    }
+
+    public Map<String, String> getOsiStatusMap(ReportConfigurationParameters configParams) {
+        Map<String, String> osiStatusMap = new HashMap<>();
+        if (configParams.isIncludeInofficialOsiStatus()) {
+            osiStatusMap.put("approved", "approved");
+            osiStatusMap.put("submitted", "submitted");
+            osiStatusMap.put("not submitted", "not submitted");
+            osiStatusMap.put("pending", "pending");
+            osiStatusMap.put("withdrawn", "withdrawn");
+            osiStatusMap.put("rejected", "rejected");
+            osiStatusMap.put("ineligible", "ineligible");
+            osiStatusMap.put("unclear", "unclear");
+        } else {
+            osiStatusMap.put("approved", "approved");
+        }
+        return osiStatusMap;
     }
 }

--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/asset-report-bom/macros/tpc_inventory-license.dita.vm
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/asset-report-bom/macros/tpc_inventory-license.dita.vm
@@ -13,7 +13,6 @@
                       scope="external">$report.xmlEscapeString($license)
                     [external]
                 </xref>
-                .
             #end
         </p>
         <p>
@@ -70,7 +69,7 @@
         </row>
         </thead>
 
-        #set($osiStatusMap = $assetAdapter.getOsiStatusMap($report))
+        #set($osiStatusMap = $assetAdapter.getOsiStatusMap($configParams))
         #set($openCoDEStatusMap = {
             "approved" : "yes",
             "(approved)" : "(yes)",

--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/asset-report-bom/tpc_asset-no-license.dita.vt
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/asset-report-bom/tpc_asset-no-license.dita.vt
@@ -12,8 +12,7 @@
     <p>$utils.getText("asset-report-bom.artifacts-without-license")</p>
 
     <table otherprops="wide" id="table_artifacts">
-        <title>$utils.getText("general.short.artifacts") $reportContext.inContextOf()</title>
-
+        <title>$utils.getText("asset-report-bom.short.artifact-without-license") $reportContext.inContextOf()</title>
         <tgroup cols="2">
             <colspec colname="COLSPEC0" colnum="1" colwidth="45*" />
             <colspec colname="COLSPEC1" colnum="2" colwidth="55*" />

--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/asset-report-bom/tpc_asset-report.dita.vt
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/asset-report-bom/tpc_asset-report.dita.vt
@@ -17,7 +17,6 @@
         <body>
             <p>
                 <table id="asset-$inventory.deriveLicenseId($asset.get("Asset Id"))">
-                <title>$assessmentReportAdapter.assetDisplayType($asset) - $assessmentReportAdapter.assetDisplayName($asset)</title>
                 <tgroup cols="2">
                     <colspec colname="COLSPEC0" colnum="1" colwidth="20*" />
                     <colspec colname="COLSPEC1" colnum="2" colwidth="80*" />

--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/inventory-report-bom/tpc_inventory-artifact-report-effective.dita.vt
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/inventory-report-bom/tpc_inventory-artifact-report-effective.dita.vt
@@ -12,7 +12,6 @@
         <p>$utils.getText("inventory-report-bom.artifact-table-descr")</p>
         <p>
             <table otherprops="wide" id="table_artifacts">
-                <title>$utils.getText("general.short.artifacts") $reportContext.inContextOf()</title>
                 <tgroup cols="3">
                     <colspec colname="COLSPEC0" colnum="1" colwidth="20*" />
                     <colspec colname="COLSPEC1" colnum="2" colwidth="45*" />
@@ -20,7 +19,7 @@
                     <thead>
                         <row>
                             <entry colname="COLSPEC0" valign="top">$utils.getText("general.short.components")</entry>
-                            <entry colname="COLSPEC1" valign="top">$utils.getText("general.short.artifacts") / $utils.getText("general.short.packages") / $utils.getText("general.short.web-modules")</entry>
+                            <entry colname="COLSPEC1" valign="top">$utils.getText("general.short.artifacts")</entry>
                             <entry colname="COLSPEC2" valign="top">$utils.getText("inventory-report-bom.short.effective-licenses")</entry>
                         </row>
                     </thead>

--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/inventory-report-bom/tpc_inventory-license-usage.dita.vt
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/inventory-report-bom/tpc_inventory-license-usage.dita.vt
@@ -2,7 +2,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "http://docs.oasis-open.org/dita/v1.1/OS/dtd/topic.dtd">
 <topic id="tpc_license-usage-$reportContext.id">
-    <title>$reportContext.combinedTitle("License Usage", true)</title>
+    #set($title = $utils.getText("inventory-report-bom.short.license-usage-title"))
+    <title>$reportContext.combinedTitle("$title", true)</title>
     #set($effectiveLicenses=$inventory.evaluateLicenses(false))
     #set($effectiveLicensesRepresented=$inventory.getRepresentedLicenses($effectiveLicenses))
 

--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/inventory-report-bom/tpc_inventory-licenses-effective.dita.vt
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/inventory-report-bom/tpc_inventory-licenses-effective.dita.vt
@@ -12,8 +12,9 @@
 
 <body>
     <p>$utils.getText("inventory-report-bom.different-effective-licenses")</p>
+    <p>$utils.getText("inventory-report-bom.different-effective-licenses-2")</p>
 
-    #if ($inventory.isFootnoteRequired($effectiveLicenses, $effectiveLicensesRepresented))
+        #if ($inventory.isFootnoteRequired($effectiveLicenses, $effectiveLicensesRepresented))
         $utils.getText("inventory-report-bom.different-effective-licenses-footnote")
     #end
 

--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/inventory-report-bom/tpc_inventory-package-report-effective.dita.vt
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/inventory-report-bom/tpc_inventory-package-report-effective.dita.vt
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "http://docs.oasis-open.org/dita/v1.1/OS/dtd/topic.dtd">
 <topic id="tpc_packages-$reportContext.id" xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/">
-    <title>$reportContext.combinedTitle("Packages", true)</title>
+    #set($title = $utils.getText("general.short.packages"))
+    <title>$reportContext.combinedTitle("$title", true)</title>
     <body>
         #set($components=$inventory.evaluateComponentsInContext("package"))
         #set($licensesInEffect=$inventory.evaluateLicenses(false))
@@ -13,7 +14,6 @@
         <p>$utils.getText("inventory-report-bom.package-table-descr")</p>
         <p>
             <table otherprops="wide" id="table_packages">
-                <title>$utils.getText("general.short.packages") $reportContext.inContextOf()</title>
                 <tgroup cols="3">
                     <colspec colname="COLSPEC0" colnum="1" colwidth="20*" />
                     <colspec colname="COLSPEC1" colnum="2" colwidth="45*" />

--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/inventory-report-bom/tpc_inventory-webmodule-report-effective.dita.vt
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/inventory-report-bom/tpc_inventory-webmodule-report-effective.dita.vt
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "http://docs.oasis-open.org/dita/v1.1/OS/dtd/topic.dtd">
 <topic id="tpc_webmodules-$reportContext.id" xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/">
-    <title>$reportContext.combinedTitle("Web Modules", true)</title>
+    #set($title = $utils.getText("general.short.web-modules"))
+    <title>$reportContext.combinedTitle("$title", true)</title>
     <body>
         #set($components=$inventory.evaluateComponentsInContext("web-module"))
         #set($licensesInEffect=$inventory.evaluateLicenses(false))
@@ -13,7 +14,6 @@
         <p>$utils.getText("inventory-report-bom.web-module-table-descr")</p>
         <p>
             <table otherprops="wide" id="table_web_modules">
-                <title>$utils.getText("general.short.web-modules") $reportContext.inContextOf()</title>
                 <tgroup cols="3">
                     <colspec colname="COLSPEC0" colnum="1" colwidth="20*" />
                     <colspec colname="COLSPEC1" colnum="2" colwidth="45*" />

--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/lang/de.properties
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/lang/de.properties
@@ -7,7 +7,7 @@ general.short.asset-type=Softarebestandstyp
 general.short.asset-version=Softwarebestandsversion
 general.short.component=Komponente
 general.short.components=Komponenten
-general.short.number-of-component=Komponenten Anzahl
+general.short.number-of-component=Anzahl
 general.short.packages=Pakete
 general.short.web-modules=Webmodule
 general.short.asset-group=Softwarebestandsgruppe
@@ -41,6 +41,8 @@ general.short.total=Gesamt
 general.short.percentage=Prozent
 general.short.assessed=Bewertet
 general.short.score=Bewertung
+general.short.overall=Gesamt
+
 
 general.assets-empty=Es wurde kein spezifischer Softwarebestand identifiziert
 general.no-affected-components=Es wurden keine betroffenen Artefakte identifiziert.
@@ -60,9 +62,9 @@ assessment-report.vuln-table-descr-unmodified=Die Tabelle zeigt die ursprünglich
 
 #Text Strings present in the asset-report-bom. -------------------------------------------------------------------------
 asset-report-bom.short.contained-components=Enthaltene Komponenten
-asset-report-bom.short.asset-licenses=Softwarebestand Lizenzen
+asset-report-bom.short.asset-licenses=Lizenzübersicht
 asset-report-bom.short.artifact-without-license=Artefakte ohne Lizenz
-asset-report-bom.short.asset-list=Softwarebestandsliste
+asset-report-bom.short.asset-list=Softwarebestand
 asset-report-bom.short.asset-license-expressions=Softwarebestand Lizenzausdrücke
 
 asset-report-bom.license-asset-topic=Die folgende Tabelle listet alle Softwarebestände auf, die unter $report.xmlEscapeString($license) lizenziert sind.
@@ -74,7 +76,7 @@ asset-report-bom.asset-table-foot-note=Lizenzen mit Variationen aber inhaltlich 
 asset-report-bom.open-code-similar=Open CoDE ermöglicht eine abgeleitete Freigabe bei Lizenz-Ähnlichkeit. Siehe <xref href="https://opencode.de/de/wissen/rahmenbedingungen/standardisierte-open-source-lizenzen" type="html" scope="external">https://opencode.de/de/wissen/rahmenbedingungen/standardisierte-open-source-lizenzen</xref> Hinweise zu Lizenz-Ähnlichkeit, Unterpunkt LÄ.4.
 asset-report-bom.license-detail-notice=$license ist repräsentativ für verschiedene Ausprägungen der Lizenz oder des Lizenzausdrucks. In diesem Abschnitt werden alle Ausprägungen von $report.xmlEscapeString($license) aufgelistet.
 asset-report-bom.product-contained-assets=Die Tabelle stellt den Softwarebestand im Umfang von ${product.name} dar. Die einzelnen Positionen werden nachfolgend in einzelnen Abschnitten mit ergänzenden Details aufgeführt.
-asset-report-bom.artifacts-without-license=Bei der Analyse der Daten konnten einem oder mehreren Artefakten keine Lizenz zugeordnet werden. Diese Artefakte werden im Folgenden aufgelistet. Eine Artefakt kann mehreren Positionen im Softwarebestand zugeordnet werden.
+asset-report-bom.artifacts-without-license=Bei der Analyse der Daten konnten einem oder mehreren Artefakten keine Lizenz zugeordnet werden. Diese Artefakte werden im Folgenden aufgelistet. Ein Artefakt kann mehreren Positionen im Softwarebestand zugeordnet werden.
 # ----------------------------------------------------------------------------------------------------------------------
 
 
@@ -92,14 +94,15 @@ inventory-report-bom.short.license-notices=Lizenzhinweise
 inventory-report-bom.short.components-under=Komponenten unter
 inventory-report-bom.short.effective-licenses=Effektive Lizenz(en)
 inventory-report-bom.short.assets-covering=Softwarebestände mit
-inventory-report-bom.short.assets-of-component=Softwarebestände mit Komponente
-inventory-report-bom.short.artifacts-of-component=Artefakte vom Komponenten
+inventory-report-bom.short.assets-of-component=Softwarebestände mit
+inventory-report-bom.short.artifacts-of-component=Artefakte der Komponente
 inventory-report-bom.short.bill-of-materials=Bestandsliste
-inventory-report-bom.short.licenses-in-effect=In Kraft getretene Lizenzen
+inventory-report-bom.short.licenses-in-effect=Effektive Lizenzen
 inventory-report-bom.short.artifact-title=Komponenten ohne Lizenz
+inventory-report-bom.short.license-usage-title=Lizenznutzung
 
 inventory-report-bom.license-artifact-topic=Die folgende Tabelle listet alle Komponenten auf, die unter $license lizenziert sind oder Unterkomponenten unter $license enthalten.
-inventory-report-bom.license-artifact-topic-location=Informationen bezüglich der Lizenz oder des Vertrags befindet sich hier: 
+inventory-report-bom.license-artifact-topic-location=Informationen bezüglich der Lizenz oder des Vertrags befindet sich hier:
 inventory-report-bom.individual-artifact=Keine <abbreviated-form keyref="artifact"/>.
 inventory-report-bom.artifact-table-descr=Die nachfolgende Tabelle führt alle in der Software beinhalteten <abbreviated-form keyref="artifact"/> auf. Die Tabelle ist nach Komponenten organisiert, um die Artefakte zu gruppieren.
 inventory-report-bom.bill-of-materials=In den folgenden Kapiteln werden die Bestandteile der Software zu $reportContext.getReportInventoryName() $reportContext.getReportInventoryVersion() aufgeführt. Eine Lizenzübersicht fasst die als verbindlich bewerteten Lizenzen für $reportContext.reportInventoryName zusammen. Zu jeder Lizenz werden die Artefakte aufgelistet, die mit der Lizenz in Verbindung stehen.
@@ -111,12 +114,13 @@ inventory-report-bom.component-with-no-licenses-title=Komponenten ohne Lizenz $r
 inventory-report-bom.no-component-without-license=Es wurden keine Komponenten ohne Lizenzbezug festgestellt.
 inventory-report-bom.effective-license-table=Lizenzen werden von einzelnen oder mehreren Komponenten genutzt werden. Im Folgenden werden die Komponenten in Bezug zur Lizenz aufgeführt.
 inventory-report-bom.license-variations=$license wird als Repräsentant für alle ähnlichen Lizenzen mit Variationen oder Modifikationen aufgeführt. Im entsprechenden Unterkapitel werden die unterschiedlichen Ausprägungen von $license separat dargestellt.
-inventory-report-bom.different-effective-licenses=Dieses Kapitel stellt die Lizenzen dar, die als effektive und verbindliche Lizenzen im Zusammenhang mit der Software abgeleitet wurden.</p><p>In der Tabelle <xref href="#tpc_license-summary-$reportContext.id/LicenseOptions" type="table">Lizenzoptionen$reportContext.inContextOf()</xref> werden Auswahlmöglichkeiten für den Empfänger der Software dokumentiert.</p><p>Die Tabelle <xref href="#tpc_license-summary-$reportContext.id/LicensesInEffect" type="table">Effektive Lizenzen</xref> beinhaltet die effektiven Lizenzen im Überblick.</p><p>Es ist zu berücksichtigen, dass eine Komponente mehreren effektiven Lizenzen zugeordnet sein kann. Dabei werden die jeweiligen Einzellizenzen als effektive Lizenz geführt. Dies gilt ebenfalls für Einzellizenzen von Lizenzoptionen.</p>
+inventory-report-bom.different-effective-licenses=Dieses Kapitel stellt die Lizenzen dar, die als effektive und verbindliche Lizenzen im Zusammenhang mit der Software abgeleitet wurden. In der Tabelle <xref href="#tpc_license-summary-$reportContext.id/LicenseOptions" type="table">Lizenzoptionen$reportContext.inContextOf()</xref> werden Auswahlmöglichkeiten für den Empfänger der Software dokumentiert. Die Tabelle <xref href="#tpc_license-summary-$reportContext.id/LicensesInEffect" type="table">Effektive Lizenzen</xref> beinhaltet die effektiven Lizenzen im Überblick.
+inventory-report-bom.different-effective-licenses-2=Es ist zu berücksichtigen, dass eine Komponente mehreren effektiven Lizenzen zugeordnet sein kann. Dabei werden die jeweiligen Einzellizenzen als effektive Lizenz geführt. Dies gilt ebenfalls für Einzellizenzen von Lizenzoptionen.
 inventory-report-bom.different-effective-licenses-footnote=<fn id="id-footnote">Lizenzvariationen werden als einzelne Lizenz geführt. Die spezifische Ausprägung der Lizenz kann vom der Standardlizenzvolage abweichen. Die Varianten werden in den entsprechenden Kapitel detailliert.</fn>
 inventory-report-bom.no-individual-package=Keine <abbreviated-form keyref="package"/>.
-inventory-report-bom.package-table-descr=Die nachfolgende Tabelle führt alle in der Software beinhalteten <abbreviated-form keyref="package"/> auf. Die Tabelle ist nach Komponenten organisiert um die Pakete zu gruppieren.
+inventory-report-bom.package-table-descr=Die nachfolgende Tabelle führt alle in der Software beinhalteten <abbreviated-form keyref="package"/> auf. Die Tabelle ist nach Komponenten organisiert, um die Pakete zu gruppieren.
 inventory-report-bom.no-individual-web-module=Keine <abbreviated-form keyref="web-module"/>.
-inventory-report-bom.web-module-table-descr=Die nachfolgende Tabelle führt alle in der Software beinhalteten <abbreviated-form keyref="web-module"/> auf. Die Tabelle ist nach Komponenten organisiert um die Webmodule zu gruppieren.
+inventory-report-bom.web-module-table-descr=Die nachfolgende Tabelle führt alle in der Software beinhalteten <abbreviated-form keyref="web-module"/> auf. Die Tabelle ist nach Komponenten organisiert, um die Webmodule zu gruppieren.
 # ----------------------------------------------------------------------------------------------------------------------
 
 
@@ -126,6 +130,7 @@ inventory-report-diff.short.version-upgrades=Versions-Upgrades
 
 
 #Text Strings present in the inventory-report-vulnerability. -----------------------------------------------------------
+inventory-report-vulnerability.short.vulnerabilites=Schwachstellen
 inventory-report-vulnerability.short.affected-components=Betroffenen Komponenten
 inventory-report-vulnerability.short.creation-date=Erstellungsdatum
 inventory-report-vulnerability.short.update-date=Aktualisierungsdatum

--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/lang/en.properties
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/lang/en.properties
@@ -98,6 +98,7 @@ inventory-report-bom.short.artifacts-of-component=Artifacts of Component
 inventory-report-bom.short.bill-of-materials=Bill of Materials
 inventory-report-bom.short.licenses-in-effect=Licenses in Effect
 inventory-report-bom.short.artifact-title=Components without License
+inventory-report-bom.short.license-usage-title=License Usage
 
 inventory-report-bom.license-artifact-topic=The following table lists all components that are licensed or contain subcomponents under $license.
 inventory-report-bom.license-artifact-topic-location=Information with respect to the license or contract can be found in
@@ -112,7 +113,8 @@ inventory-report-bom.component-with-no-licenses-title=Components without License
 inventory-report-bom.no-component-without-license= No components without license detected.
 inventory-report-bom.effective-license-table=Licenses are used by several or individual components. In the following the components are listed for each effective license.
 inventory-report-bom.license-variations=$license is representative of all licenses with variations, characteristics and modifications of the original license template. In this subchapter, all these license variations, which are represented by the $license, are listed individually
-inventory-report-bom.different-effective-licenses=This chapter outlines the different licenses considered effective within the given context. Table <xref href="#tpc_license-summary-$reportContext.id/LicenseOptions" type="table">License Options$reportContext.inContextOf()</xref> provides an outline of licenses options for the recipient of the software. In <xref href="#tpc_license-summary-$reportContext.id/LicensesInEffect" type="table">Licenses in Effect$reportContext.inContextOf()</xref> provides an overview of the licenses in effect. In the following paragraphs the individual components are listed for each effective license. A component may be subject to several licenses in effect. The individual parts of a license option are also listed as effective license.
+inventory-report-bom.different-effective-licenses=This chapter outlines the different licenses considered effective within the given context. Table <xref href="#tpc_license-summary-$reportContext.id/LicenseOptions" type="table">License Options$reportContext.inContextOf()</xref> provides an outline of licenses options for the recipient of the software. In <xref href="#tpc_license-summary-$reportContext.id/LicensesInEffect" type="table">Licenses in Effect$reportContext.inContextOf()</xref> provides an overview of the licenses in effect. In the following paragraphs the individual components are listed for each effective license.
+inventory-report-bom.different-effective-licenses-2=A component may be subject to several licenses in effect. The individual parts of a license option are also listed as effective license.
 inventory-report-bom.different-effective-licenses-footnote=<fn id="id-footnote">License variations are represented as a single effective license. The concrete license may differ from the standard license template. The variations are detailed in the corresponding paragraphs.</fn>
 inventory-report-bom.no-individual-package=There are no individual <abbreviated-form keyref="package"/>.
 inventory-report-bom.package-table-descr=The following table lists all <abbreviated-form keyref="package"/> included in the software covered by this document. The list is organized by components to group the packages.

--- a/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/ReportLanguagePropertyTest.java
+++ b/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/ReportLanguagePropertyTest.java
@@ -1,0 +1,60 @@
+package org.metaeffekt.core.inventory.processor;
+
+import org.junit.Test;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringReader;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.fail;
+
+public class ReportLanguagePropertyTest {
+
+    public static String[] propertyFiles = { "en.properties", "de.properties" };
+
+    @Test
+    public void testLangFilesHaveSameKeys() throws IOException {
+        Map<String, Set<String>> fileKeys = new HashMap<>();
+        Set<String> allKeys = new HashSet<>();
+
+        for (String file : propertyFiles) {
+            Properties props = loadProperties(file);
+            Set<String> keys = props.stringPropertyNames();
+            fileKeys.put(file, keys);
+            allKeys.addAll(keys);
+        }
+
+        StringBuilder failureMessage = new StringBuilder();
+        for (Map.Entry<String, Set<String>> entry : fileKeys.entrySet()) {
+            Set<String> keys = entry.getValue();
+            Set<String> missing = new HashSet<>(allKeys);
+            missing.removeAll(keys);
+
+            if (!missing.isEmpty()) {
+                failureMessage.append("File '").append(entry.getKey())
+                        .append("' is missing keys: ").append(missing).append("\n");
+            }
+        }
+
+        if (failureMessage.length() > 0) {
+            fail("Properties files do not have the same keys:\n" + failureMessage);
+        }
+    }
+
+    private Properties loadProperties(String resourceName) throws IOException {
+        Properties props = new Properties();
+        try (InputStream is = getClass().getClassLoader().getResourceAsStream("META-INF/templates/lang/" + resourceName)) {
+            if (is == null) {
+                throw new IOException("Resource not found: " + resourceName);
+            }
+            props.load(is);
+        }
+        return props;
+    }
+}

--- a/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/RepositoryReportTest.java
+++ b/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/RepositoryReportTest.java
@@ -447,12 +447,12 @@ public class RepositoryReportTest {
     @Ignore
     @Test
     public void testCreateTestReport_External() throws Exception {
-        final File inventoryDir = new File("<path>");
-        final File reportDir = new File("<path>");
+        final File inventoryDir = new File("/Users/jfuegen/IdeaProjects/h-ham-005-workbench/opt.metaeffekt/workbench/workbench-executor/templates/re32-document-generator/documentation/initial-license-documentation_de/inventories");
+        final File reportDir = new File("/tmp/target");
 
-        configureAndCreateReport(inventoryDir, "<file>",
+        configureAndCreateReport(inventoryDir, "*.xlsx",
                 null, null,
-                reportDir, new InventoryReport());
+                reportDir, new InventoryReport(ReportConfigurationParameters.builder().reportLanguage("de").build()));
     }
 
     @Test


### PR DESCRIPTION
### Report Additions
- introduced `ReportLanguagePropertyTest` to ensure language files contain the same keys.

### Report Fixes
- translation mistakes corrected based on 0.135.x
- formatting of strings
- missing language string keys in `de.properties`
- reintroduced removed method `getOsiStatus()` in `AssetReportAdapter `producing `NullPointerException`

