### PR TITLE
Ae 1152 fix summary labels

### DIFF
--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/configuration/ProcessConfiguration.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/configuration/ProcessConfiguration.java
@@ -77,54 +77,63 @@ public abstract class ProcessConfiguration {
         return id;
     }
 
+    public void debugLogConfiguration() {
+        final Map<String, Object> configuration = getProperties();
+
+        if (!configuration.isEmpty()) {
+            LOG.debug("Configuration [{}]:", getId());
+            logConfiguration(configuration, 1, LOG::debug);
+        }
+    }
+
     public void logConfiguration() {
         final Map<String, Object> configuration = getProperties();
 
         if (!configuration.isEmpty()) {
             LOG.info("Configuration [{}]:", getId());
-            logConfiguration(configuration, 1);
+            logConfiguration(configuration, 1, LOG::info);
         }
     }
 
-    private void logConfiguration(List<Object> configuration, int indent) {
+    private void logConfiguration(List<Object> configuration, int indent, Consumer<String> logLevel) {
         if (!configuration.isEmpty()) {
             configuration.forEach(value -> {
                 final StringBuilder sb = new StringBuilder();
                 sb.append(IntStream.range(0, indent).mapToObj(i -> "  ").reduce("", String::concat));
                 if (value instanceof LinkedHashMap) {
-                    LOG.info(sb.toString());
-                    logConfiguration((LinkedHashMap<String, Object>) value, indent + 1);
+                    logLevel.accept(sb.toString());
+                    logConfiguration((LinkedHashMap<String, Object>) value, indent + 1, logLevel);
                 } else if (value instanceof List) {
-                    LOG.info(sb.toString());
-                    logConfiguration((List) value, indent + 1);
+                    logLevel.accept(sb.toString());
+                    logConfiguration((List) value, indent + 1, logLevel);
                 } else if (value instanceof ProcessConfiguration) {
-                    logConfiguration(((ProcessConfiguration) value).getProperties(), indent + 1);
+                    logConfiguration(((ProcessConfiguration) value).getProperties(), indent + 1, logLevel);
                 } else {
                     sb.append(value);
-                    LOG.info(sb.toString());
+                    logLevel.accept(sb.toString());
                 }
             });
         }
     }
 
-    private void logConfiguration(Map<String, Object> configuration, int indent) {
+    private void logConfiguration(Map<String, Object> configuration, int indent, Consumer<String> logLevel) {
         if (!configuration.isEmpty()) {
             configuration.forEach((key, value) -> {
                 final StringBuilder sb = new StringBuilder();
                 sb.append(IntStream.range(0, indent).mapToObj(i -> "  ").reduce("", String::concat))
                         .append(key).append(": ");
                 if (value instanceof LinkedHashMap) {
-                    LOG.info(sb.toString());
-                    logConfiguration((LinkedHashMap<String, Object>) value, indent + 1);
+                    logLevel.accept(sb.toString());
+                    logConfiguration((LinkedHashMap<String, Object>) value, indent + 1, logLevel);
                 } else if (value instanceof List) {
-                    LOG.info(sb.toString());
-                    logConfiguration((List) value, indent + 1);
+                    logLevel.accept(sb.toString());
+                    logConfiguration((List) value, indent + 1, logLevel);
                 } else if (value instanceof ProcessConfiguration) {
-                    LOG.info(sb.toString());
-                    logConfiguration(((ProcessConfiguration) value).getProperties(), indent + 1);
+                    logLevel.accept(sb.toString());
+                    logConfiguration(((ProcessConfiguration) value).getProperties(), indent + 1, logLevel);
                 } else {
                     sb.append(value);
-                    LOG.info(sb.toString());
+                    logLevel.accept(sb.toString());
                 }
             });
         }

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/InventoryReport.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/InventoryReport.java
@@ -998,9 +998,9 @@ public class InventoryReport {
     }
 
     private void logConfiguration() {
-        LOG.info("Report configuration:");
+        LOG.debug("Report configuration:");
 
-        LOG.info("- Source/Target paths:");
+        LOG.debug("- Source/Target paths:");
         logConfigurationLogFile("referenceInventoryDir", referenceInventoryDir);
         logConfigurationLogToString("referenceInventoryIncludes", referenceInventoryIncludes);
         logConfigurationLogToString("referenceComponentPath", referenceComponentPath);
@@ -1013,30 +1013,30 @@ public class InventoryReport {
         logConfigurationLogFile("targetLicenseDir", targetLicenseDir);
         logConfigurationLogToString("relativeLicensePath", relativeLicensePath);
 
-        LOG.info("- Validation fail flags:");
-        LOG.info(" - [failOnError: {}] [failOnBanned: {}] [failOnDowngrade: {}] [failOnUnknown: {}] [failOnUnknownVersion: {}] [failOnDevelopment: {}] [failOnInternal: {}]", configParams.isFailOnError(),  configParams.isFailOnBanned(),  configParams.isFailOnDowngrade(),  configParams.isFailOnUnknown(),  configParams.isFailOnUnknownVersion(),  configParams.isFailOnDevelopment(),  configParams.isFailOnInternal());
-        LOG.info("   [failOnUpgrade: {}] [failOnMissingLicense: {}] [failOnMissingLicenseFile: {}] [failOnMissingNotice: {}] [failOnMissingComponentFiles: {}]",  configParams.isFailOnUpgrade(),  configParams.isFailOnMissingLicense(),  configParams.isFailOnMissingLicenseFile(),  configParams.isFailOnMissingNotice(),  configParams.isFailOnMissingComponentFiles());
+        LOG.debug("- Validation fail flags:");
+        LOG.debug(" - [failOnError: {}] [failOnBanned: {}] [failOnDowngrade: {}] [failOnUnknown: {}] [failOnUnknownVersion: {}] [failOnDevelopment: {}] [failOnInternal: {}]", configParams.isFailOnError(),  configParams.isFailOnBanned(),  configParams.isFailOnDowngrade(),  configParams.isFailOnUnknown(),  configParams.isFailOnUnknownVersion(),  configParams.isFailOnDevelopment(),  configParams.isFailOnInternal());
+        LOG.debug("   [failOnUpgrade: {}] [failOnMissingLicense: {}] [failOnMissingLicenseFile: {}] [failOnMissingNotice: {}] [failOnMissingComponentFiles: {}]",  configParams.isFailOnUpgrade(),  configParams.isFailOnMissingLicense(),  configParams.isFailOnMissingLicenseFile(),  configParams.isFailOnMissingNotice(),  configParams.isFailOnMissingComponentFiles());
 
-        LOG.info("- Data display settings:");
+        LOG.debug("- Data display settings:");
         logConfigurationLogToString("artifactFilter", artifactFilter);
         logConfigurationLogToString("filterVulnerabilitiesNotCoveredByArtifacts", configParams.isFilterVulnerabilitiesNotCoveredByArtifacts());
         logConfigurationLogToString("filterAdvisorySummary", configParams.isFilterAdvisorySummary());
 
-        LOG.info("- Template settings:");
-        LOG.info(" - [inventoryBomReportEnabled: {}] [inventoryDiffReportEnabled: {}] [inventoryPomEnabled: {}] [inventoryVulnerabilityReportEnabled: {}]",  configParams.isInventoryBomReportEnabled(),  configParams.isInventoryDiffReportEnabled(),  configParams.isInventoryPomEnabled(),  configParams.isInventoryVulnerabilityReportEnabled());
-        LOG.info("   [inventoryVulnerabilityReportSummaryEnabled: {}] [inventoryVulnerabilityStatisticsReportEnabled: {}]",  configParams.isInventoryVulnerabilityReportSummaryEnabled(),  configParams.isInventoryVulnerabilityStatisticsReportEnabled());
+        LOG.debug("- Template settings:");
+        LOG.debug(" - [inventoryBomReportEnabled: {}] [inventoryDiffReportEnabled: {}] [inventoryPomEnabled: {}] [inventoryVulnerabilityReportEnabled: {}]",  configParams.isInventoryBomReportEnabled(),  configParams.isInventoryDiffReportEnabled(),  configParams.isInventoryPomEnabled(),  configParams.isInventoryVulnerabilityReportEnabled());
+        LOG.debug("   [inventoryVulnerabilityReportSummaryEnabled: {}] [inventoryVulnerabilityStatisticsReportEnabled: {}]",  configParams.isInventoryVulnerabilityReportSummaryEnabled(),  configParams.isInventoryVulnerabilityStatisticsReportEnabled());
         logConfigurationLogToString("templateLanguageSelector", configParams.getReportLanguage());
 
-        LOG.info("- Addon data:");
+        LOG.debug("- Addon data:");
         if (addOnArtifacts == null) {
-            LOG.info(" - addOnArtifacts: <null>");
+            LOG.debug(" - addOnArtifacts: <null>");
         } else if (addOnArtifacts.isEmpty()) {
-            LOG.info(" - addOnArtifacts: <empty>");
+            LOG.debug(" - addOnArtifacts: <empty>");
         } else {
-            LOG.info(" - addOnArtifacts: {}", addOnArtifacts.stream().map(Artifact::getId).collect(Collectors.toList()));
+            LOG.debug(" - addOnArtifacts: {}", addOnArtifacts.stream().map(Artifact::getId).collect(Collectors.toList()));
         }
 
-        securityPolicy.logConfiguration();
+        securityPolicy.debugLogConfiguration();
     }
 
     private void logConfigurationLogFile(String property, File file) {

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/configuration/CspLoader.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/configuration/CspLoader.java
@@ -37,6 +37,7 @@ public class CspLoader {
     private File file;
     private List<File> files = new ArrayList<>();
     private List<String> activeIds = new ArrayList<>();
+    private boolean failOnMissingPolicyFile = true;
 
     public void addFile(File... files) {
         this.files.addAll(Arrays.asList(files));
@@ -52,7 +53,7 @@ public class CspLoader {
         try {
             return this.loadConfigurationInternal();
         } catch (IOException e) {
-            throw new RuntimeException("CSP loader failed to create Central Security Policy instance from parameters.", e);
+            throw new RuntimeException("[csp-loader] CSP loader failed to create Central Security Policy instance from parameters.", e);
         }
     }
 
@@ -60,6 +61,11 @@ public class CspLoader {
         final List<File> policyFiles = this.getFiles();
 
         if (policyFiles.isEmpty() && StringUtils.isEmpty(inlineOverwriteJson)) {
+
+            if (failOnMissingPolicyFile) {
+                throw new IllegalStateException("[csp-loader] No valid security policy files were provided and property failOnMissingPolicyFile is set to true.");
+            }
+
             log.info("[csp-loader] No policyFiles or inlineOverwriteJson were provided, using default Central Security Policy instance");
             return new CentralSecurityPolicyConfiguration();
         }

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/configuration/CspLoader.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/configuration/CspLoader.java
@@ -53,7 +53,7 @@ public class CspLoader {
         try {
             return this.loadConfigurationInternal();
         } catch (IOException e) {
-            throw new RuntimeException("[csp-loader] CSP loader failed to create Central Security Policy instance from parameters.", e);
+            throw new RuntimeException("Central security policy loader failed to create CCentral security policy instance from parameters.", e);
         }
     }
 
@@ -63,23 +63,23 @@ public class CspLoader {
         if (policyFiles.isEmpty() && StringUtils.isEmpty(inlineOverwriteJson)) {
 
             if (failOnMissingPolicyFile) {
-                throw new IllegalStateException("[csp-loader] No valid security policy files were provided and property failOnMissingPolicyFile is set to true.");
+                throw new IllegalStateException("No valid security policy files were provided and property failOnMissingPolicyFile is set to true.");
             }
 
-            log.info("[csp-loader] No policyFiles or inlineOverwriteJson were provided, using default Central Security Policy instance");
+            log.info("No policyFiles or inlineOverwriteJson were provided, using default Central Security Policy instance");
             return new CentralSecurityPolicyConfiguration();
         }
 
         if (activeIds.isEmpty()) {
-            log.info("[csp-loader] No active Ids provided to build security policy from, either activeByDefault or inlineOverwriteJson must be set to obtain any properties");
+            log.info("No active Ids provided to build security policy from, either activeByDefault or inlineOverwriteJson must be set to obtain any properties");
         } else {
-            log.info("[csp-loader] Building configurations from Ids: {}", activeIds);
+            log.info("Building configurations from Ids: {}", activeIds);
         }
 
         final List<CspLoaderEntry> allEntries = new ArrayList<>();
         for (File policyFile : policyFiles) {
             final List<CspLoaderEntry> entries = CspLoaderEntry.fromFile(policyFile);
-            log.info("[csp-loader]   ↳ Parsed [{}] configurations", entries.size());
+            log.info("  ↳ Parsed [{}] configurations", entries.size());
             allEntries.addAll(entries);
         }
 
@@ -97,13 +97,13 @@ public class CspLoader {
         for (String activeId : activeIds) {
             final CspLoaderEntry foundEntry = idToEntryMap.get(activeId);
             if (foundEntry == null) {
-                throw new IllegalStateException("[csp-loader] Configured Configuration Id [" + activeId + "] does not exist");
+                throw new IllegalStateException("Configured Configuration Id [" + activeId + "] does not exist");
             }
             if (!activeEntries.contains(foundEntry)) {
                 activeEntries.add(foundEntry);
             }
         }
-        log.info("[csp-loader] - Activating configuration(s): {}", activeEntries.stream().map(CspLoaderEntry::getId).collect(Collectors.toList()));
+        log.info("Activating configuration(s): {}", activeEntries.stream().map(CspLoaderEntry::getId).collect(Collectors.toList()));
 
         final Set<CspLoaderEntry> checkedExtends = new HashSet<>();
         final Queue<CspLoaderEntry> checkExtends = new LinkedList<>(activeEntries);
@@ -114,34 +114,34 @@ public class CspLoader {
             for (String extendedId : current.getExtendsEntries()) {
                 final CspLoaderEntry extendsEntry = idToEntryMap.get(extendedId);
                 if (extendsEntry == null) {
-                    throw new IllegalStateException("[csp-loader] Configuration [" + current.getId() + "] extends entry does not exist [" + extendedId + "]");
+                    throw new IllegalStateException("Configuration [" + current.getId() + "] extends entry does not exist [" + extendedId + "]");
                 }
                 if (!activeEntries.contains(extendsEntry)) {
-                    log.info("[csp-loader] - Activating configuration [{}] because it is extended by [{}]", extendsEntry.getId(), current.getId());
+                    log.info("- Activating configuration [{}] because it is extended by [{}]", extendsEntry.getId(), current.getId());
                     activeEntries.add(0, extendsEntry);
                     checkExtends.add(extendsEntry);
                 }
             }
         }
 
-        log.info("[csp-loader] Filtered total configurations [{}] {} to selected configurations [{}] {}",
+        log.info("Filtered total configurations [{}] {} to selected configurations [{}] {}",
                 idToEntryMap.size(), allEntries.stream().map(CspLoaderEntry::getId).collect(Collectors.toList()),
                 activeEntries.size(), activeEntries.stream().map(CspLoaderEntry::getId).collect(Collectors.toList()));
 
-        log.info("[csp-loader] Merging [{}] configurations into effective configuration", activeEntries.size());
+        log.info("Merging [{}] configurations into effective configuration", activeEntries.size());
         final JSONObject mergedConfig = new JSONObject();
         for (CspLoaderEntry entry : activeEntries) {
-            log.info("[csp-loader] - [{}]: {}", entry.getId(), entry.getConfiguration());
+            log.info("[{}]: {}", entry.getId(), entry.getConfiguration());
             mergeJson(mergedConfig, entry.getConfiguration());
         }
 
         if (inlineOverwriteJson != null && !inlineOverwriteJson.trim().isEmpty()) {
-            log.info("[csp-loader] - inline overwrite: {}", inlineOverwriteJson);
+            log.info("inline overwrite: {}", inlineOverwriteJson);
             mergeJson(mergedConfig, new JSONObject(inlineOverwriteJson));
         }
 
-        log.info("[csp-loader]   ↳ {}", mergedConfig);
-        return CentralSecurityPolicyConfiguration.fromJson(mergedConfig, "CSP Failed to parse Effective Security Policy Configuration");
+        log.info("  ↳ {}", mergedConfig);
+        return CentralSecurityPolicyConfiguration.fromJson(mergedConfig, "Central security policy failed to parse effective security policy configuration");
     }
 
     private void mergeJson(JSONObject target, JSONObject source) {
@@ -162,10 +162,10 @@ public class CspLoader {
 
         public static List<CspLoaderEntry> fromFile(File file) throws IOException {
             if (file == null || !file.exists() || !file.isFile()) {
-                throw new FileNotFoundException("[csp-loader] CSP file must exist but was not found: file://" + canonicalOrAbsolute(file));
+                throw new FileNotFoundException("CSP file must exist but was not found: file://" + canonicalOrAbsolute(file));
             }
 
-            log.info("[csp-loader] - Loading file://{}", canonicalOrAbsolute(file));
+            log.info("Loading file://{}", canonicalOrAbsolute(file));
             final List<CspLoaderEntry> entries = new ArrayList<>();
             final String content = FileUtils.readFileToString(file, StandardCharsets.UTF_8);
 
@@ -174,21 +174,21 @@ public class CspLoader {
                 for (int i = 0; i < jsonArray.length(); i++) {
                     final JSONObject jsonEntry = jsonArray.optJSONObject(i);
                     if (jsonEntry == null) {
-                        throw new IllegalStateException("[csp-loader] Expected JSON Object in file://" + canonicalOrAbsolute(file) + " but got: " + jsonArray.get(i));
+                        throw new IllegalStateException("Expected JSON Object in file://" + canonicalOrAbsolute(file) + " but got: " + jsonArray.get(i));
                     }
 
                     final Set<String> keys = jsonEntry.keySet();
                     for (String key : keys) {
                         if (!ALLOWED_KEYS.contains(key)) {
-                            throw new IllegalStateException("[csp-loader] Unknown key in configuration entry [" + key + "] in file://" + canonicalOrAbsolute(file));
+                            throw new IllegalStateException("Unknown key in configuration entry [" + key + "] in file://" + canonicalOrAbsolute(file));
                         }
                     }
 
                     if (!jsonEntry.has("id")) {
-                        throw new IllegalStateException("[csp-loader] Missing required key 'id' in configuration entry in file://" + canonicalOrAbsolute(file));
+                        throw new IllegalStateException("Missing required key 'id' in configuration entry in file://" + canonicalOrAbsolute(file));
                     }
                     if (!jsonEntry.has("configuration")) {
-                        throw new IllegalStateException("[csp-loader] Missing required key 'configuration' in configuration entry [" + jsonEntry.get("id") + "] in file://" + canonicalOrAbsolute(file));
+                        throw new IllegalStateException("Missing required key 'configuration' in configuration entry [" + jsonEntry.get("id") + "] in file://" + canonicalOrAbsolute(file));
                     }
 
                     final CspLoaderEntry entry = new CspLoaderEntry(file);
@@ -197,13 +197,13 @@ public class CspLoader {
                     if (jsonEntry.has("extends")) {
                         final Object extendsObj = jsonEntry.get("extends");
                         if (!(extendsObj instanceof JSONArray)) {
-                            throw new IllegalStateException("[csp-loader] 'extends' must be a JSON array in configuration entry [" + entry.id + "] in file://" + canonicalOrAbsolute(file));
+                            throw new IllegalStateException("'extends' must be a JSON array in configuration entry [" + entry.id + "] in file://" + canonicalOrAbsolute(file));
                         }
                         final JSONArray extendsArray = (JSONArray) extendsObj;
                         for (int j = 0; j < extendsArray.length(); j++) {
                             final Object val = extendsArray.get(j);
                             if (!(val instanceof String)) {
-                                throw new IllegalStateException("[csp-loader] All elements of 'extends' must be strings in configuration entry [" + entry.id + "] in file://" + canonicalOrAbsolute(file));
+                                throw new IllegalStateException("All elements of 'extends' must be strings in configuration entry [" + entry.id + "] in file://" + canonicalOrAbsolute(file));
                             }
                             entry.extendsEntries.add((String) val);
                         }
@@ -212,7 +212,7 @@ public class CspLoader {
                     if (jsonEntry.has("activeByDefault")) {
                         final Object activeObj = jsonEntry.get("activeByDefault");
                         if (!(activeObj instanceof Boolean)) {
-                            throw new IllegalStateException("[csp-loader] 'activeByDefault' must be a boolean in configuration entry [" + entry.id + "] in file://" + canonicalOrAbsolute(file));
+                            throw new IllegalStateException("'activeByDefault' must be a boolean in configuration entry [" + entry.id + "] in file://" + canonicalOrAbsolute(file));
                         }
                         entry.activeByDefault = (Boolean) activeObj;
                     }
@@ -223,14 +223,14 @@ public class CspLoader {
                         try {
                             entry.configuration = new JSONObject(FileUtils.readFileToString(nestedFile, StandardCharsets.UTF_8));
                         } catch (IOException e) {
-                            throw new IllegalStateException("[csp-loader] Failed to load sub-configuration from://" + canonicalOrAbsolute(nestedFile), e);
+                            throw new IllegalStateException("Failed to load sub-configuration from://" + canonicalOrAbsolute(nestedFile), e);
                         } catch (JSONException e) {
-                            throw new IllegalStateException("[csp-loader] Invalid JSON in sub-configuration file://" + canonicalOrAbsolute(nestedFile), e);
+                            throw new IllegalStateException("Invalid JSON in sub-configuration file://" + canonicalOrAbsolute(nestedFile), e);
                         }
                     } else if (config instanceof JSONObject) {
                         entry.configuration = (JSONObject) config;
                     } else {
-                        throw new IllegalStateException("[csp-loader] 'configuration' must be a string path or JSON object in configuration entry [" + entry.id + "] in file://" + canonicalOrAbsolute(file));
+                        throw new IllegalStateException("'configuration' must be a string path or JSON object in configuration entry [" + entry.id + "] in file://" + canonicalOrAbsolute(file));
                     }
 
                     entries.add(entry);

--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/inventory-report-vulnerability/tpc_inventory-vulnerability-details.dita.vt
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/inventory-report-vulnerability/tpc_inventory-vulnerability-details.dita.vt
@@ -187,16 +187,23 @@
 ##                </section>
 #end
 
-                <section>
-                    #set($title = $utils.getText("inventory-report-vulnerability.short.cvss-severity"))
+                #set ($vulnerabilityName=$vulnerability.getId())
+                #set ($chartModifiedFilePath     = "resources/svg/cvss_modified_${vulnerabilityName}.svg")
+                #set ($chartModifiedFileExists   = $vulnerabilityAdapter.fileExists("${targetReportDir}/${chartModifiedFilePath}"))
+                #set ($chartUnmodifiedFilePath   = "resources/svg/cvss_unmodified_${vulnerabilityName}.svg")
+                #set ($chartUnmodifiedFileExists = $vulnerabilityAdapter.fileExists("${targetReportDir}/${chartUnmodifiedFilePath}"))
+
+                #if ($chartModifiedFileExists || $chartUnmodifiedFileExists)
+                  <section>
+                      #set($title = $utils.getText("inventory-report-vulnerability.short.cvss-severity"))
                     <title>$title</title>
                     <body>
                         #cvssScoreChartsTable("${vulnerabilityNameIdEscaped}_severity_charts", "$vulnerabilityNameTextEscaped $title", $vulnerability)
                     </body>
-                </section>
+                  </section>
 
-                #vulnerabilityStatusDetails($vulnerability)
-
+                    #vulnerabilityStatusDetails($vulnerability)
+                #end
             </body>
         </topic>
 

--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/inventory-report-vulnerability/tpc_inventory-vulnerability-details.dita.vt
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/inventory-report-vulnerability/tpc_inventory-vulnerability-details.dita.vt
@@ -148,13 +148,17 @@
                     <title>$utils.getText("general.short.summary")</title>
                     <body>
                         <p>
-                            #set ($assessmentSummaryLabels = $vulnerabilityAdapter.getVulnerabilityStatusLabels($vulnerability))
+                            #set($statusLabel = $vulnerabilityAdapter.getStatusLabel($vulnerability))
+                            #set($priorityLabel = $vulnerabilityAdapter.getPriorityLabel($vulnerability))
                             #set ($displaySeverity = $vulnerabilityAdapter.shouldDisplayEffectiveVulnerabilityStatusCvssSeverity($vulnerability))
-##
-                            #foreach ($label in $assessmentSummaryLabels)
-                                #labelRef($label)
+
+                            #if ($statusLabel)
+                                #labelRef($statusLabel)
                             #end
-##
+                            #if ($priorityLabel && !$configParams.isHidePriorityInformation())
+                                #labelRef($priorityLabel)
+                            #end
+
                             #if ($displaySeverity)
                                 #set ($cvssVector = $vulnerability.getCvssSelectionResult().getSelectedContextIfAvailableOtherwiseInitial())
                                 #if ($cvssVector)

--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/inventory-report-vulnerability/tpc_inventory-vulnerability-details.dita.vt
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/inventory-report-vulnerability/tpc_inventory-vulnerability-details.dita.vt
@@ -142,32 +142,29 @@
             </body>
         </topic>
         <topic id="$vulnerability.getId()-assessment">
-            <title>$utils.getText("inventory-report-vulnerability.short.assessment")</title>
+            <title>$utils.getText("inventory-report-vulnerability.short.assessment")
+            <sub>
+                #set($statusLabel = $vulnerabilityAdapter.getStatusLabel($vulnerability))
+                #set($priorityLabel = $vulnerabilityAdapter.getPriorityLabel($vulnerability))
+                #set ($displaySeverity = $vulnerabilityAdapter.shouldDisplayEffectiveVulnerabilityStatusCvssSeverity($vulnerability))
+
+                #if ($displaySeverity)
+                    #set ($cvssVector = $vulnerability.getCvssSelectionResult().getSelectedContextIfAvailableOtherwiseInitial())
+                    #if ($cvssVector)
+                        #labelRef($vulnerabilityAdapter.getSeverityForVectorScore($cvssVector.getOverallScore()).getName())
+                    #end
+                #end
+
+                #if ($priorityLabel && !$configParams.isHidePriorityInformation())
+                    #labelRef($priorityLabel)
+                #end
+
+                #if ($statusLabel)
+                    #labelRef($statusLabel)
+                #end
+            </sub>
+            </title>
             <body>
-                <section>
-                    <title>$utils.getText("general.short.summary")</title>
-                    <body>
-                        <p>
-                            #set($statusLabel = $vulnerabilityAdapter.getStatusLabel($vulnerability))
-                            #set($priorityLabel = $vulnerabilityAdapter.getPriorityLabel($vulnerability))
-                            #set ($displaySeverity = $vulnerabilityAdapter.shouldDisplayEffectiveVulnerabilityStatusCvssSeverity($vulnerability))
-
-                            #if ($statusLabel)
-                                #labelRef($statusLabel)
-                            #end
-                            #if ($priorityLabel && !$configParams.isHidePriorityInformation())
-                                #labelRef($priorityLabel)
-                            #end
-
-                            #if ($displaySeverity)
-                                #set ($cvssVector = $vulnerability.getCvssSelectionResult().getSelectedContextIfAvailableOtherwiseInitial())
-                                #if ($cvssVector)
-                                    #labelRef($vulnerabilityAdapter.getSeverityForVectorScore($cvssVector.getOverallScore()).getName())
-                                #end
-                            #end
-                        </p>
-                    </body>
-                </section>
 ##
 #if ($vulnerability.getCvssSelectionResult().hasContextCvss())
                 <section>

--- a/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/RepositoryReportTest.java
+++ b/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/RepositoryReportTest.java
@@ -452,12 +452,20 @@ public class RepositoryReportTest {
     @Ignore
     @Test
     public void testCreateTestReport_External() throws Exception {
-        final File inventoryDir = new File("<path>");
-        final File reportDir = new File("<path>");
+        final File inventoryDir = new File("/Users/jfuegen/Desktop/test");
+        final File reportDir = new File("/Users/jfuegen/Desktop/test");
 
-        configureAndCreateReport(inventoryDir, "*.xlsx",
+        InventoryReport report = new InventoryReport(ReportConfigurationParameters.builder()
+                .reportLanguage("en")
+                .inventoryVulnerabilityStatisticsReportEnabled(true)
+                .inventoryVulnerabilityReportSummaryEnabled(true)
+                .inventoryVulnerabilityReportEnabled(true)
+                .hidePriorityInformation(false)
+                .build());
+
+        configureAndCreateReport(inventoryDir, "*.xls",
                 null, null,
-                reportDir, new InventoryReport(ReportConfigurationParameters.builder().reportLanguage("de").build()));
+                reportDir, report);
     }
 
     @Test

--- a/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/RepositoryReportTest.java
+++ b/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/RepositoryReportTest.java
@@ -452,8 +452,8 @@ public class RepositoryReportTest {
     @Ignore
     @Test
     public void testCreateTestReport_External() throws Exception {
-        final File inventoryDir = new File("/Users/jfuegen/Desktop/test");
-        final File reportDir = new File("/Users/jfuegen/Desktop/test");
+        final File inventoryDir = new File("<source>");
+        final File reportDir = new File("<target>");
 
         InventoryReport report = new InventoryReport(ReportConfigurationParameters.builder()
                 .reportLanguage("en")

--- a/plugins/ae-inventory-maven-plugin/src/main/java/org/metaeffekt/core/maven/inventory/mojo/AbstractInventoryReportCreationMojo.java
+++ b/plugins/ae-inventory-maven-plugin/src/main/java/org/metaeffekt/core/maven/inventory/mojo/AbstractInventoryReportCreationMojo.java
@@ -332,10 +332,10 @@ public abstract class AbstractInventoryReportCreationMojo extends AbstractProjec
 
         // log the security policy only when it fits the context -->
         if (enableAssessmentReport || enableVulnerabilityReport || enableVulnerabilityReportSummary || enableVulnerabilityStatisticsReport) {
-            getLog().info("");
-            getLog().info("-------------------< Security Policy Configuration >--------------------");
-            activeSecurityPolicy.logConfiguration();
-            getLog().info("");
+            getLog().debug("");
+            getLog().debug("-------------------< Security Policy Configuration >--------------------");
+            activeSecurityPolicy.debugLogConfiguration();
+            getLog().debug("");
         }
 
         report.setSecurityPolicy(activeSecurityPolicy);

--- a/poms/ae-core-plugin-management-pom/pom.xml
+++ b/poms/ae-core-plugin-management-pom/pom.xml
@@ -309,7 +309,10 @@
                                 <manageOptional>${artifact.inventory.manage.optional}</manageOptional>
                                 <managePlugins>${artifact.inventory.manage.plugins}</managePlugins>
 
-                                <securityPolicyOverwriteJson>{}</securityPolicyOverwriteJson>
+                                <securityPolicy>
+                                    <failOnMissingPolicyFile>false</failOnMissingPolicyFile>
+                                </securityPolicy>
+
                                 <artifactExcludes>${artifact.inventory.exclude.artifacts}</artifactExcludes>
                             </configuration>
                             <executions>


### PR DESCRIPTION
### Additions

- fixed priority label and status label showing up in report vulnerability summary
- priority label now only shows up if hidePriorityScore is disabled
- CVSS-Charts section is now omitted if no graphs exist
- CSPLoader now fails by default if no policy file was specified

### Notes

- CSP logging changes on ae:artifact-analysis were implemented in PR: AE-1153