### PR TITLE
AE-1120: Dedicated Central Security Configuration Loader

### DIFF
--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/document/report/DocumentDescriptorReportGenerator.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/document/report/DocumentDescriptorReportGenerator.java
@@ -170,7 +170,8 @@ public class DocumentDescriptorReportGenerator {
                         if (generateOverviewTablesForAdvisories != null) {
                             try {
                                 // FIXME-RTU: discuss with Karsten how we want to pass the list of providers & how to list them in the yaml
-                                report.addGenerateOverviewTablesForAdvisoriesByMap(convertToJSONArray(generateOverviewTablesForAdvisories));
+                                //  YWI: check whether the implementation I provided works for you, the generateOverviewTablesForAdvisories are now a parameter in the security policy
+                                report.getSecurityPolicy().getGenerateOverviewTablesForAdvisories().putAll(convertToJSONArray(generateOverviewTablesForAdvisories));
                             } catch (Exception e) {
                                 throw new RuntimeException("Failed to parse generateOverviewTablesForAdvisories, must be a valid content identifier JSONArray: " + generateOverviewTablesForAdvisories, e);
                             }

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/InventoryReport.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/InventoryReport.java
@@ -27,7 +27,6 @@ import org.apache.velocity.VelocityContext;
 import org.apache.velocity.app.Velocity;
 import org.apache.velocity.app.VelocityEngine;
 import org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader;
-import org.json.JSONArray;
 import org.metaeffekt.core.inventory.InventoryUtils;
 import org.metaeffekt.core.inventory.processor.model.*;
 import org.metaeffekt.core.inventory.processor.reader.InventoryReader;
@@ -38,9 +37,6 @@ import org.metaeffekt.core.inventory.processor.report.adapter.VulnerabilityRepor
 import org.metaeffekt.core.inventory.processor.report.configuration.CentralSecurityPolicyConfiguration;
 import org.metaeffekt.core.inventory.processor.report.configuration.ReportConfigurationParameters;
 import org.metaeffekt.core.inventory.processor.report.model.AssetData;
-import org.metaeffekt.core.inventory.processor.report.model.aeaa.store.AeaaAdvisoryTypeIdentifier;
-import org.metaeffekt.core.inventory.processor.report.model.aeaa.store.AeaaAdvisoryTypeStore;
-import org.metaeffekt.core.inventory.processor.report.model.aeaa.store.AeaaContentIdentifierStore;
 import org.metaeffekt.core.inventory.processor.writer.InventoryWriter;
 import org.metaeffekt.core.util.FileUtils;
 import org.metaeffekt.core.util.RegExUtils;
@@ -143,12 +139,6 @@ public class InventoryReport {
      * Project name initialized with default value.
      */
     private String projectName = "local project";
-
-    /**
-     * For which advisory providers to generate additional tables in the overview section containing statistic data on
-     * which vulnerabilities have already been reviewed.
-     */
-    private final List<AeaaAdvisoryTypeIdentifier<?>> generateOverviewTablesForAdvisories = new ArrayList<>();
 
     private CentralSecurityPolicyConfiguration securityPolicy = new CentralSecurityPolicyConfiguration();
 
@@ -1026,7 +1016,6 @@ public class InventoryReport {
         LOG.info("   [failOnUpgrade: {}] [failOnMissingLicense: {}] [failOnMissingLicenseFile: {}] [failOnMissingNotice: {}] [failOnMissingComponentFiles: {}]",  configParams.isFailOnUpgrade(),  configParams.isFailOnMissingLicense(),  configParams.isFailOnMissingLicenseFile(),  configParams.isFailOnMissingNotice(),  configParams.isFailOnMissingComponentFiles());
 
         LOG.info("- Data display settings:");
-        LOG.info(" - generateOverviewTablesForAdvisories: {}", generateOverviewTablesForAdvisories.stream().map(AeaaContentIdentifierStore.AeaaContentIdentifier::toExtendedString).collect(Collectors.toList()));
         logConfigurationLogToString("artifactFilter", artifactFilter);
         logConfigurationLogToString("filterVulnerabilitiesNotCoveredByArtifacts", configParams.isFilterVulnerabilitiesNotCoveredByArtifacts());
         logConfigurationLogToString("filterAdvisorySummary", configParams.isFilterAdvisorySummary());
@@ -1193,33 +1182,6 @@ public class InventoryReport {
 
     public File getGlobalInventoryDir() {
         return referenceInventoryDir;
-    }
-
-    public void addGenerateOverviewTablesForAdvisories(AeaaAdvisoryTypeIdentifier<?>... providers) {
-        if (providers == null || providers.length == 0) {
-            return;
-        }
-        this.addGenerateOverviewTablesForAdvisories(Arrays.asList(providers));
-    }
-
-    public void addGenerateOverviewTablesForAdvisories(Collection<AeaaAdvisoryTypeIdentifier<?>> providers) {
-        this.generateOverviewTablesForAdvisories.addAll(providers);
-    }
-
-    public void addGenerateOverviewTablesForAdvisoriesByMap(Map<String, String> providers) {
-        if (providers == null || providers.isEmpty()) {
-            return;
-        }
-        final List<AeaaAdvisoryTypeIdentifier<?>> parsed = AeaaAdvisoryTypeStore.get().fromMapNamesAndImplementations(providers);
-        this.generateOverviewTablesForAdvisories.addAll(parsed);
-    }
-
-    public void addGenerateOverviewTablesForAdvisoriesByMap(JSONArray providers) {
-        if (providers == null || providers.isEmpty()) {
-            return;
-        }
-        final List<AeaaAdvisoryTypeIdentifier<?>> parsed = AeaaAdvisoryTypeStore.get().fromJsonNamesAndImplementations(providers);
-        this.generateOverviewTablesForAdvisories.addAll(parsed);
     }
 
     public AssetData getAssetData(Inventory inventory) {

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/configuration/CspLoader.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/configuration/CspLoader.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright 2009-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.metaeffekt.core.inventory.processor.report.configuration;
+
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.metaeffekt.core.util.FileUtils;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Data
+public class CspLoader {
+    private String inlineOverwriteJson;
+    private List<File> policyFiles = new ArrayList<>();
+    private List<String> activeIds = new ArrayList<>();
+
+    public CentralSecurityPolicyConfiguration loadConfiguration() throws IOException {
+        if (policyFiles.isEmpty() && StringUtils.isEmpty(inlineOverwriteJson)) {
+            log.info("[csp-loader] No policyFiles or inlineOverwriteJson were provided, using default Central Security Policy instance");
+            return new CentralSecurityPolicyConfiguration();
+        }
+
+        if (activeIds.isEmpty()) {
+            log.info("[csp-loader] No active Ids provided to build security policy from, either activeByDefault or inlineOverwriteJson must be set to obtain any properties");
+        } else {
+            log.info("[csp-loader] Building configurations from Ids: {}", activeIds);
+        }
+
+        final List<CspLoaderEntry> allEntries = new ArrayList<>();
+        for (File policyFile : policyFiles) {
+            final List<CspLoaderEntry> entries = CspLoaderEntry.fromFile(policyFile);
+            log.info("[csp-loader]   ↳ Parsed [{}] configurations", entries.size());
+            allEntries.addAll(entries);
+        }
+
+        final Map<String, CspLoaderEntry> idToEntryMap = new HashMap<>();
+        for (CspLoaderEntry entry : allEntries) {
+            idToEntryMap.put(entry.getId(), entry);
+        }
+
+        final List<CspLoaderEntry> activeEntries = new ArrayList<>();
+
+        // the ones that are active by default must be loaded first
+        allEntries.stream().filter(CspLoaderEntry::isActiveByDefault).forEach(activeEntries::add);
+
+        // search the user-specified ids in the known events
+        for (String activeId : activeIds) {
+            final CspLoaderEntry foundEntry = idToEntryMap.get(activeId);
+            if (foundEntry == null) {
+                throw new IllegalStateException("[csp-loader] Configured Configuration Id [" + activeId + "] does not exist");
+            }
+            if (!activeEntries.contains(foundEntry)) {
+                activeEntries.add(foundEntry);
+            }
+        }
+        log.info("[csp-loader] - Activating configuration(s): {}", activeEntries.stream().map(CspLoaderEntry::getId).collect(Collectors.toList()));
+
+        final Set<CspLoaderEntry> checkedExtends = new HashSet<>();
+        final Queue<CspLoaderEntry> checkExtends = new LinkedList<>(activeEntries);
+        while (!checkExtends.isEmpty()) {
+            final CspLoaderEntry current = checkExtends.poll();
+            if (!checkedExtends.add(current)) continue;
+
+            for (String extendedId : current.getExtendsEntries()) {
+                final CspLoaderEntry extendsEntry = idToEntryMap.get(extendedId);
+                if (extendsEntry == null) {
+                    throw new IllegalStateException("[csp-loader] Configuration [" + current.getId() + "] extends entry does not exist [" + extendedId + "]");
+                }
+                if (!activeEntries.contains(extendsEntry)) {
+                    log.info("[csp-loader] - Activating configuration [{}] because it is extended by [{}]", extendsEntry.getId(), current.getId());
+                    activeEntries.add(0, extendsEntry);
+                    checkExtends.add(extendsEntry);
+                }
+            }
+        }
+
+        log.info("[csp-loader] Filtered total configurations [{}] {} to selected configurations [{}] {}",
+                idToEntryMap.size(), allEntries.stream().map(CspLoaderEntry::getId).collect(Collectors.toList()),
+                activeEntries.size(), activeEntries.stream().map(CspLoaderEntry::getId).collect(Collectors.toList()));
+
+        log.info("[csp-loader] Merging [{}] configurations into effective configuration", activeEntries.size());
+        final JSONObject mergedConfig = new JSONObject();
+        for (CspLoaderEntry entry : activeEntries) {
+            log.info("[csp-loader] - [{}]: {}", entry.getId(), entry.getConfiguration());
+            mergeJson(mergedConfig, entry.getConfiguration());
+        }
+
+        if (inlineOverwriteJson != null && !inlineOverwriteJson.trim().isEmpty()) {
+            log.info("[csp-loader] - inline overwrite: {}", inlineOverwriteJson);
+            mergeJson(mergedConfig, new JSONObject(inlineOverwriteJson));
+        }
+
+        log.info("[csp-loader]   ↳ {}", mergedConfig);
+        return CentralSecurityPolicyConfiguration.fromJson(mergedConfig, "CSP Failed to parse Effective Security Policy Configuration");
+    }
+
+    private void mergeJson(JSONObject target, JSONObject source) {
+        for (String key : source.keySet()) {
+            target.put(key, source.get(key));
+        }
+    }
+
+    @Data
+    private static class CspLoaderEntry {
+        private final File originFile;
+        private String id;
+        private boolean activeByDefault = false;
+        private final Set<String> extendsEntries = new HashSet<>();
+        private JSONObject configuration;
+
+        private static final Set<String> ALLOWED_KEYS = new HashSet<>(Arrays.asList("id", "extends", "activeByDefault", "configuration"));
+
+        public static List<CspLoaderEntry> fromFile(File file) throws IOException {
+            if (file == null || !file.exists() || !file.isFile()) {
+                throw new FileNotFoundException("[csp-loader] CSP file must exist but was not found: file://" + canonicalOrAbsolute(file));
+            }
+
+            log.info("[csp-loader] - Loading file://{}", canonicalOrAbsolute(file));
+            final List<CspLoaderEntry> entries = new ArrayList<>();
+            final String content = FileUtils.readFileToString(file, StandardCharsets.UTF_8);
+
+            if (content.startsWith("[")) {
+                final JSONArray jsonArray = new JSONArray(content);
+                for (int i = 0; i < jsonArray.length(); i++) {
+                    final JSONObject jsonEntry = jsonArray.optJSONObject(i);
+                    if (jsonEntry == null) {
+                        throw new IllegalStateException("[csp-loader] Expected JSON Object in file://" + canonicalOrAbsolute(file) + " but got: " + jsonArray.get(i));
+                    }
+
+                    final Set<String> keys = jsonEntry.keySet();
+                    for (String key : keys) {
+                        if (!ALLOWED_KEYS.contains(key)) {
+                            throw new IllegalStateException("[csp-loader] Unknown key in configuration entry [" + key + "] in file://" + canonicalOrAbsolute(file));
+                        }
+                    }
+
+                    if (!jsonEntry.has("id")) {
+                        throw new IllegalStateException("[csp-loader] Missing required key 'id' in configuration entry in file://" + canonicalOrAbsolute(file));
+                    }
+                    if (!jsonEntry.has("configuration")) {
+                        throw new IllegalStateException("[csp-loader] Missing required key 'configuration' in configuration entry [" + jsonEntry.get("id") + "] in file://" + canonicalOrAbsolute(file));
+                    }
+
+                    final CspLoaderEntry entry = new CspLoaderEntry(file);
+                    entry.id = jsonEntry.getString("id");
+
+                    if (jsonEntry.has("extends")) {
+                        final Object extendsObj = jsonEntry.get("extends");
+                        if (!(extendsObj instanceof JSONArray)) {
+                            throw new IllegalStateException("[csp-loader] 'extends' must be a JSON array in configuration entry [" + entry.id + "] in file://" + canonicalOrAbsolute(file));
+                        }
+                        final JSONArray extendsArray = (JSONArray) extendsObj;
+                        for (int j = 0; j < extendsArray.length(); j++) {
+                            final Object val = extendsArray.get(j);
+                            if (!(val instanceof String)) {
+                                throw new IllegalStateException("[csp-loader] All elements of 'extends' must be strings in configuration entry [" + entry.id + "] in file://" + canonicalOrAbsolute(file));
+                            }
+                            entry.extendsEntries.add((String) val);
+                        }
+                    }
+
+                    if (jsonEntry.has("activeByDefault")) {
+                        final Object activeObj = jsonEntry.get("activeByDefault");
+                        if (!(activeObj instanceof Boolean)) {
+                            throw new IllegalStateException("[csp-loader] 'activeByDefault' must be a boolean in configuration entry [" + entry.id + "] in file://" + canonicalOrAbsolute(file));
+                        }
+                        entry.activeByDefault = (Boolean) activeObj;
+                    }
+
+                    final Object config = jsonEntry.get("configuration");
+                    if (config instanceof String) {
+                        final File nestedFile = new File(file.getParentFile(), (String) config);
+                        try {
+                            entry.configuration = new JSONObject(FileUtils.readFileToString(nestedFile, StandardCharsets.UTF_8));
+                        } catch (IOException e) {
+                            throw new IllegalStateException("[csp-loader] Failed to load sub-configuration from://" + canonicalOrAbsolute(nestedFile), e);
+                        } catch (JSONException e) {
+                            throw new IllegalStateException("[csp-loader] Invalid JSON in sub-configuration file://" + canonicalOrAbsolute(nestedFile), e);
+                        }
+                    } else if (config instanceof JSONObject) {
+                        entry.configuration = (JSONObject) config;
+                    } else {
+                        throw new IllegalStateException("[csp-loader] 'configuration' must be a string path or JSON object in configuration entry [" + entry.id + "] in file://" + canonicalOrAbsolute(file));
+                    }
+
+                    entries.add(entry);
+                }
+            } else if (content.startsWith("{")) {
+                final JSONObject json = new JSONObject(content);
+                final CspLoaderEntry entry = new CspLoaderEntry(file);
+                entry.id = file.getName() + UUID.randomUUID();
+                entry.configuration = json;
+                entry.activeByDefault = true;
+                entries.add(entry);
+            }
+
+            return entries;
+        }
+    }
+
+    private static String canonicalOrAbsolute(File file) {
+        try {
+            return file.getCanonicalPath();
+        } catch (IOException e) {
+            return file.getAbsolutePath();
+        }
+    }
+
+    public static CentralSecurityPolicyConfiguration legacyParsing(
+            CentralSecurityPolicyConfiguration baseConfiguration,
+            File securityPolicyFile,
+            String securityPolicyOverwriteJson,
+            CspLoader cspLoader) {
+
+        if (baseConfiguration != null || securityPolicyOverwriteJson != null || securityPolicyFile != null) {
+            log.warn("Configuring the Central Security Policy using the securityPolicy, securityPolicyOverwriteJson or securityPolicyFile is deprecated and will be removed in the future.");
+            log.warn("Consider switching to the new cspLoader: https://github.com/org-metaeffekt/metaeffekt-documentation/blob/main/metaeffekt-vulnerability-management/inventory-enrichment/central-security-policy-loader.md");
+            try {
+                if (securityPolicyOverwriteJson != null) {
+                    log.info("Reading security policy from securityPolicyOverwriteJson: {}", securityPolicyOverwriteJson);
+                }
+                if (securityPolicyFile != null) {
+                    log.info("Reading security policy from securityPolicyFile: file://{}", securityPolicyFile.getCanonicalPath());
+                }
+                return CentralSecurityPolicyConfiguration.fromConfiguration(baseConfiguration, securityPolicyFile, securityPolicyOverwriteJson);
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to process security policy configuration: " + e.getMessage(), e);
+            }
+
+        } else {
+            try {
+                return cspLoader.loadConfiguration();
+            } catch (IOException e) {
+                throw new RuntimeException("CSP loader failed to create Central Security Policy instance from parameters.", e);
+            }
+        }
+    }
+}

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/configuration/CspLoader.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/configuration/CspLoader.java
@@ -34,10 +34,31 @@ import java.util.stream.Collectors;
 @Data
 public class CspLoader {
     private String inlineOverwriteJson;
-    private List<File> policyFiles = new ArrayList<>();
+    private File file;
+    private List<File> files = new ArrayList<>();
     private List<String> activeIds = new ArrayList<>();
 
-    public CentralSecurityPolicyConfiguration loadConfiguration() throws IOException {
+    public void addFile(File... files) {
+        this.files.addAll(Arrays.asList(files));
+    }
+
+    public List<File> getFiles() {
+        final List<File> policyFiles = new ArrayList<>(files);
+        if (file != null) policyFiles.add(file);
+        return Collections.unmodifiableList(policyFiles);
+    }
+
+    public CentralSecurityPolicyConfiguration loadConfiguration() {
+        try {
+            return this.loadConfigurationInternal();
+        } catch (IOException e) {
+            throw new RuntimeException("CSP loader failed to create Central Security Policy instance from parameters.", e);
+        }
+    }
+
+    protected CentralSecurityPolicyConfiguration loadConfigurationInternal() throws IOException {
+        final List<File> policyFiles = this.getFiles();
+
         if (policyFiles.isEmpty() && StringUtils.isEmpty(inlineOverwriteJson)) {
             log.info("[csp-loader] No policyFiles or inlineOverwriteJson were provided, using default Central Security Policy instance");
             return new CentralSecurityPolicyConfiguration();
@@ -251,11 +272,7 @@ public class CspLoader {
             }
 
         } else {
-            try {
-                return cspLoader.loadConfiguration();
-            } catch (IOException e) {
-                throw new RuntimeException("CSP loader failed to create Central Security Policy instance from parameters.", e);
-            }
+            return cspLoader.loadConfiguration();
         }
     }
 }

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/model/aeaa/store/AeaaContentIdentifierStore.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/model/aeaa/store/AeaaContentIdentifierStore.java
@@ -246,6 +246,16 @@ public abstract class AeaaContentIdentifierStore<T extends AeaaContentIdentifier
         return jsonArray;
     }
 
+    public static <T extends AeaaContentIdentifier> JSONArray toJson(Collection<T> contentIdentifiers) {
+        final JSONArray jsonArray = new JSONArray();
+        for (T contentIdentifier : contentIdentifiers) {
+            jsonArray.put(new JSONObject()
+                    .put("name", contentIdentifier.getName())
+                    .put("implementation", contentIdentifier.getImplementation()));
+        }
+        return jsonArray;
+    }
+
     public static class AeaaSingleContentIdentifierParseResult<T extends AeaaContentIdentifier> {
         private final T identifier;
         private final String id;
@@ -254,11 +264,11 @@ public abstract class AeaaContentIdentifierStore<T extends AeaaContentIdentifier
             this.identifier = identifier;
             this.id = id;
         }
-        
+
         public T getIdentifier() {
             return identifier;
         }
-        
+
         public String getId() {
             return id;
         }

--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/inventory-statistics-vulnerability/tpc_inventory-vulnerability-statistics.dita.vt
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/inventory-statistics-vulnerability/tpc_inventory-vulnerability-statistics.dita.vt
@@ -16,7 +16,7 @@
 
 
 ## iterate over all advisories that shall have their own overview table
-#foreach($advisory in $report.getGenerateOverviewTablesForAdvisories())
+#foreach($advisory in $report.getSecurityPolicy().getGenerateOverviewTablesForAdvisoriesInst())
     #set ($advisoryName = $advisory.getWellFormedName())
     #set ($advisoryIdentifier = $advisory.name())
 ##
@@ -34,7 +34,7 @@
 
 
 ## iterate over all advisories that shall have their own modified overview table
-#foreach($advisory in $report.getGenerateOverviewTablesForAdvisories())
+#foreach($advisory in $report.getSecurityPolicy().getGenerateOverviewTablesForAdvisoriesInst())
     #set ($advisoryName = $advisory.getWellFormedName())
     #set ($advisoryIdentifier = $advisory.name())
 ##

--- a/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/RepositoryReportTest.java
+++ b/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/RepositoryReportTest.java
@@ -31,13 +31,12 @@ import org.metaeffekt.core.inventory.processor.report.configuration.ReportConfig
 import org.metaeffekt.core.inventory.processor.report.model.aeaa.store.AeaaAdvisoryTypeStore;
 import org.metaeffekt.core.inventory.processor.writer.InventoryWriter;
 import org.metaeffekt.core.util.FileUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.util.AntPathMatcher;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertFalse;
@@ -65,6 +64,8 @@ public class RepositoryReportTest {
                 .inventoryBomReportEnabled(true)
                 .build());
 
+        report.getSecurityPolicy().setGenerateOverviewTablesForAdvisories(AeaaAdvisoryTypeStore.toJson(Arrays.asList(AeaaAdvisoryTypeStore.CERT_FR, AeaaAdvisoryTypeStore.GHSA, AeaaAdvisoryTypeStore.CERT_SEI, AeaaAdvisoryTypeStore.MSRC)));
+
         report.setReportContext(new ReportContext("test", "Test", "Test Context"));
 
         report.setReferenceInventoryDir(inventoryDir);
@@ -81,7 +82,7 @@ public class RepositoryReportTest {
         File target = new File("target/test-inventory-01");
         target.mkdirs();
 
-        File  targetReportPath = new File(target, "report");
+        File targetReportPath = new File(target, "report");
         targetReportPath.mkdirs();
 
         File licenseReport = new File(targetReportPath, "tpc_inventory-licenses.dita");
@@ -276,10 +277,10 @@ public class RepositoryReportTest {
                 .build());
 
 
-        report.addGenerateOverviewTablesForAdvisories(AeaaAdvisoryTypeStore.ANY_ADVISORY_FILTER_WILDCARD);
         report.getSecurityPolicy()
                 // .setIncludeVulnerabilitiesWithAdvisoryProviders(Collections.singletonList("GHSA"))
-                .setVulnerabilityStatusDisplayMapper(CentralSecurityPolicyConfiguration.VULNERABILITY_STATUS_DISPLAY_MAPPER_ABSTRACTED);
+                .setVulnerabilityStatusDisplayMapper(CentralSecurityPolicyConfiguration.VULNERABILITY_STATUS_DISPLAY_MAPPER_ABSTRACTED)
+                .setGenerateOverviewTablesForAdvisories(AeaaAdvisoryTypeStore.toJson(Collections.singletonList(AeaaAdvisoryTypeStore.ANY_ADVISORY_FILTER_WILDCARD)));
 
         configureAndCreateReport(inventoryDir, "*.xls",
                 inventoryDir, "*.xls",
@@ -362,7 +363,7 @@ public class RepositoryReportTest {
         File target = new File("target/test-inventory-05");
         target.mkdirs();
 
-        File  targetReportPath = new File(target, "report");
+        File targetReportPath = new File(target, "report");
         targetReportPath.mkdirs();
 
         File licenseReport = new File(targetReportPath, "tpc_inventory-licenses.dita");
@@ -430,12 +431,12 @@ public class RepositoryReportTest {
 
         report.setTargetReportDir(new File(reportTarget, "report"));
 
-        report.addGenerateOverviewTablesForAdvisories(AeaaAdvisoryTypeStore.CERT_FR, AeaaAdvisoryTypeStore.GHSA, AeaaAdvisoryTypeStore.CERT_SEI, AeaaAdvisoryTypeStore.MSRC);
         report.getSecurityPolicy()
                 .setInsignificantThreshold(7)
                 .setIncludeScoreThreshold(0)
                 .setIncludeAdvisoryTypes(Arrays.asList("alert", "notice"))
-                .setVulnerabilityStatusDisplayMapper(CentralSecurityPolicyConfiguration.VULNERABILITY_STATUS_DISPLAY_MAPPER_ABSTRACTED);
+                .setVulnerabilityStatusDisplayMapper(CentralSecurityPolicyConfiguration.VULNERABILITY_STATUS_DISPLAY_MAPPER_ABSTRACTED)
+                .setGenerateOverviewTablesForAdvisories(AeaaAdvisoryTypeStore.toJson(Arrays.asList(AeaaAdvisoryTypeStore.CERT_FR, AeaaAdvisoryTypeStore.GHSA, AeaaAdvisoryTypeStore.CERT_SEI, AeaaAdvisoryTypeStore.MSRC)));
 
         reportTarget.mkdirs();
 

--- a/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/report/configuration/CspLoaderTest.java
+++ b/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/report/configuration/CspLoaderTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2009-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.metaeffekt.core.inventory.processor.report.configuration;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.metaeffekt.core.security.cvss.processor.CvssSelectionResult;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+
+public class CspLoaderTest {
+    private final static File RESOURCE_DIR = new File("src/test/resources/security-policy/CspLoaderTest");
+
+    @Test
+    public void initialTest() throws IOException {
+        final CspLoader loader = new CspLoader();
+        loader.getPolicyFiles().add(new File(RESOURCE_DIR, "initialTest/file-a.json"));
+        loader.getPolicyFiles().add(new File(RESOURCE_DIR, "initialTest/file-b.json"));
+
+        loader.setActiveIds(Arrays.asList("config d", "config a"));
+        final CentralSecurityPolicyConfiguration resultPolicy1 = loader.loadConfiguration();
+
+        Assert.assertEquals(Collections.singletonList("notice"), resultPolicy1.getIncludeAdvisoryTypes());
+        Assert.assertEquals(5, resultPolicy1.getIncludeScoreThreshold(), 0.01);
+        Assert.assertEquals(7.8, resultPolicy1.getInsignificantThreshold(), 0.01);
+        Assert.assertEquals(Collections.singletonList(CvssSelectionResult.CvssScoreVersionSelectionPolicy.HIGHEST), resultPolicy1.getCvssVersionSelectionPolicy());
+        Assert.assertEquals(CentralSecurityPolicyConfiguration.JsonSchemaValidationErrorsHandling.LENIENT, resultPolicy1.getJsonSchemaValidationErrorsHandling());
+
+        loader.setActiveIds(Arrays.asList("config a", "config d"));
+        final CentralSecurityPolicyConfiguration resultPolicy2 = loader.loadConfiguration();
+
+        Assert.assertEquals(Collections.singletonList("alert"), resultPolicy2.getIncludeAdvisoryTypes());
+        Assert.assertEquals(5, resultPolicy2.getIncludeScoreThreshold(), 0.01);
+        Assert.assertEquals(7.8, resultPolicy2.getInsignificantThreshold(), 0.01);
+        Assert.assertEquals(Collections.singletonList(CvssSelectionResult.CvssScoreVersionSelectionPolicy.HIGHEST), resultPolicy2.getCvssVersionSelectionPolicy());
+        Assert.assertEquals(CentralSecurityPolicyConfiguration.JsonSchemaValidationErrorsHandling.LENIENT, resultPolicy2.getJsonSchemaValidationErrorsHandling());
+    }
+
+
+    @Test
+    public void invalidKeysTest() {
+        Assert.assertThrows(RuntimeException.class, () -> {
+            final CspLoader loader = new CspLoader();
+            loader.getPolicyFiles().add(new File(RESOURCE_DIR, "invalidTest/keys-1.json"));
+            loader.loadConfiguration();
+        });
+        Assert.assertThrows(RuntimeException.class, () -> {
+            final CspLoader loader = new CspLoader();
+            loader.getPolicyFiles().add(new File(RESOURCE_DIR, "invalidTest/keys-2.json"));
+            loader.loadConfiguration();
+        });
+        Assert.assertThrows(RuntimeException.class, () -> {
+            final CspLoader loader = new CspLoader();
+            loader.getPolicyFiles().add(new File(RESOURCE_DIR, "invalidTest/keys-3.json"));
+            loader.loadConfiguration();
+        });
+    }
+}

--- a/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/report/configuration/CspLoaderTest.java
+++ b/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/report/configuration/CspLoaderTest.java
@@ -30,8 +30,8 @@ public class CspLoaderTest {
     @Test
     public void initialTest() throws IOException {
         final CspLoader loader = new CspLoader();
-        loader.getPolicyFiles().add(new File(RESOURCE_DIR, "initialTest/file-a.json"));
-        loader.getPolicyFiles().add(new File(RESOURCE_DIR, "initialTest/file-b.json"));
+        loader.setFile(new File(RESOURCE_DIR, "initialTest/file-a.json")); // test via single file property
+        loader.addFile(new File(RESOURCE_DIR, "initialTest/file-b.json")); // and via file list property
 
         loader.setActiveIds(Arrays.asList("config d", "config a"));
         final CentralSecurityPolicyConfiguration resultPolicy1 = loader.loadConfiguration();
@@ -57,17 +57,17 @@ public class CspLoaderTest {
     public void invalidKeysTest() {
         Assert.assertThrows(RuntimeException.class, () -> {
             final CspLoader loader = new CspLoader();
-            loader.getPolicyFiles().add(new File(RESOURCE_DIR, "invalidTest/keys-1.json"));
+            loader.addFile(new File(RESOURCE_DIR, "invalidTest/keys-1.json"));
             loader.loadConfiguration();
         });
         Assert.assertThrows(RuntimeException.class, () -> {
             final CspLoader loader = new CspLoader();
-            loader.getPolicyFiles().add(new File(RESOURCE_DIR, "invalidTest/keys-2.json"));
+            loader.addFile(new File(RESOURCE_DIR, "invalidTest/keys-2.json"));
             loader.loadConfiguration();
         });
         Assert.assertThrows(RuntimeException.class, () -> {
             final CspLoader loader = new CspLoader();
-            loader.getPolicyFiles().add(new File(RESOURCE_DIR, "invalidTest/keys-3.json"));
+            loader.addFile(new File(RESOURCE_DIR, "invalidTest/keys-3.json"));
             loader.loadConfiguration();
         });
     }

--- a/libraries/ae-inventory-processor/src/test/resources/security-policy/CspLoaderTest/initialTest/file-a.json
+++ b/libraries/ae-inventory-processor/src/test/resources/security-policy/CspLoaderTest/initialTest/file-a.json
@@ -1,0 +1,31 @@
+[
+  {
+    "id": "config d",
+    "configuration": {
+      "insignificantThreshold": 7.8,
+      "includeAdvisoryTypes": ["alert"]
+    }
+  },
+  {
+    "id": "config a",
+    "extends": ["config b"],
+    "configuration": {
+      "cvssSeverityRanges": "escalate:strong-red:9.0:,due:strong-dark-orange:7.0:8.9,elevated:strong-light-orange::6.9",
+      "cvssVersionSelectionPolicy": ["HIGHEST"],
+      "includeAdvisoryTypes": ["notice"]
+    }
+  },
+  {
+    "id": "config b",
+    "extends": ["config e"],
+    "configuration": {
+      "cvssSeverityRanges": ">0.8:strong-red:0.8:,>0.1:strong-light-orange:0.1:0.8,>0.01:strong-yellow:0.01:0.1,≤0.01:pastel-gray::0.01"
+    }
+  },
+  {
+    "id": "config e",
+    "configuration": {
+      "jsonSchemaValidationErrorsHandling": "LENIENT"
+    }
+  }
+]

--- a/libraries/ae-inventory-processor/src/test/resources/security-policy/CspLoaderTest/initialTest/file-b.json
+++ b/libraries/ae-inventory-processor/src/test/resources/security-policy/CspLoaderTest/initialTest/file-b.json
@@ -1,0 +1,7 @@
+[
+  {
+    "id": "config c",
+    "activeByDefault": true,
+    "configuration": "file-c.json"
+  }
+]

--- a/libraries/ae-inventory-processor/src/test/resources/security-policy/CspLoaderTest/initialTest/file-c.json
+++ b/libraries/ae-inventory-processor/src/test/resources/security-policy/CspLoaderTest/initialTest/file-c.json
@@ -1,0 +1,3 @@
+{
+  "includeScoreThreshold": 5
+}

--- a/libraries/ae-inventory-processor/src/test/resources/security-policy/CspLoaderTest/invalidTest/keys-1.json
+++ b/libraries/ae-inventory-processor/src/test/resources/security-policy/CspLoaderTest/invalidTest/keys-1.json
@@ -1,0 +1,10 @@
+[
+  {
+    "id": "config d",
+    "id2": "config d",
+    "configuration": {
+      "insignificantThreshold": 7.8,
+      "includeAdvisoryTypes": ["alert"]
+    }
+  }
+]

--- a/libraries/ae-inventory-processor/src/test/resources/security-policy/CspLoaderTest/invalidTest/keys-2.json
+++ b/libraries/ae-inventory-processor/src/test/resources/security-policy/CspLoaderTest/invalidTest/keys-2.json
@@ -1,0 +1,9 @@
+[
+  {
+    "id": "config d",
+    "configuration2": {
+      "insignificantThreshold": 7.8,
+      "includeAdvisoryTypes": ["alert"]
+    }
+  }
+]

--- a/libraries/ae-inventory-processor/src/test/resources/security-policy/CspLoaderTest/invalidTest/keys-3.json
+++ b/libraries/ae-inventory-processor/src/test/resources/security-policy/CspLoaderTest/invalidTest/keys-3.json
@@ -1,0 +1,10 @@
+[
+  {
+    "id": "config d",
+    "extends": "config a",
+    "configuration": {
+      "insignificantThreshold": 7.8,
+      "includeAdvisoryTypes": ["alert"]
+    }
+  }
+]

--- a/plugins/ae-inventory-maven-plugin/src/main/java/org/metaeffekt/core/maven/inventory/mojo/AbstractInventoryReportCreationMojo.java
+++ b/plugins/ae-inventory-maven-plugin/src/main/java/org/metaeffekt/core/maven/inventory/mojo/AbstractInventoryReportCreationMojo.java
@@ -228,35 +228,11 @@ public abstract class AbstractInventoryReportCreationMojo extends AbstractProjec
     // vulnerability report parameters
 
     /**
-     * @parameter
-     * @deprecated Use {@link AbstractInventoryReportCreationMojo#cspLoader} instead
-     */
-    private CentralSecurityPolicyConfiguration securityPolicy;
-
-    /**
-     * If set, will overwrite the {@link #securityPolicy} with the contents of this file.<br>
-     * If the {@link #securityPolicyOverwriteJson} is set, the properties of both will be merged.
-     *
-     * @parameter
-     * @deprecated Use {@link AbstractInventoryReportCreationMojo#cspLoader} instead
-     */
-    private File securityPolicyFile;
-
-    /**
-     * If set, will overwrite the {@link #securityPolicy} with the contents of this JSON string.<br>
-     * If the {@link #securityPolicyFile} is set, the properties of both will be merged.
-     *
-     * @parameter
-     * @deprecated Use {@link AbstractInventoryReportCreationMojo#cspLoader} instead
-     */
-    private String securityPolicyOverwriteJson;
-
-    /**
      * The CspLoader instance that will provide the {@link CentralSecurityPolicyConfiguration} instance to use for report generation.
      *
      * @parameter
      */
-    private CspLoader cspLoader = new CspLoader();
+    private CspLoader securityPolicy = new CspLoader();
 
     /**
      * @parameter default-value="false"
@@ -352,7 +328,7 @@ public abstract class AbstractInventoryReportCreationMojo extends AbstractProjec
         report.setTargetComponentDir(targetComponentDir);
 
         // vulnerability settings
-        final CentralSecurityPolicyConfiguration activeSecurityPolicy = CspLoader.legacyParsing(this.securityPolicy, this.securityPolicyFile, this.securityPolicyOverwriteJson, this.cspLoader);
+        final CentralSecurityPolicyConfiguration activeSecurityPolicy = this.securityPolicy.loadConfiguration();
 
         // log the security policy only when it fits the context -->
         if (enableAssessmentReport || enableVulnerabilityReport || enableVulnerabilityReportSummary || enableVulnerabilityStatisticsReport) {


### PR DESCRIPTION
- Documentation: https://github.com/org-metaeffekt/metaeffekt-documentation/blob/main/metaeffekt-vulnerability-management/inventory-enrichment/central-security-policy-loader.md
- https://github.com/org-metaeffekt/metaeffekt-artifact-analysis/pull/232
- https://github.com/org-metaeffekt/metaeffekt-documentation-template/pull/24

Created a new Central Security Policy Configuration loader system that builds on and expands the features of the current system.  
Applied the new CspLoader on every mojo that requires a Security Policy with backwards compatibility by leaving the old parameters in place.

#### Advisor Periodic enrichment

- replace local advisoryProviders with security policy file parameter includeAdvisoryProviders
- replace local includeAdvisoryTypes with security policy file parameter includeAdvisoryTypes
- replace local vulnerabilityAdvisoryFilter with security policy file parameter includeVulnerabilitiesWithAdvisoryProviders

#### Vulnerability Report

- replace local generateOverviewTablesForAdvisories with a new security policy file parameter generateOverviewTablesForAdvisories