### PR TITLE
AE-1014: Group asset Groups into one if only one-element Groups exist

### DIFF
--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/adapter/AssessmentReportAdapter.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/adapter/AssessmentReportAdapter.java
@@ -63,16 +63,19 @@ public class AssessmentReportAdapter {
     }
 
     public String assetGroupDisplayName(AssetMetaData asset) {
-        return InventoryReport.xmlEscapeString(ObjectUtils.firstNonNull(asset.get("Asset Group"), "Other Assets"));
+        return InventoryReport.xmlEscapeString(ObjectUtils.firstNonNull(asset.get("Asset Group"), DEFAULT_ASSET_GROUP_NAME));
     }
 
     /* counting and grouping assets */
 
+    private final static String DEFAULT_ASSET_GROUP_NAME = "Default";
+
     public List<GroupedAssetsVulnerabilityCounts> groupAssetsByAssetGroup(Collection<AssetMetaData> assets, boolean useEffectiveSeverity) {
-        return assets.stream()
+        final List<GroupedAssetsVulnerabilityCounts> groupedAssets = assets.stream()
                 .sorted(Comparator.comparing(this::assetGroupDisplayName, (s, str) -> {
-                    // "Other Assets" should be last
-                    if (s.equals("Other Assets")) return 1;
+                    // "Default" should be last
+                    if (s.equals(DEFAULT_ASSET_GROUP_NAME)) return 1;
+                    if (str.equals(DEFAULT_ASSET_GROUP_NAME)) return -1;
                     return s.compareToIgnoreCase(str);
                 }))
                 .collect(Collectors.groupingBy(this::assetGroupDisplayName, LinkedHashMap::new, Collectors.toList()))
@@ -93,15 +96,42 @@ public class AssessmentReportAdapter {
                             .collect(Collectors.toList());
 
                     final GroupedAssetsVulnerabilityCounts groupedAssetsCounts = new GroupedAssetsVulnerabilityCounts();
-
                     groupedAssetsCounts.setGroupedAssetVulnerabilityCounts(groupedAssetVulnerabilityCounts);
                     groupedAssetsCounts.setAssetGroupDisplayName(entry.getKey());
                     groupedAssetsCounts.setAssetGroupAsXmlId(InventoryReport.xmlEscapeStringAttribute(entry.getKey()));
-                    groupedAssetsCounts.setTotalVulnerabilityCounts(VulnerabilityCounts.sumFrom(groupedAssetVulnerabilityCounts.stream().map(GroupedAssetVulnerabilityCounts::getTotalCounts).collect(Collectors.toList())));
+                    groupedAssetsCounts.setTotalVulnerabilityCounts(VulnerabilityCounts.sumFrom(groupedAssetVulnerabilityCounts.stream()
+                            .map(GroupedAssetVulnerabilityCounts::getTotalCounts).collect(Collectors.toList())));
 
                     return groupedAssetsCounts;
                 })
                 .collect(Collectors.toList());
