### PR TITLE
fix: handle more than two consecutive links to parent directories

### DIFF
--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/util/FileUtils.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/util/FileUtils.java
@@ -27,6 +27,7 @@ import org.springframework.util.AntPathMatcher;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -319,10 +320,7 @@ public class FileUtils extends org.apache.commons.io.FileUtils {
 
         if (path.startsWith("/..")) throw new IllegalStateException("Illegal path detected: " + originalPath);
 
-        path = RegExUtils.replaceAll(path, FOLDER_SLASH_DOTDOT_SLASH_PATTERN, "");
-        path = RegExUtils.replaceAll(path, DOT_SLASH_PREFIX_PATTERN, "");
-
-        return path;
+        return Paths.get(path).normalize().toString();
     }
 
     public static String[] scanDirectoryForFolders(File targetDir, String... includes) {

--- a/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/util/FileUtilsTest.java
+++ b/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/util/FileUtilsTest.java
@@ -28,7 +28,7 @@ import static org.metaeffekt.core.util.FileUtils.toAbsoluteOrReferencePath;
 public class FileUtilsTest {
 
     @Test
-    public void canonicializeLinuxPathTest() {
+    public void canonicalizeLinuxPathTest() {
         assertEquals("test", FileUtils.canonicalizeLinuxPath("test"));
         assertEquals("test/test", FileUtils.canonicalizeLinuxPath("test/test"));
         assertEquals("test/test", FileUtils.canonicalizeLinuxPath("test/./test"));
@@ -41,6 +41,7 @@ public class FileUtilsTest {
         assertEquals("test/test", FileUtils.canonicalizeLinuxPath("./test//./test/../././test"));
         assertEquals("test/test", FileUtils.canonicalizeLinuxPath("./test/./test//../././test"));
         assertEquals("test/test", FileUtils.canonicalizeLinuxPath("./test/./test/../././/test"));
+        assertEquals("/base/path/inventories", FileUtils.canonicalizeLinuxPath("/base/path/1st_level/2nd_level/3rd_level/4th_level/../../../../inventories/"));
     }
 
     @Test


### PR DESCRIPTION
I would propose to use the functionality of paths in the background, because its hard for me to find an appropriate regex.