### PR TITLE
GenericAssetInventoryProcessor will now properly unescape all underscores from the asset keys

### DIFF
--- a/plugins/ae-inventory-maven-plugin/src/main/java/org/metaeffekt/core/maven/inventory/extractor/GenericAssetInventoryProcessor.java
+++ b/plugins/ae-inventory-maven-plugin/src/main/java/org/metaeffekt/core/maven/inventory/extractor/GenericAssetInventoryProcessor.java
@@ -84,11 +84,8 @@ public class GenericAssetInventoryProcessor extends BaseInventoryProcessor {
         }
 
         for (Map.Entry<String, String> attribute : attributes.entrySet()) {
-
             // handle escaping (_ are spaces, __ are _)
-            String key = attribute.getKey().replaceAll("([^_]+)_([^_]+)", "$1 $2");
-            key = key.replaceAll("([^_]+)__([^_]+)", "$1_$2");
-
+            final String key = unescapeKey(attribute.getKey());
             assetMetaData.set(key, attribute.getValue());
         }
 
@@ -108,6 +105,12 @@ public class GenericAssetInventoryProcessor extends BaseInventoryProcessor {
             targetInventoryFile.getParentFile().mkdirs();
         }
         new InventoryWriter().writeInventory(inventory, targetInventoryFile);
+    }
+
+    public static String unescapeKey(String key) {
+        return key
+                .replaceAll("([^_]+)_([^_])", "$1 $2")
+                .replaceAll("([^_]+)__([^_])", "$1_$2");
     }
 
     public GenericAssetInventoryProcessor withAttributes(Map<String, String> attributes) {

--- a/plugins/ae-inventory-maven-plugin/src/main/java/org/metaeffekt/core/maven/inventory/extractor/GenericAssetInventoryProcessor.java
+++ b/plugins/ae-inventory-maven-plugin/src/main/java/org/metaeffekt/core/maven/inventory/extractor/GenericAssetInventoryProcessor.java
@@ -109,8 +109,8 @@ public class GenericAssetInventoryProcessor extends BaseInventoryProcessor {
 
     public static String unescapeKey(String key) {
         return key
-                .replaceAll("([^_]+)_([^_])", "$1 $2")
-                .replaceAll("([^_]+)__([^_])", "$1_$2");
+                .replaceAll("([^_]+)_(?=[^_])", "$1 ")
+                .replaceAll("([^_]+)__(?=[^_])", "$1_");
     }
 
     public GenericAssetInventoryProcessor withAttributes(Map<String, String> attributes) {

--- a/plugins/ae-inventory-maven-plugin/src/test/java/org/metaeffekt/core/maven/inventory/extractor/GenericAssetInventoryProcessorTest.java
+++ b/plugins/ae-inventory-maven-plugin/src/test/java/org/metaeffekt/core/maven/inventory/extractor/GenericAssetInventoryProcessorTest.java
@@ -150,4 +150,11 @@ public class GenericAssetInventoryProcessorTest {
         Assert.assertEquals("namespace/corporation/level", targetInventory.getAssetMetaData().get(0).get("Asset Path"));
         Assert.assertEquals("ASSESSMENT-01", targetInventory.getAssetMetaData().get(0).get("Assessment Id"));
     }
+
+    @Test
+    public void underscoreKeyHandlingTest() {
+        Assert.assertEquals("test_test_test", GenericAssetInventoryProcessor.unescapeKey("test__test__test"));
+        Assert.assertEquals("test test test", GenericAssetInventoryProcessor.unescapeKey("test_test_test"));
+        Assert.assertEquals("test_test test test_test test_test", GenericAssetInventoryProcessor.unescapeKey("test__test_test test__test_test__test"));
+    }
 }

--- a/plugins/ae-inventory-maven-plugin/src/test/java/org/metaeffekt/core/maven/inventory/extractor/GenericAssetInventoryProcessorTest.java
+++ b/plugins/ae-inventory-maven-plugin/src/test/java/org/metaeffekt/core/maven/inventory/extractor/GenericAssetInventoryProcessorTest.java
@@ -156,5 +156,14 @@ public class GenericAssetInventoryProcessorTest {
         Assert.assertEquals("test_test_test", GenericAssetInventoryProcessor.unescapeKey("test__test__test"));
         Assert.assertEquals("test test test", GenericAssetInventoryProcessor.unescapeKey("test_test_test"));
         Assert.assertEquals("test_test test test_test test_test", GenericAssetInventoryProcessor.unescapeKey("test__test_test test__test_test__test"));
+        Assert.assertEquals("t t t", GenericAssetInventoryProcessor.unescapeKey("t_t_t"));
+        Assert.assertEquals("t_t_t", GenericAssetInventoryProcessor.unescapeKey("t__t__t"));
+        Assert.assertEquals("_", GenericAssetInventoryProcessor.unescapeKey("_"));
+        Assert.assertEquals("__", GenericAssetInventoryProcessor.unescapeKey("__"));
+        Assert.assertEquals("_t", GenericAssetInventoryProcessor.unescapeKey("_t"));
+        Assert.assertEquals("t_", GenericAssetInventoryProcessor.unescapeKey("t_"));
+        Assert.assertEquals("t__", GenericAssetInventoryProcessor.unescapeKey("t__"));
+        Assert.assertEquals("__t", GenericAssetInventoryProcessor.unescapeKey("__t"));
+        Assert.assertEquals("_t___t_", GenericAssetInventoryProcessor.unescapeKey("_t___t_"));
     }
 }


### PR DESCRIPTION
Due to an incorrectly formed regular expression, the keys in the `attach-asset-metadata` plugin would only unescape every odd occurrence of an `_` or `__`. This has been fixed.

The logic has been extracted to allow for individual testing.