### PR TITLE
AE-1151 Fixed missing fields in vuln pdf report

### DIFF
--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/InventoryReport.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/InventoryReport.java
@@ -707,6 +707,8 @@ public class InventoryReport {
         properties.put(Velocity.INPUT_ENCODING, FileUtils.ENCODING_UTF_8);
         properties.put(Velocity.OUTPUT_ENCODING, FileUtils.ENCODING_UTF_8);
         properties.put(Velocity.SET_NULL_ALLOWED, true);
+        //https://velocity.apache.org/engine/1.7/developer-guide.html#velocimacro
+        properties.put("velocimacro.arguments.strict", true);
 
         final VelocityEngine velocityEngine = new VelocityEngine(properties);
         final Template template = velocityEngine.getTemplate(templateResourcePath);

--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/inventory-report-vulnerability/tpc_inventory-vulnerability-components.dita.vt
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/inventory-report-vulnerability/tpc_inventory-vulnerability-components.dita.vt
@@ -40,9 +40,10 @@
                     ## section with vulnerabilities for component
                     #if(!$vulnerabilitiesForComponent.isEmpty())
                     <section>
-                        <title>$utils.getText("inventory-report-vulnerability.short.vulnerabilites")</title>
+                        #set($title = $utils.getText("inventory-report-vulnerability.short.vulnerabilites"))
+                        <title>$title</title>
                         <body>
-                            #vulnerabilityOverview("${componentEscapedId}_vulnerabilities", "${component}" $utils.getText("inventory-report-vulnerability.short.vulnerabilites"), $vulnerabilitiesForComponent, true)
+                            #vulnerabilityOverview("${componentEscapedId}_vulnerabilities", "${component} $title", $vulnerabilitiesForComponent, true)
                         </body>
                     </section>
                     #end

--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/inventory-report-vulnerability/tpc_inventory-vulnerability-details.dita.vt
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/inventory-report-vulnerability/tpc_inventory-vulnerability-details.dita.vt
@@ -40,47 +40,50 @@
             </section>
 
             <section>
-                <title>$utils.getText("general.short.references")</title>
+                #set($title = $utils.getText("general.short.references"))
+                <title>$title</title>
                 <body>
-                    #referenceTable("${vulnerabilityNameIdEscaped}_ref", "$vulnerabilityNameTextEscaped" $utils.getText("general.short.references"), $vulnerability)
+                    #referenceTable("${vulnerabilityNameIdEscaped}_ref", "$vulnerabilityNameTextEscaped $title", $vulnerability)
                 </body>
             </section>
 
             #set($affectedAssets = $vulnerabilityAdapter.getAffectedAssets($vulnerability.getAffectedArtifactsByDefaultKey()))
             #if(!$affectedAssets.isEmpty())
             <section>
-                <title>$utils.getText("general.short.affected-assets")</title>
+                #set($title = $utils.getText("general.short.affected-assets"))
+                <title>$title</title>
                 <body>
-                    #set($title = "${vulnerabilityNameTextEscaped}" + $utils.getText("general.short.affected-assets"))
-                    #affectedAssetsTable($vulnerability, $affectedAssets, $title)
+                    #affectedAssetsTable($vulnerability, $affectedAssets, "$vulnerabilityNameTextEscaped $title")
                 </body>
             </section>
             #end
 
             <section>
-                <title>$utils.getText("general.short.affected-components")</title>
+                #set($title = $utils.getText("general.short.affected-components"))
+                <title>$title</title>
                 <body>
                     #set($affectedComponents = $vulnerability.getAffectedArtifactsByDefaultKey())
-                    #set($title = "${vulnerabilityNameTextEscaped}" + $utils.getText("general.short.affected-components"))
-                    #affectedComponentsTable($vulnerability, $affectedComponents, $title)
+                    #affectedComponentsTable($vulnerability, $affectedComponents, "${vulnerabilityNameTextEscaped} $title")
                 </body>
             </section>
 ##
 
 #if ($utils.notEmpty($vulnerability.getCweString()))
             <section>
-                <title>$utils.getText("inventory-report-vulnerability.short.weakness")</title>
+                #set($title = $utils.getText("inventory-report-vulnerability.short.weakness"))
+                <title>$title</title>
                 <body>
                     $report.xmlEscapeString($vulnerability.getCweString())
                 </body>
             </section>
 #end
             <section>
-                <title>$utils.getText("inventory-report-vulnerability.short.initial-severity")</title>
+                #set($title = $utils.getText("inventory-report-vulnerability.short.initial-severity"))
+                <title>$title</title>
                 <body>
 #if ($vulnerability.getCvssSelectionResult().hasInitialCvss())
                     <p>
-                        #cvssScoreOverviewTable("${vulnerabilityNameIdEscaped}_severity", "$vulnerabilityNameTextEscaped" $utils.getText("inventory-report-vulnerability.short.initial-severity"), $vulnerability, false)
+                        #cvssScoreOverviewTable("${vulnerabilityNameIdEscaped}_severity", "$vulnerabilityNameTextEscaped $title", $vulnerability, false)
                     </p>
 ##                    <p>
 ##                        #cvssScoreDetailsTable("${vulnerabilityNameIdEscaped}_severity_details", "$vulnerabilityNameTextEscaped Initial Severity Details", $vulnerability, false)
@@ -94,40 +97,45 @@
         </body>
 
         <topic id="${vulnerabilityName}-advisories">
-            <title>$utils.getText("inventory-report-vulnerability.short.advisories")</title>
+            #set($title = $utils.getText("inventory-report-vulnerability.short.advisories"))
+            <title>$title</title>
             <body>
 #if ($advisoriesAlerts.isEmpty() && $advisoriesNotices.isEmpty() && $advisoriesNews.isEmpty() && $otherAdvisories.isEmpty())
                 <p>$utils.getText("inventory-report-vulnerability.no-identified-security-advisories")</p>
 #end
 #if (!$advisoriesAlerts.isEmpty())
             <section>
-                <title>$utils.getText("inventory-report-vulnerability.short.alerts")</title>
+                #set($title = $utils.getText("inventory-report-vulnerability.short.alerts"))
+                <title>$title</title>
                 <p>
-#advisoryOverview("${vulnerabilityNameIdEscaped}_alerts", "$vulnerabilityNameTextEscaped" $utils.getText("inventory-report-vulnerability.short.alerts"), $advisoriesAlerts)
+                    #advisoryOverview("${vulnerabilityNameIdEscaped}_alerts", "${vulnerabilityNameTextEscaped} $title", $advisoriesAlerts)
                 </p>
             </section>
 #end
 #if (!$advisoriesNotices.isEmpty())
             <section>
-                <title>$utils.getText("inventory-report-vulnerability.short.notices")</title>
+                #set($title = $utils.getText("inventory-report-vulnerability.short.notices"))
+                <title>$title</title>
                 <p>
-#advisoryOverview("${vulnerabilityNameIdEscaped}_notices", "$vulnerabilityNameTextEscaped" $utils.getText("inventory-report-vulnerability.short.notices"), $advisoriesNotices)
+                    #advisoryOverview("${vulnerabilityNameIdEscaped}_notices", "${vulnerabilityNameTextEscaped} $title", $advisoriesNotices)
                 </p>
             </section>
 #end
 #if (!$advisoriesNews.isEmpty())
             <section>
-                <title>$utils.getText("inventory-report-vulnerability.short.updates")</title>
+                #set($title = $utils.getText("inventory-report-vulnerability.short.updates"))
+                <title>$title</title>
                 <p>
-#advisoryOverview("${vulnerabilityNameIdEscaped}_updates", "$vulnerabilityNameTextEscaped" $utils.getText("inventory-report-vulnerability.short.updates"), $advisoriesNews)
+                    #advisoryOverview("${vulnerabilityNameIdEscaped}_updates", "${vulnerabilityNameTextEscaped} $title", $advisoriesNews)
                 </p>
             </section>
 #end
 #if (!$otherAdvisories.isEmpty())
             <section>
-                <title>$utils.getText("general.short.other")</title>
+                #set($title = $utils.getText("general.short.other"))
+                <title>$title</title>
                 <p>
-#advisoryOverview("${vulnerabilityNameIdEscaped}_other_advisories", "$vulnerabilityNameTextEscaped" $utils.getText("general.short.other"), $otherAdvisories)
+                    #advisoryOverview("${vulnerabilityNameIdEscaped}_other_advisories", "$vulnerabilityNameTextEscaped $title", $otherAdvisories)
                 </p>
             </section>
 #end
@@ -159,10 +167,11 @@
 ##
 #if ($vulnerability.getCvssSelectionResult().hasContextCvss())
                 <section>
-                    <title>$utils.getText("inventory-report-vulnerability.short.context-severity")</title>
+                    #set($title = $utils.getText("inventory-report-vulnerability.short.context-severity"))
+                    <title>$title</title>
                     <body>
                         <p>
-                            #cvssScoreOverviewTable("${vulnerabilityNameIdEscaped}_modified_severity", "$vulnerabilityNameTextEscaped" $utils.getText("inventory-report-vulnerability.short.context-severity"), $vulnerability, true)
+                            #cvssScoreOverviewTable("${vulnerabilityNameIdEscaped}_modified_severity", "$vulnerabilityNameTextEscaped $title", $vulnerability, true)
                         </p>
                     </body>
                 </section>
@@ -178,9 +187,10 @@
 #end
 
                 <section>
-                    <title>$utils.getText("inventory-report-vulnerability.short.cvss-severity")</title>
+                    #set($title = $utils.getText("inventory-report-vulnerability.short.cvss-severity"))
+                    <title>$title</title>
                     <body>
-                        #cvssScoreChartsTable("${vulnerabilityNameIdEscaped}_severity_charts", "$vulnerabilityNameTextEscaped" $utils.getText("inventory-report-vulnerability.short.cvss-severity"), $vulnerability)
+                        #cvssScoreChartsTable("${vulnerabilityNameIdEscaped}_severity_charts", "$vulnerabilityNameTextEscaped $title", $vulnerability)
                     </body>
                 </section>
 


### PR DESCRIPTION
[Jira](https://metaeffekt.atlassian.net/jira/software/projects/AE/boards/11?assignee=712020%3A1ca1c356-dfc9-41ee-903b-85a15274b62d&selectedIssue=AE-1151)

fields such as 'advisories' and 'assessment' in the 'vuln details' chapter of the report were missing in the pdf.


the problem was casued by too many arguments being supplied to a vt macro, yet the vt engine would silently fail and simply not render those sections -> added a vt config which now fails the generation process if argument count diverges 