### PR TITLE
Improve SSVC handling

### DIFF
--- a/libraries/ae-security/src/main/java/org/metaeffekt/core/security/cvss/CvssVector.java
+++ b/libraries/ae-security/src/main/java/org/metaeffekt/core/security/cvss/CvssVector.java
@@ -494,7 +494,6 @@ public abstract class CvssVector {
             return new Cvss3P1(vector);
         } else if (vector.startsWith("CVSS:4.0")) {
             return new Cvss4P0(vector);
-
         } else {
             final Cvss2 potentialCvss2Vector = CvssVector.parseVectorOnlyIfKnownAttributes(vector, Cvss2::new);
             if (potentialCvss2Vector != null) {

--- a/libraries/ae-security/src/main/java/org/metaeffekt/core/security/cvss/CvssVector.java
+++ b/libraries/ae-security/src/main/java/org/metaeffekt/core/security/cvss/CvssVector.java
@@ -512,6 +512,8 @@ public abstract class CvssVector {
 
             if (vector.startsWith("CVSS:")) {
                 LOG.warn("Cannot fully determine CVSS version in vector [{}]", vector);
+            } else if (LOG.isDebugEnabled()) {
+                LOG.debug("Unable to parse non-CVSS vector string [{}]", vector);
             }
 
             return null;

--- a/libraries/ae-security/src/main/java/org/metaeffekt/core/security/cvss/CvssVector.java
+++ b/libraries/ae-security/src/main/java/org/metaeffekt/core/security/cvss/CvssVector.java
@@ -510,7 +510,10 @@ public abstract class CvssVector {
                 return potentialCvss4P0Vector;
             }
 
-            LOG.warn("Cannot fully determine CVSS version in vector [{}]", vector);
+            if (vector.startsWith("CVSS:")) {
+                LOG.warn("Cannot fully determine CVSS version in vector [{}]", vector);
+            }
+
             return null;
         }
     }


### PR DESCRIPTION
I'm filing this as a draft to already start the PR discussion until #245 is resolved.

Note that I consider the commits titled `Return early for unsupported SSVC vectors` and `Only warn about the CVSS version for CVSS vectors` to actually be *alternative solutions* to the same "problem", which is the "Cannot fully determine CVSS version in vector" warning being logged for SSVC vectors (also see [this discussion](https://github.com/org-metaeffekt/metaeffekt-universal-cvss-calculator/issues/11)). As I could not decide between the approaches, I've included both of them, but the final PR should drop the unwanted commit.