### PR TITLE
Fixed CVSS:3.0 vectors serializing into CVSS:3.1 vector strings instead of their version.

### DIFF
--- a/libraries/ae-security/src/main/java/org/metaeffekt/core/security/cvss/CvssVector.java
+++ b/libraries/ae-security/src/main/java/org/metaeffekt/core/security/cvss/CvssVector.java
@@ -23,6 +23,7 @@ import org.metaeffekt.core.security.cvss.processor.BakedCvssVectorScores;
 import org.metaeffekt.core.security.cvss.processor.UniversalCvssCalculatorLinkGenerator;
 import org.metaeffekt.core.security.cvss.v2.Cvss2;
 import org.metaeffekt.core.security.cvss.v3.Cvss3;
+import org.metaeffekt.core.security.cvss.v3.Cvss3P0;
 import org.metaeffekt.core.security.cvss.v3.Cvss3P1;
 import org.metaeffekt.core.security.cvss.v4P0.Cvss4P0;
 import org.slf4j.Logger;
@@ -450,6 +451,8 @@ public abstract class CvssVector {
             throw new IllegalArgumentException("Unknown or unregistered CVSS version: null");
         } else if (Cvss2.class.isAssignableFrom(clazz)) {
             return Cvss2.getVersionName();
+        } else if (Cvss3P0.class.isAssignableFrom(clazz)) {
+            return Cvss3P0.getVersionName();
         } else if (Cvss3P1.class.isAssignableFrom(clazz)) {
             return Cvss3P1.getVersionName();
         } else if (Cvss4P0.class.isAssignableFrom(clazz)) {
@@ -464,6 +467,8 @@ public abstract class CvssVector {
             throw new IllegalArgumentException("Unknown or unregistered CVSS version: null");
         } else if (versionName.equals(Cvss2.getVersionName())) {
             return Cvss2.class;
+        } else if (versionName.equals(Cvss3P0.getVersionName())) {
+            return Cvss3P0.class;
         } else if (versionName.equals(Cvss3P1.getVersionName())) {
             return Cvss3P1.class;
         } else if (versionName.equals(Cvss4P0.getVersionName())) {
@@ -490,8 +495,10 @@ public abstract class CvssVector {
 
         if (vector.startsWith("CVSS:2.0")) {
             return new Cvss2(vector);
-        } else if (vector.startsWith("CVSS:3.1") || vector.startsWith("CVSS:3.0")) {
+        } else if (vector.startsWith("CVSS:3.1")) {
             return new Cvss3P1(vector);
+        } else if (vector.startsWith("CVSS:3.0")) {
+            return new Cvss3P0(vector);
         } else if (vector.startsWith("CVSS:4.0")) {
             return new Cvss4P0(vector);
 

--- a/libraries/ae-security/src/main/java/org/metaeffekt/core/security/cvss/CvssVector.java
+++ b/libraries/ae-security/src/main/java/org/metaeffekt/core/security/cvss/CvssVector.java
@@ -207,10 +207,13 @@ public abstract class CvssVector {
     /* APPLYING VECTORS */
 
     public int applyVector(String vector) {
-        if (vector == null || vector.isEmpty()) return 0;
-
+        if (vector == null) return 0;
         final String normalizedVector = normalizeVector(vector);
-        if (normalizedVector.isEmpty()) return 0;
+        return applyNormalizedVector(normalizedVector);
+    }
+
+    protected int applyNormalizedVector(String normalizedVector) {
+        if (StringUtils.isEmpty(normalizedVector)) return 0;
 
         int appliedCount = 0;
         int start = 0;
@@ -442,8 +445,11 @@ public abstract class CvssVector {
 
     public static <T extends CvssVector> T parseVectorOnlyIfKnownAttributes(String vector, Supplier<T> constructor) {
         final T cvssVector = constructor.get();
-        final int unknownAttributes = cvssVector.applyVector(vector);
-        return unknownAttributes > 0 ? null : cvssVector;
+        final String normalizedVector = normalizeVector(vector);
+        final int knownAttributes = cvssVector.applyNormalizedVector(normalizedVector);
+        final int allAttributes = normalizedVector.split("/").length;
+
+        return allAttributes - knownAttributes > 0 ? null : cvssVector;
     }
 
     public static <T extends CvssVector> String getVersionName(Class<T> clazz) {

--- a/libraries/ae-security/src/main/java/org/metaeffekt/core/security/cvss/v3/Cvss3.java
+++ b/libraries/ae-security/src/main/java/org/metaeffekt/core/security/cvss/v3/Cvss3.java
@@ -754,15 +754,6 @@ public abstract class Cvss3 extends MultiScoreCvssVector {
      */
     public abstract double roundUp(double value);
 
-    public static String getVersionName() {
-        return "CVSS:3.1";
-    }
-
-    @Override
-    public String getName() {
-        return getVersionName();
-    }
-
     /**
      * Depending on whether the environmental or temporal attributes are defined, one of the following two URLs is generated:
      * <pre>

--- a/libraries/ae-security/src/main/java/org/metaeffekt/core/security/cvss/v3/Cvss3P0.java
+++ b/libraries/ae-security/src/main/java/org/metaeffekt/core/security/cvss/v3/Cvss3P0.java
@@ -71,4 +71,13 @@ public final class Cvss3P0 extends Cvss3 {
         }
         return Optional.of(new Cvss3P0(vector));
     }
+
+    public static String getVersionName() {
+        return "CVSS:3.0";
+    }
+
+    @Override
+    public String getName() {
+        return Cvss3P0.getVersionName();
+    }
 }

--- a/libraries/ae-security/src/main/java/org/metaeffekt/core/security/cvss/v3/Cvss3P1.java
+++ b/libraries/ae-security/src/main/java/org/metaeffekt/core/security/cvss/v3/Cvss3P1.java
@@ -75,4 +75,13 @@ public final class Cvss3P1 extends Cvss3 {
         }
         return Optional.of(new Cvss3P1(vector));
     }
+
+    public static String getVersionName() {
+        return "CVSS:3.1";
+    }
+
+    @Override
+    public String getName() {
+        return Cvss3P1.getVersionName();
+    }
 }

--- a/libraries/ae-security/src/test/java/org/metaeffekt/core/security/cvss/CvssVectorTest.java
+++ b/libraries/ae-security/src/test/java/org/metaeffekt/core/security/cvss/CvssVectorTest.java
@@ -248,4 +248,12 @@ public class CvssVectorTest {
         gen.addVector(result, "result", true);
         return gen;
     }
+
+    @Test
+    public void vectorVersionTest() {
+        Assert.assertEquals("CVSS:3.0", Cvss3P0.getVersionName());
+        Assert.assertEquals("CVSS:3.0", new Cvss3P0().getName());
+        Assert.assertEquals("CVSS:3.1", Cvss3P1.getVersionName());
+        Assert.assertEquals("CVSS:3.1", new Cvss3P1().getName());
+    }
 }

--- a/libraries/ae-security/src/test/java/org/metaeffekt/core/security/cvss/CvssVectorTest.java
+++ b/libraries/ae-security/src/test/java/org/metaeffekt/core/security/cvss/CvssVectorTest.java
@@ -256,4 +256,29 @@ public class CvssVectorTest {
         Assert.assertEquals("CVSS:3.1", Cvss3P1.getVersionName());
         Assert.assertEquals("CVSS:3.1", new Cvss3P1().getName());
     }
+
+    @Test
+    public void parseVectorWithUnknownPartsTest() {
+        Assert.assertNull(CvssVector.parseVector("AV:P/AC:L/AT:P/PR:H/UI:P/VC:N/VI:N/VA:N/SC:N/SI:N/SA:H/NO:O"));
+        Assert.assertNull(CvssVector.parseVector("AR:N/NO:O"));
+    }
+
+    @Test
+    public void parseVectorWithKnownPartsTest() {
+        Assert.assertEquals(
+                Cvss2.parseVector("AV:N/AC:L/Au:N/C:P/I:N/A:N/E:U/RL:W/RC:UR/CDP:L/TD:M/CR:M/IR:H/AR:L"),
+                CvssVector.parseVector("AV:N/AC:L/Au:N/C:P/I:N/A:N/E:U/RL:W/RC:UR/CDP:L/TD:M/CR:M/IR:H/AR:L"));
+        Assert.assertEquals(
+                Cvss3P0.parseVector("CVSS:3.0/AV:P/AC:H/PR:L/UI:R/S:C/C:H/I:L/A:H"),
+                CvssVector.parseVector("CVSS:3.0/AV:P/AC:H/PR:L/UI:R/S:C/C:H/I:L/A:H"));
+        Assert.assertEquals(
+                Cvss3P1.parseVector("CVSS:3.1/AV:N/AC:L/PR:H/UI:R/S:U/C:L/I:N/A:L"),
+                CvssVector.parseVector("CVSS:3.1/AV:N/AC:L/PR:H/UI:R/S:U/C:L/I:N/A:L"));
+        Assert.assertEquals(
+                Cvss3P1.parseVector("AV:N/AC:L/PR:H/UI:R/S:U/C:L/I:N/A:L"),
+                CvssVector.parseVector("AV:N/AC:L/PR:H/UI:R/S:U/C:L/I:N/A:L"));
+        Assert.assertEquals(
+                Cvss4P0.parseVector("CVSS:4.0/AV:P/AC:L/AT:P/PR:H/UI:P/VC:N/VI:N/VA:N/SC:N/SI:N/SA:H"),
+                CvssVector.parseVector("CVSS:4.0/AV:P/AC:L/AT:P/PR:H/UI:P/VC:N/VI:N/VA:N/SC:N/SI:N/SA:H"));
+    }
 }

--- a/libraries/ae-security/src/test/java/org/metaeffekt/core/security/cvss/v3/Cvss3P0Test.java
+++ b/libraries/ae-security/src/test/java/org/metaeffekt/core/security/cvss/v3/Cvss3P0Test.java
@@ -17,6 +17,8 @@ package org.metaeffekt.core.security.cvss.v3;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.metaeffekt.core.security.cvss.CvssVector;
+import org.metaeffekt.core.security.cvss.MultiScoreCvssVector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -163,6 +165,13 @@ public class Cvss3P0Test {
             Assert.assertEquals(cvss3P0.getBaseScore(), base, 0.01);
             Assert.assertEquals(cvss3P0.getTemporalScore(), temporal, 0.01);
             Assert.assertEquals(cvss3P0.getEnvironmentalScore(), enviromental, 0.01);
+
+            MultiScoreCvssVector reParsed = (MultiScoreCvssVector) CvssVector.parseVector(cvss3P0.toString());
+            Assert.assertEquals(reParsed.toString(), cvss3P0.toString());
+            Assert.assertTrue(reParsed + " " + cvss3P0, reParsed.toString().startsWith("CVSS:3.0/"));
+            Assert.assertEquals(reParsed.getBaseScore(), base, 0.01);
+            Assert.assertEquals(reParsed.getTemporalScore(), temporal, 0.01);
+            Assert.assertEquals(reParsed.getEnvironmentalScore(), enviromental, 0.01);
         }
     }
 }


### PR DESCRIPTION
> closes #242

- the `Cvss3.toString()` method will now use the proper CVSS version of the vector instead of hard-coding CVSS:3.1 as the schema version
- the `CvssVector.parseVector(String)` method will now properly recognize CVSS:3.0 vectors and parse them accordingly instead of using the CVSS:3.1 spec to evaluate them

> closes #181

- applied metric count must match input vector metric count when applying only metrics that are known