### PR TITLE
#253 Strict Vector parsing and full string serialization

### DIFF
--- a/libraries/ae-security/src/main/java/org/metaeffekt/core/security/cvss/CvssVector.java
+++ b/libraries/ae-security/src/main/java/org/metaeffekt/core/security/cvss/CvssVector.java
@@ -503,7 +503,7 @@ public abstract class CvssVector {
      * </ol>
      * If the <code>strict</code> parameter is set to true, only fully valid vectors are parsed and for others, <code>null</code> is returned.
      *
-     * @param vector   the vector to parse
+     * @param vector the vector to parse
      * @param strict whether <code>null</code> should be returned instead of a partial vector when the vector contains unknown/invalid metrics
      * @return the parsed vector or <code>null</code> if the vector could not be parsed
      */
@@ -557,6 +557,8 @@ public abstract class CvssVector {
     }
 
     /* SERIALIZATION */
+
+    public abstract String toString(boolean filterUndefinedProperties);
 
     public JSONObject toJson() {
         final JSONObject json = new JSONObject();

--- a/libraries/ae-security/src/main/java/org/metaeffekt/core/security/cvss/CvssVector.java
+++ b/libraries/ae-security/src/main/java/org/metaeffekt/core/security/cvss/CvssVector.java
@@ -485,28 +485,43 @@ public abstract class CvssVector {
     }
 
     /**
-     * Attempts to parse the given vector. This is split into two steps:
-     * <ol>
-     *     <li>Try to discover the vector version using the prefix (e.g. <code>CVSS:3.1</code>)</li>
-     *     <li>Attempt to find a vector implementation that can parse all attributes on the vector, uses the {@link #parseVectorOnlyIfKnownAttributes(String, Supplier)} method</li>
-     * </ol>
+     * See overload {@link CvssVector#parseVector(String, boolean)} for more details.
+     * The <code>strict</code> parameter is set to false, meaning this method will always return a vector if the version is specified explicitly, even if it contains unknown metrics.
      *
      * @param vector the vector to parse
      * @return the parsed vector or <code>null</code> if the vector could not be parsed
      */
     public static CvssVector parseVector(String vector) {
+        return parseVector(vector, false);
+    }
+
+    /**
+     * Attempts to parse the given vector. This is split into two steps:
+     * <ol>
+     *     <li>Try to discover the vector version using the prefix (e.g. <code>CVSS:3.1</code>)</li>
+     *     <li>Attempt to find a vector implementation that can parse all attributes on the vector, uses the {@link #parseVectorOnlyIfKnownAttributes(String, Supplier)} method</li>
+     * </ol>
+     * If the <code>strict</code> parameter is set to true, only fully valid vectors are parsed and for others, <code>null</code> is returned.
+     *
+     * @param vector   the vector to parse
+     * @param strict whether <code>null</code> should be returned instead of a partial vector when the vector contains unknown/invalid metrics
+     * @return the parsed vector or <code>null</code> if the vector could not be parsed
+     */
+    public static CvssVector parseVector(String vector, boolean strict) {
         if (vector == null || StringUtils.isEmpty(vector)) {
             return null;
         }
 
+        final Supplier<CvssVector> constructor;
         if (vector.startsWith("CVSS:2.0")) {
-            return new Cvss2(vector);
+            constructor = Cvss2::new;
         } else if (vector.startsWith("CVSS:3.1")) {
-            return new Cvss3P1(vector);
+            constructor = Cvss3P1::new;
         } else if (vector.startsWith("CVSS:3.0")) {
-            return new Cvss3P0(vector);
+            constructor = Cvss3P0::new;
         } else if (vector.startsWith("CVSS:4.0")) {
-            return new Cvss4P0(vector);
+            constructor = Cvss4P0::new;
+
         } else {
             final Cvss2 potentialCvss2Vector = CvssVector.parseVectorOnlyIfKnownAttributes(vector, Cvss2::new);
             if (potentialCvss2Vector != null) {
@@ -530,6 +545,14 @@ public abstract class CvssVector {
             }
 
             return null;
+        }
+
+        if (strict) {
+            return CvssVector.parseVectorOnlyIfKnownAttributes(vector, constructor);
+        } else {
+            final CvssVector inst = constructor.get();
+            inst.applyVector(vector);
+            return inst;
         }
     }
 

--- a/libraries/ae-security/src/main/java/org/metaeffekt/core/security/cvss/v2/Cvss2.java
+++ b/libraries/ae-security/src/main/java/org/metaeffekt/core/security/cvss/v2/Cvss2.java
@@ -601,23 +601,25 @@ public final class Cvss2 extends MultiScoreCvssVector {
     }
 
     @Override
-    public String toString() {
+    public String toString(boolean filterUndefinedProperties) {
         final StringBuilder vector = new StringBuilder();
 
-        appendIfValid(vector, "AV", accessVector.shortIdentifier);
-        appendIfValid(vector, "AC", accessComplexity.shortIdentifier);
-        appendIfValid(vector, "Au", authentication.shortIdentifier);
-        appendIfValid(vector, "C", confidentialityImpact.shortIdentifier);
-        appendIfValid(vector, "I", integrityImpact.shortIdentifier);
-        appendIfValid(vector, "A", availabilityImpact.shortIdentifier);
-        appendIfValid(vector, "E", exploitability.shortIdentifier);
-        appendIfValid(vector, "RL", remediationLevel.shortIdentifier);
-        appendIfValid(vector, "RC", reportConfidence.shortIdentifier);
-        appendIfValid(vector, "CDP", collateralDamagePotential.shortIdentifier);
-        appendIfValid(vector, "TD", targetDistribution.shortIdentifier);
-        appendIfValid(vector, "CR", confidentialityRequirement.shortIdentifier);
-        appendIfValid(vector, "IR", integrityRequirement.shortIdentifier);
-        appendIfValid(vector, "AR", availabilityRequirement.shortIdentifier);
+        boolean appendAnyways = !filterUndefinedProperties;
+
+        appendIfValid(vector, "AV", accessVector.shortIdentifier, appendAnyways);
+        appendIfValid(vector, "AC", accessComplexity.shortIdentifier, appendAnyways);
+        appendIfValid(vector, "Au", authentication.shortIdentifier, appendAnyways);
+        appendIfValid(vector, "C", confidentialityImpact.shortIdentifier, appendAnyways);
+        appendIfValid(vector, "I", integrityImpact.shortIdentifier, appendAnyways);
+        appendIfValid(vector, "A", availabilityImpact.shortIdentifier, appendAnyways);
+        appendIfValid(vector, "E", exploitability.shortIdentifier, appendAnyways);
+        appendIfValid(vector, "RL", remediationLevel.shortIdentifier, appendAnyways);
+        appendIfValid(vector, "RC", reportConfidence.shortIdentifier, appendAnyways);
+        appendIfValid(vector, "CDP", collateralDamagePotential.shortIdentifier, appendAnyways);
+        appendIfValid(vector, "TD", targetDistribution.shortIdentifier, appendAnyways);
+        appendIfValid(vector, "CR", confidentialityRequirement.shortIdentifier, appendAnyways);
+        appendIfValid(vector, "IR", integrityRequirement.shortIdentifier, appendAnyways);
+        appendIfValid(vector, "AR", availabilityRequirement.shortIdentifier, appendAnyways);
 
         if (vector.length() > 0 && vector.charAt(vector.length() - 1) == '/') {
             vector.setLength(vector.length() - 1);
@@ -626,8 +628,13 @@ public final class Cvss2 extends MultiScoreCvssVector {
         return vector.toString();
     }
 
-    private void appendIfValid(StringBuilder builder, String prefix, String value) {
-        if (value != null && !value.equals("X")) {
+    @Override
+    public String toString() {
+        return toString(true);
+    }
+
+    private void appendIfValid(StringBuilder builder, String prefix, String value, boolean appendAnyways) {
+        if (value != null && (appendAnyways || !(value.equals("X") || value.equals("ND")))) {
             if (builder.length() > 0) {
                 builder.append('/');
             }

--- a/libraries/ae-security/src/main/java/org/metaeffekt/core/security/cvss/v4P0/Cvss4P0.java
+++ b/libraries/ae-security/src/main/java/org/metaeffekt/core/security/cvss/v4P0/Cvss4P0.java
@@ -956,61 +956,68 @@ public final class Cvss4P0 extends CvssVector {
     }
 
     @Override
-    public String toString() {
+    public String toString(boolean filterUndefinedProperties) {
         final StringBuilder vector = new StringBuilder();
         vector.append(getName()).append("/");
 
+        boolean appendAnyways = !filterUndefinedProperties;
+
         // Base Metrics: Exploitability Metrics
-        appendIfNotDefault(vector, "AV", attackVector, AttackVector.NOT_DEFINED);
-        appendIfNotDefault(vector, "AC", attackComplexity, AttackComplexity.NOT_DEFINED);
-        appendIfNotDefault(vector, "AT", attackRequirements, AttackRequirements.NOT_DEFINED);
-        appendIfNotDefault(vector, "PR", privilegesRequired, PrivilegesRequired.NOT_DEFINED);
-        appendIfNotDefault(vector, "UI", userInteraction, UserInteraction.NOT_DEFINED);
+        appendIfNotDefault(vector, "AV", attackVector, AttackVector.NOT_DEFINED, appendAnyways);
+        appendIfNotDefault(vector, "AC", attackComplexity, AttackComplexity.NOT_DEFINED, appendAnyways);
+        appendIfNotDefault(vector, "AT", attackRequirements, AttackRequirements.NOT_DEFINED, appendAnyways);
+        appendIfNotDefault(vector, "PR", privilegesRequired, PrivilegesRequired.NOT_DEFINED, appendAnyways);
+        appendIfNotDefault(vector, "UI", userInteraction, UserInteraction.NOT_DEFINED, appendAnyways);
 
         // Base Metrics: Vulnerable System Impact Metrics
-        appendIfNotDefault(vector, "VC", vulnConfidentialityImpact, VulnerabilityCia.NOT_DEFINED);
-        appendIfNotDefault(vector, "VI", vulnIntegrityImpact, VulnerabilityCia.NOT_DEFINED);
-        appendIfNotDefault(vector, "VA", vulnAvailabilityImpact, VulnerabilityCia.NOT_DEFINED);
+        appendIfNotDefault(vector, "VC", vulnConfidentialityImpact, VulnerabilityCia.NOT_DEFINED, appendAnyways);
+        appendIfNotDefault(vector, "VI", vulnIntegrityImpact, VulnerabilityCia.NOT_DEFINED, appendAnyways);
+        appendIfNotDefault(vector, "VA", vulnAvailabilityImpact, VulnerabilityCia.NOT_DEFINED, appendAnyways);
 
         // Base Metrics: Subsequent System Impact Metrics
-        appendIfNotDefault(vector, "SC", subConfidentialityImpact, SubsequentCia.NOT_DEFINED);
-        appendIfNotDefault(vector, "SI", subIntegrityImpact, SubsequentCia.NOT_DEFINED);
-        appendIfNotDefault(vector, "SA", subAvailabilityImpact, SubsequentCia.NOT_DEFINED);
+        appendIfNotDefault(vector, "SC", subConfidentialityImpact, SubsequentCia.NOT_DEFINED, appendAnyways);
+        appendIfNotDefault(vector, "SI", subIntegrityImpact, SubsequentCia.NOT_DEFINED, appendAnyways);
+        appendIfNotDefault(vector, "SA", subAvailabilityImpact, SubsequentCia.NOT_DEFINED, appendAnyways);
 
         // Threat Metrics
-        appendIfNotDefault(vector, "E", exploitMaturity, ExploitMaturity.NOT_DEFINED);
+        appendIfNotDefault(vector, "E", exploitMaturity, ExploitMaturity.NOT_DEFINED, appendAnyways);
 
         // Environmental (Security Requirements)
-        appendIfNotDefault(vector, "CR", confidentialityRequirement, RequirementsCia.NOT_DEFINED);
-        appendIfNotDefault(vector, "IR", integrityRequirement, RequirementsCia.NOT_DEFINED);
-        appendIfNotDefault(vector, "AR", availabilityRequirement, RequirementsCia.NOT_DEFINED);
+        appendIfNotDefault(vector, "CR", confidentialityRequirement, RequirementsCia.NOT_DEFINED, appendAnyways);
+        appendIfNotDefault(vector, "IR", integrityRequirement, RequirementsCia.NOT_DEFINED, appendAnyways);
+        appendIfNotDefault(vector, "AR", availabilityRequirement, RequirementsCia.NOT_DEFINED, appendAnyways);
 
         // Environmental (Modified Base Metrics): Exploitability Metrics
-        appendIfNotDefault(vector, "MAV", modifiedAttackVector, ModifiedAttackVector.NOT_DEFINED);
-        appendIfNotDefault(vector, "MAC", modifiedAttackComplexity, ModifiedAttackComplexity.NOT_DEFINED);
-        appendIfNotDefault(vector, "MAT", modifiedAttackRequirements, ModifiedAttackRequirements.NOT_DEFINED);
-        appendIfNotDefault(vector, "MPR", modifiedPrivilegesRequired, ModifiedPrivilegesRequired.NOT_DEFINED);
-        appendIfNotDefault(vector, "MUI", modifiedUserInteraction, ModifiedUserInteraction.NOT_DEFINED);
+        appendIfNotDefault(vector, "MAV", modifiedAttackVector, ModifiedAttackVector.NOT_DEFINED, appendAnyways);
+        appendIfNotDefault(vector, "MAC", modifiedAttackComplexity, ModifiedAttackComplexity.NOT_DEFINED, appendAnyways);
+        appendIfNotDefault(vector, "MAT", modifiedAttackRequirements, ModifiedAttackRequirements.NOT_DEFINED, appendAnyways);
+        appendIfNotDefault(vector, "MPR", modifiedPrivilegesRequired, ModifiedPrivilegesRequired.NOT_DEFINED, appendAnyways);
+        appendIfNotDefault(vector, "MUI", modifiedUserInteraction, ModifiedUserInteraction.NOT_DEFINED, appendAnyways);
 
         // Environmental (Modified Base Metrics): Vulnerable System Impact Metrics
-        appendIfNotDefault(vector, "MVC", modifiedVulnConfidentialityImpact, ModifiedVulnerabilityCia.NOT_DEFINED);
-        appendIfNotDefault(vector, "MVI", modifiedVulnIntegrityImpact, ModifiedVulnerabilityCia.NOT_DEFINED);
-        appendIfNotDefault(vector, "MVA", modifiedVulnAvailabilityImpact, ModifiedVulnerabilityCia.NOT_DEFINED);
+        appendIfNotDefault(vector, "MVC", modifiedVulnConfidentialityImpact, ModifiedVulnerabilityCia.NOT_DEFINED, appendAnyways);
+        appendIfNotDefault(vector, "MVI", modifiedVulnIntegrityImpact, ModifiedVulnerabilityCia.NOT_DEFINED, appendAnyways);
+        appendIfNotDefault(vector, "MVA", modifiedVulnAvailabilityImpact, ModifiedVulnerabilityCia.NOT_DEFINED, appendAnyways);
 
         // Environmental (Modified Base Metrics): Subsequent System Impact Metrics
-        appendIfNotDefault(vector, "MSC", modifiedSubConfidentialityImpact, ModifiedSubsequentConfidentiality.NOT_DEFINED);
-        appendIfNotDefault(vector, "MSI", modifiedSubIntegrityImpact, ModifiedSubsequentIntegrityAvailability.NOT_DEFINED);
-        appendIfNotDefault(vector, "MSA", modifiedSubAvailabilityImpact, ModifiedSubsequentIntegrityAvailability.NOT_DEFINED);
+        appendIfNotDefault(vector, "MSC", modifiedSubConfidentialityImpact, ModifiedSubsequentConfidentiality.NOT_DEFINED, appendAnyways);
+        appendIfNotDefault(vector, "MSI", modifiedSubIntegrityImpact, ModifiedSubsequentIntegrityAvailability.NOT_DEFINED, appendAnyways);
+        appendIfNotDefault(vector, "MSA", modifiedSubAvailabilityImpact, ModifiedSubsequentIntegrityAvailability.NOT_DEFINED, appendAnyways);
 
         // Supplemental Metrics
-        appendIfNotDefault(vector, "S", safety, Safety.NOT_DEFINED);
-        appendIfNotDefault(vector, "AU", automatable, Automatable.NOT_DEFINED);
-        appendIfNotDefault(vector, "R", recovery, Recovery.NOT_DEFINED);
-        appendIfNotDefault(vector, "V", valueDensity, ValueDensity.NOT_DEFINED);
-        appendIfNotDefault(vector, "RE", vulnerabilityResponseEffort, VulnerabilityResponseEffort.NOT_DEFINED);
-        appendIfNotDefault(vector, "U", providerUrgency, ProviderUrgency.NOT_DEFINED);
+        appendIfNotDefault(vector, "S", safety, Safety.NOT_DEFINED, appendAnyways);
+        appendIfNotDefault(vector, "AU", automatable, Automatable.NOT_DEFINED, appendAnyways);
+        appendIfNotDefault(vector, "R", recovery, Recovery.NOT_DEFINED, appendAnyways);
+        appendIfNotDefault(vector, "V", valueDensity, ValueDensity.NOT_DEFINED, appendAnyways);
+        appendIfNotDefault(vector, "RE", vulnerabilityResponseEffort, VulnerabilityResponseEffort.NOT_DEFINED, appendAnyways);
+        appendIfNotDefault(vector, "U", providerUrgency, ProviderUrgency.NOT_DEFINED, appendAnyways);
 
         return TRAILING_SLASH_PATTERN.matcher(vector.toString()).replaceAll("");
+    }
+
+    @Override
+    public String toString() {
+        return toString(true);
     }
 
     private static final Pattern TRAILING_SLASH_PATTERN = Pattern.compile("/$");
@@ -1076,8 +1083,8 @@ public final class Cvss4P0 extends CvssVector {
         return array.toString();
     }
 
-    private <T extends Cvss4P0Attribute> void appendIfNotDefault(StringBuilder vector, String partName, T currentValue, T defaultValue) {
-        if (currentValue != defaultValue) {
+    private <T extends Cvss4P0Attribute> void appendIfNotDefault(StringBuilder vector, String partName, T currentValue, T defaultValue, boolean appendAnyways) {
+        if (appendAnyways || currentValue != defaultValue) {
             vector.append(partName).append(":").append(currentValue.getShortIdentifier()).append("/");
         }
     }

--- a/libraries/ae-security/src/test/java/org/metaeffekt/core/security/cvss/CvssVectorTest.java
+++ b/libraries/ae-security/src/test/java/org/metaeffekt/core/security/cvss/CvssVectorTest.java
@@ -322,4 +322,14 @@ public class CvssVectorTest {
         Assert.assertNull(CvssVector.parseVector("CVSS:3.1/AV:N/INVALID:METRIC/AC:L", true));
         Assert.assertNotNull(CvssVector.parseVector("CVSS:3.1/AV:N/INVALID:METRIC/AC:L"));
     }
+
+    @Test
+    public void toStringTest() {
+        Assert.assertEquals("AV:A/CDP:L", CvssVector.parseVector("AV:A/CDP:L", true).toString());
+        Assert.assertEquals("AV:A/AC:X/Au:X/C:X/I:X/A:X/E:X/RL:X/RC:X/CDP:L/TD:ND/CR:ND/IR:ND/AR:ND", CvssVector.parseVector("AV:A/CDP:L", true).toString(false));
+        Assert.assertEquals("CVSS:3.1/AV:L/MAV:L", CvssVector.parseVector("CVSS:3.1/AV:L/MAV:L", true).toString());
+        Assert.assertEquals("CVSS:3.1/AV:L/AC:X/PR:X/UI:X/S:X/C:X/I:X/A:X/E:X/RL:X/RC:X/MAV:L/MAC:X/MPR:X/MUI:X/MS:X/MC:X/MI:X/MA:X/CR:X/IR:X/AR:X", CvssVector.parseVector("CVSS:3.1/AV:L/MAV:L", true).toString(false));
+        Assert.assertEquals("CVSS:4.0/AV:L/MAV:L", CvssVector.parseVector("CVSS:4.0/AV:L/MAV:L", true).toString());
+        Assert.assertEquals("CVSS:4.0/AV:L/AC:X/AT:X/PR:X/UI:X/VC:X/VI:X/VA:X/SC:X/SI:X/SA:X/E:X/CR:X/IR:X/AR:X/MAV:L/MAC:X/MAT:X/MPR:X/MUI:X/MVC:X/MVI:X/MVA:X/MSC:X/MSI:X/MSA:X/S:X/AU:X/R:X/V:X/RE:X/U:X", CvssVector.parseVector("CVSS:4.0/AV:L/MAV:L", true).toString(false));
+    }
 }

--- a/libraries/ae-security/src/test/java/org/metaeffekt/core/security/cvss/CvssVectorTest.java
+++ b/libraries/ae-security/src/test/java/org/metaeffekt/core/security/cvss/CvssVectorTest.java
@@ -281,4 +281,45 @@ public class CvssVectorTest {
                 Cvss4P0.parseVector("CVSS:4.0/AV:P/AC:L/AT:P/PR:H/UI:P/VC:N/VI:N/VA:N/SC:N/SI:N/SA:H"),
                 CvssVector.parseVector("CVSS:4.0/AV:P/AC:L/AT:P/PR:H/UI:P/VC:N/VI:N/VA:N/SC:N/SI:N/SA:H"));
     }
+
+    @Test
+    public void parseVectorStrictModeTest() {
+        // return null for invalid vectors
+        Assert.assertNull(CvssVector.parseVector("CVSS:2.0/INVALID:VECTOR", true));
+        Assert.assertNull(CvssVector.parseVector("CVSS:3.1/UNKNOWN:METRIC", true));
+        Assert.assertNull(CvssVector.parseVector("AV:P/AC:L/AT:P/PR:H/UI:P/VC:N/VI:N/VA:N/SC:N/SI:N/SA:H/NO:O", true));
+        Assert.assertNull(CvssVector.parseVector("AR:N/NO:O", true));
+        // return vector for valid vectors
+        Assert.assertNotNull(CvssVector.parseVector("CVSS:3.1/AV:N/AC:L/PR:H/UI:R/S:U/C:L/I:N/A:L", true));
+        Assert.assertNotNull(CvssVector.parseVector("CVSS:4.0/AV:P/AC:L/AT:P/PR:H/UI:P/VC:N/VI:N/VA:N/SC:N/SI:N/SA:H", true));
+
+        // default: return vector even with unknown metrics
+        Assert.assertNotNull(CvssVector.parseVector("CVSS:2.0/INVALID:VECTOR"));
+        Assert.assertNotNull(CvssVector.parseVector("CVSS:3.1/UNKNOWN:METRIC"));
+
+        // empty/null vectors
+        Assert.assertNull(CvssVector.parseVector(null, true));
+        Assert.assertNull(CvssVector.parseVector("", true));
+        Assert.assertNull(CvssVector.parseVector("   ", true));
+        Assert.assertNull(CvssVector.parseVector(null));
+        Assert.assertNull(CvssVector.parseVector(""));
+        Assert.assertNull(CvssVector.parseVector("   "));
+
+        // vectors with version prefix but no valid metrics
+        Assert.assertNull(CvssVector.parseVector("CVSS:3.1/", true));
+        Assert.assertNull(CvssVector.parseVector("CVSS:4.0/", true));
+        Assert.assertNotNull(CvssVector.parseVector("CVSS:3.1/"));
+        Assert.assertNotNull(CvssVector.parseVector("CVSS:4.0/"));
+    }
+
+    @Test
+    public void parseVectorStrictModeEdgeCasesTest() {
+        // invalid prefix, valid content
+        Assert.assertNull(CvssVector.parseVector("CVSS:XYZ/AV:N/AC:L", true));
+        // valid prefix, invalid content
+        Assert.assertNull(CvssVector.parseVector("CVSS:3.1/THIS:IS/COMPLETELY:INVALID", true));
+        // some more
+        Assert.assertNull(CvssVector.parseVector("CVSS:3.1/AV:N/INVALID:METRIC/AC:L", true));
+        Assert.assertNotNull(CvssVector.parseVector("CVSS:3.1/AV:N/INVALID:METRIC/AC:L"));
+    }
 }


### PR DESCRIPTION
> closes #253

### Parsing Logic:
* Added a `strict` parameter to the `parseVector` method to control whether invalid or unknown metrics should result in a `null` return value or a partially parsed vector. A new overload of `parseVector` defaults the `strict` parameter to `false` for backward compatibility.

### String Representation:
* Introduced a new `toString(boolean filterUndefinedProperties)` method in `CvssVector` and its subclasses (`Cvss2` and `Cvss4P0`) to allow filtering of undefined or default properties when generating the vector string representation.