+
+        // check if all groups contain exactly one asset
+        final boolean allGroupsHaveOneAsset = !groupedAssets.isEmpty() &&
+                groupedAssets.stream().allMatch(group -> group.getGroupedAssetVulnerabilityCounts().size() == 1);
+        // if all groups have exactly one asset and there are more than one group, combine them into a single group
+        boolean combineIntoOneGroup = allGroupsHaveOneAsset && groupedAssets.size() > 1;
+
+        if (!combineIntoOneGroup) {
+            return groupedAssets;
+        }
+
+        log.debug("Combining all groups into a single group [{}] as all groups have exactly one asset: {}", DEFAULT_ASSET_GROUP_NAME,
+                groupedAssets.stream().map(c -> c.getAssetGroupDisplayName() + " (" + c.getGroupedAssetVulnerabilityCounts().stream().map(GroupedAssetVulnerabilityCounts::getAssetDisplayName).collect(Collectors.joining(", ")) + ")").collect(Collectors.joining(", ")));
+
+        final GroupedAssetsVulnerabilityCounts combinedGroup = new GroupedAssetsVulnerabilityCounts();
+        final List<GroupedAssetVulnerabilityCounts> combinedAssets = groupedAssets.stream()
+                .flatMap(group -> group.getGroupedAssetVulnerabilityCounts().stream())
+                .sorted(Comparator.comparing(GroupedAssetVulnerabilityCounts::getAssetDisplayName))
+                .collect(Collectors.toList());
+
+        combinedGroup.setGroupedAssetVulnerabilityCounts(combinedAssets);
+        combinedGroup.setAssetGroupDisplayName(DEFAULT_ASSET_GROUP_NAME);
+        combinedGroup.setAssetGroupAsXmlId(InventoryReport.xmlEscapeStringAttribute(DEFAULT_ASSET_GROUP_NAME));
+        combinedGroup.setTotalVulnerabilityCounts(VulnerabilityCounts.sumFrom(combinedAssets.stream()
+                .map(GroupedAssetVulnerabilityCounts::getTotalCounts).collect(Collectors.toList())));
+
+        return Collections.singletonList(combinedGroup);
     }
 
     public VulnerabilityCounts countVulnerabilities(AssetMetaData assetMetaData, boolean useEffectiveSeverity) {

--- a/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/report/adapter/AssessmentReportAdapterTest.java
+++ b/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/report/adapter/AssessmentReportAdapterTest.java
@@ -15,6 +15,7 @@
  */
 package org.metaeffekt.core.inventory.processor.report.adapter;
 
+import lombok.extern.slf4j.Slf4j;
 import org.junit.Assert;
 import org.junit.Test;
 import org.metaeffekt.core.inventory.processor.model.AssetMetaData;
@@ -22,8 +23,11 @@ import org.metaeffekt.core.inventory.processor.model.Inventory;
 import org.metaeffekt.core.inventory.processor.model.VulnerabilityMetaData;
 import org.metaeffekt.core.inventory.processor.report.configuration.CentralSecurityPolicyConfiguration;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
+@Slf4j
 public class AssessmentReportAdapterTest {
     @Test
     public void vulnerabilityAssetGroupVulnerabilityCountTest() {
@@ -103,14 +107,14 @@ Asset Group:  group4
 Total Counts: AssessmentReportAdapter.VulnerabilityCounts(criticalCounter=0, highCounter=0, mediumCounter=0, lowCounter=2, noneCounter=2, assessedCounter=4, totalCounter=4)
  - Asset:     asset4 (in group4)
    Counts:    AssessmentReportAdapter.VulnerabilityCounts(criticalCounter=0, highCounter=0, mediumCounter=0, lowCounter=2, noneCounter=2, assessedCounter=4, totalCounter=4)
-Asset Group:  Other Assets
+Asset Group:  Default
 Total Counts: AssessmentReportAdapter.VulnerabilityCounts(criticalCounter=0, highCounter=1, mediumCounter=0, lowCounter=1, noneCounter=2, assessedCounter=4, totalCounter=4)
- - Asset:     asset3 (in Other Assets)
+ - Asset:     asset3 (in Default)
    Counts:    AssessmentReportAdapter.VulnerabilityCounts(criticalCounter=0, highCounter=1, mediumCounter=0, lowCounter=1, noneCounter=2, assessedCounter=4, totalCounter=4)
          */
 
         Assert.assertEquals(3, grouped.size());
-        Assert.assertEquals("Other Assets", grouped.get(2).getAssetGroupDisplayName()); // "Other Assets" should be last
+        Assert.assertEquals("Default", grouped.get(2).getAssetGroupDisplayName()); // "Default" should be last
 
         final AssessmentReportAdapter.GroupedAssetsVulnerabilityCounts group1 = grouped.get(0);
         Assert.assertEquals(new AssessmentReportAdapter.VulnerabilityCounts() {{
@@ -148,6 +152,62 @@ Total Counts: AssessmentReportAdapter.VulnerabilityCounts(criticalCounter=0, hig
             totalCounter = 4;
         }}, otherAssets.totalVulnerabilityCounts);
         Assert.assertEquals("asset3", otherAssets.groupedAssetVulnerabilityCounts.get(0).assetDisplayName);
+    }
+
+    @Test
+    public void testGroupCollapsingWhenEachGroupHasOneAsset() {
+        final Inventory testInventory = new Inventory();
+
+        // Asset 1 in Group A
+        final AssetMetaData asset1 = new AssetMetaData();
+        asset1.set(AssetMetaData.Attribute.ASSET_ID, "asset1");
+        asset1.set(AssetMetaData.Attribute.NAME, "asset1");
+        asset1.set(AssetMetaData.Attribute.ASSESSMENT, "assessment1");
+        asset1.set("Asset Group", "Group A");
+        testInventory.getAssetMetaData().add(asset1);
+        testInventory.getVulnerabilityMetaData("assessment1").add(constructVulnerability("low", "void"));
+
+        // Asset 2 in Group B
+        final AssetMetaData asset2 = new AssetMetaData();
+        asset2.set(AssetMetaData.Attribute.ASSET_ID, "asset2");
+        asset2.set(AssetMetaData.Attribute.NAME, "asset2");
+        asset2.set(AssetMetaData.Attribute.ASSESSMENT, "assessment2");
+        asset2.set("Asset Group", "Group B");
+        testInventory.getAssetMetaData().add(asset2);
+        testInventory.getVulnerabilityMetaData("assessment2").add(constructVulnerability("medium", "applicable"));
+
+        // Asset 3 in Group C
+        final AssetMetaData asset3 = new AssetMetaData();
+        asset3.set(AssetMetaData.Attribute.ASSET_ID, "asset3");
+        asset3.set(AssetMetaData.Attribute.NAME, "asset3");
+        asset3.set(AssetMetaData.Attribute.ASSESSMENT, "assessment3");
+        asset3.set("Asset Group", "Group C");
+        testInventory.getAssetMetaData().add(asset3);
+        testInventory.getVulnerabilityMetaData("assessment3").add(constructVulnerability("high", "not applicable"));
+
+        final AssessmentReportAdapter adapter = new AssessmentReportAdapter(testInventory, new CentralSecurityPolicyConfiguration());
+
+        final List<AssessmentReportAdapter.GroupedAssetsVulnerabilityCounts> grouped = adapter.groupAssetsByAssetGroup(testInventory.getAssetMetaData(), true);
+
+        Assert.assertEquals(1, grouped.size());
+        Assert.assertEquals("Default", grouped.get(0).getAssetGroupDisplayName());
+        Assert.assertEquals(3, grouped.get(0).getGroupedAssetVulnerabilityCounts().size());
+
+        // asset order
+        final List<String> assetNames = grouped.get(0).getGroupedAssetVulnerabilityCounts().stream()
+                .map(AssessmentReportAdapter.GroupedAssetVulnerabilityCounts::getAssetDisplayName)
+                .collect(Collectors.toList());
+        Assert.assertEquals(Arrays.asList("asset1", "asset2", "asset3"), assetNames);
+
+        final AssessmentReportAdapter.VulnerabilityCounts totalCounts = grouped.get(0).getTotalVulnerabilityCounts();
+        log.info("{}", totalCounts);
+        Assert.assertEquals(0, totalCounts.criticalCounter);
+        Assert.assertEquals(0, totalCounts.highCounter);
+        Assert.assertEquals(1, totalCounts.mediumCounter);
+        Assert.assertEquals(0, totalCounts.lowCounter);
+        Assert.assertEquals(2, totalCounts.noneCounter);
+        Assert.assertEquals(3, totalCounts.assessedCounter);
+        Assert.assertEquals(3, totalCounts.totalCounter);
     }
 
     private static int vulnerabilityCount = 0;


### PR DESCRIPTION
- added logic to combine all groups into a single group if each group contains exactly one asset
- default asset group is now `Default` instead of `Other Assets`