### PR TITLE
Fixed split column header duplication

### DIFF
--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/reader/AbstractInventoryReader.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/reader/AbstractInventoryReader.java
@@ -16,10 +16,7 @@
 package org.metaeffekt.core.inventory.processor.reader;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.poi.ss.usermodel.Cell;
-import org.apache.poi.ss.usermodel.CellType;
-import org.apache.poi.ss.usermodel.DataFormatter;
-import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.*;
 import org.metaeffekt.core.inventory.processor.model.*;
 import org.metaeffekt.core.inventory.processor.report.model.aeaa.AeaaInventoryAttribute;
 import org.slf4j.Logger;
@@ -34,6 +31,7 @@ import java.text.DecimalFormatSymbols;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static org.metaeffekt.core.inventory.processor.writer.InventoryWriter.VULNERABILITY_ASSESSMENT_WORKSHEET_PREFIX;
 
@@ -228,6 +226,16 @@ public abstract class AbstractInventoryReader {
             return numericCellDataFormatter.format(cell.getNumericCellValue());
         } else {
             return baseCellDataFormatter.formatCellValue(cell);
+        }
+    }
+
+    protected void populateSerializationContextHeaders(Inventory inventory, Sheet sheet, String contextKey, ParsingContext pc) {
+        final List<String> headerList = pc.columns.stream().filter(col -> !this.isSplitColumn(col)).collect(Collectors.toList());
+        final InventorySerializationContext serializationContext = inventory.getSerializationContext();
+        serializationContext.put(contextKey + ".columnlist", headerList);
+        for (int i = 0; i < headerList.size(); i++) {
+            int width = sheet.getColumnWidth(i);
+            serializationContext.put(contextKey + ".column[" + i + "].width", width);
         }
     }
 }

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/reader/AbstractInventoryReader.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/reader/AbstractInventoryReader.java
@@ -230,11 +230,14 @@ public abstract class AbstractInventoryReader {
     }
 
     protected void populateSerializationContextHeaders(Inventory inventory, Sheet sheet, String contextKey, ParsingContext pc) {
-        final List<String> headerList = pc.columns.stream().filter(col -> !this.isSplitColumn(col)).collect(Collectors.toList());
+        final List<String> headerList = pc.columns;
+        final List<String> filteredHeaderList = headerList.stream().filter(col -> !this.isSplitColumn(col)).collect(Collectors.toList());
+
         final InventorySerializationContext serializationContext = inventory.getSerializationContext();
-        serializationContext.put(contextKey + ".columnlist", headerList);
+        serializationContext.put(contextKey + ".columnlist", filteredHeaderList);
         for (int i = 0; i < headerList.size(); i++) {
-            int width = sheet.getColumnWidth(i);
+            if (!filteredHeaderList.contains(headerList.get(i))) continue;
+            final int width = sheet.getColumnWidth(i);
             serializationContext.put(contextKey + ".column[" + i + "].width", width);
         }
     }

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/reader/XlsInventoryReader.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/reader/XlsInventoryReader.java
@@ -265,13 +265,7 @@ public class XlsInventoryReader extends AbstractInventoryReader {
             }
 
             // read formatting data
-            final List<String> headerList = pc.columns;
-            final InventorySerializationContext serializationContext = inventory.getSerializationContext();
-            serializationContext.put(contextKey + ".columnlist", headerList);
-            for (int i = 0; i < headerList.size(); i++) {
-                int width = sheet.getColumnWidth(i);
-                serializationContext.put(contextKey + ".column[" + i + "].width", width);
-            }
+            populateSerializationContextHeaders(inventory, sheet, contextKey, pc);
         }
     }
 

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/reader/XlsxInventoryReader.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/reader/XlsxInventoryReader.java
@@ -260,13 +260,7 @@ public class XlsxInventoryReader extends AbstractInventoryReader {
             }
 
             // read formatting data
-            final List<String> headerList = pc.columns;
-            final InventorySerializationContext serializationContext = inventory.getSerializationContext();
-            serializationContext.put(contextKey + ".columnlist", headerList);
-            for (int i = 0; i < headerList.size(); i++) {
-                int width = sheet.getColumnWidth(i);
-                serializationContext.put(contextKey + ".column[" + i + "].width", width);
-            }
+            populateSerializationContextHeaders(inventory, sheet, contextKey, pc);
         }
     }
 


### PR DESCRIPTION
Reading an inventory file with split columns and writing it back will cause all split columns to duplicate themselves with a real version and one that is not filled.

Use the below code to test this for yourself.

```java
static final String AB = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
static SecureRandom rnd = new SecureRandom();

public String alphaNum(int len) {
    StringBuilder sb = new StringBuilder(len);
    for (int i = 0; i < len; i++)
        sb.append(AB.charAt(rnd.nextInt(AB.length())));
    return sb.toString();
}

@Test
public void writeExtremelyLongStringTest() throws IOException {
    final Inventory inventory = new Inventory();

    final Artifact artifact = new Artifact();
    artifact.setId("some-id");
    artifact.set("Long Attribute (some parenthesis)", alphaNum(100000));
    inventory.getArtifacts().add(artifact);

    File file1 = new File("inv-1.xlsx");
    File file2 = new File("inv-2.xlsx");
    new InventoryWriter().writeInventory(inventory, file1);
    new InventoryWriter().writeInventory(new InventoryReader().readInventory(file1), file2);
}
```