### PR TITLE
AE-1304: Revise Asset Summary Report Table rendering

### DIFF
--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/InventoryReport.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/InventoryReport.java
@@ -708,7 +708,7 @@ public class InventoryReport {
         properties.put(Velocity.OUTPUT_ENCODING, FileUtils.ENCODING_UTF_8);
         properties.put(Velocity.SET_NULL_ALLOWED, true);
         //https://velocity.apache.org/engine/1.7/developer-guide.html#velocimacro
-        properties.put("velocimacro.arguments.strict", true);
+        properties.put("velocimacro.arguments.strict", "true");
 
         final VelocityEngine velocityEngine = new VelocityEngine(properties);
         final Template template = velocityEngine.getTemplate(templateResourcePath);

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/adapter/AssessmentReportAdapter.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/adapter/AssessmentReportAdapter.java
@@ -16,8 +16,10 @@
 package org.metaeffekt.core.inventory.processor.report.adapter;
 
 import lombok.Data;
+import lombok.experimental.Accessors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.metaeffekt.core.inventory.processor.model.AssetMetaData;
 import org.metaeffekt.core.inventory.processor.model.Inventory;
 import org.metaeffekt.core.inventory.processor.report.InventoryReport;
@@ -28,6 +30,7 @@ import org.metaeffekt.core.inventory.processor.report.model.aeaa.AeaaVulnerabili
 
 import java.util.*;
 import java.util.function.Consumer;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.metaeffekt.core.inventory.processor.report.StatisticsOverviewTable.SeverityToStatusRow;
@@ -55,7 +58,16 @@ public class AssessmentReportAdapter {
     /* display strings and names of the asset */
 
     public String assetDisplayName(AssetMetaData asset) {
-        return InventoryReport.xmlEscapeString(ObjectUtils.firstNonNull(asset.get(AssetMetaData.Attribute.NAME), asset.get(AssetMetaData.Attribute.ASSET_ID), "Unnamed Asset"));
+        final String assetName = ObjectUtils.firstNonNull(asset.get(AssetMetaData.Attribute.NAME), asset.get(AssetMetaData.Attribute.ASSET_ID), "Unnamed Asset");
+        final String assetVersion = asset.get(AssetMetaData.Attribute.VERSION);
+
+        // name might contain the version at the end, separated by a " - ".
+        // remove the version in this case, as it will be added below anyway.
+        if (StringUtils.isNotEmpty(assetVersion) && assetName.endsWith(assetVersion)) {
+            return InventoryReport.xmlEscapeString(assetName.replaceAll("( - |-)?" + Pattern.quote(assetVersion) + "$", ""));
+        } else {
+            return InventoryReport.xmlEscapeString(assetName);
+        }
     }
 
     public String assetDisplayType(AssetMetaData asset) {
@@ -68,9 +80,9 @@ public class AssessmentReportAdapter {
 
     /* counting and grouping assets */
 
-    private final static String DEFAULT_ASSET_GROUP_NAME = "Default";
+    public final static String DEFAULT_ASSET_GROUP_NAME = "Default";
 
-    public List<GroupedAssetsVulnerabilityCounts> groupAssetsByAssetGroup(Collection<AssetMetaData> assets, boolean useEffectiveSeverity) {
+    public List<GroupedAssetsVulnerabilityCounts> groupAssetsByAssetGroup(Collection<AssetMetaData> assets, boolean useEffectiveSeverity, boolean enableSingleAssetGroups) {
         final List<GroupedAssetsVulnerabilityCounts> groupedAssets = assets.stream()
                 .sorted(Comparator.comparing(this::assetGroupDisplayName, (s, str) -> {
                     // "Default" should be last
@@ -83,55 +95,78 @@ public class AssessmentReportAdapter {
                 .map(entry -> {
 
                     final List<GroupedAssetVulnerabilityCounts> groupedAssetVulnerabilityCounts = entry.getValue().stream()
-                            .map(asset -> {
-                                final VulnerabilityCounts counts = countVulnerabilities(asset, useEffectiveSeverity);
-                                final GroupedAssetVulnerabilityCounts groupedAssetCounts = new GroupedAssetVulnerabilityCounts();
-                                groupedAssetCounts.setAsset(asset);
-                                groupedAssetCounts.setAssetGroupDisplayName(entry.getKey());
-                                groupedAssetCounts.setAssetPath(ObjectUtils.firstNonNull(asset.get("Path"), asset.get(AssetMetaData.Attribute.ASSET_PATH)));
-                                groupedAssetCounts.setAssetDisplayName(assetDisplayName(asset));
-                                groupedAssetCounts.setTotalCounts(counts);
-                                return groupedAssetCounts;
-                            })
+                            .map(asset -> new GroupedAssetVulnerabilityCounts()
+                                    .setAsset(asset)
+                                    .setAssetGroupDisplayName(entry.getKey())
+                                    .setAssetPath(ObjectUtils.firstNonNull(asset.get("Path"), asset.get(AssetMetaData.Attribute.ASSET_PATH)))
+                                    .setAssetDisplayName(assetDisplayName(asset))
+                                    .setAssetVersion(asset.get(AssetMetaData.Attribute.VERSION))
+                                    .setTotalCounts(countVulnerabilities(asset, useEffectiveSeverity)))
                             .collect(Collectors.toList());
 
-                    final GroupedAssetsVulnerabilityCounts groupedAssetsCounts = new GroupedAssetsVulnerabilityCounts();
-                    groupedAssetsCounts.setGroupedAssetVulnerabilityCounts(groupedAssetVulnerabilityCounts);
-                    groupedAssetsCounts.setAssetGroupDisplayName(entry.getKey());
-                    groupedAssetsCounts.setAssetGroupAsXmlId(InventoryReport.xmlEscapeStringAttribute(entry.getKey()));
-                    groupedAssetsCounts.setTotalVulnerabilityCounts(VulnerabilityCounts.sumFrom(groupedAssetVulnerabilityCounts.stream()
-                            .map(GroupedAssetVulnerabilityCounts::getTotalCounts).collect(Collectors.toList())));
-
-                    return groupedAssetsCounts;
+                    return new GroupedAssetsVulnerabilityCounts()
+                            .setGroupedAssetVulnerabilityCounts(groupedAssetVulnerabilityCounts)
+                            .setAssetGroupDisplayName(entry.getKey())
+                            .setAssetGroupAsXmlId(InventoryReport.xmlEscapeStringAttribute(entry.getKey()))
+                            .setTotalVulnerabilityCounts(VulnerabilityCounts.sumFrom(groupedAssetVulnerabilityCounts.stream()
+                                    .map(GroupedAssetVulnerabilityCounts::getTotalCounts).collect(Collectors.toList())));
                 })
                 .collect(Collectors.toList());
 
-        // check if all groups contain exactly one asset
-        final boolean allGroupsHaveOneAsset = !groupedAssets.isEmpty() &&
-                groupedAssets.stream().allMatch(group -> group.getGroupedAssetVulnerabilityCounts().size() == 1);
-        // if all groups have exactly one asset and there are more than one group, combine them into a single group
-        boolean combineIntoOneGroup = allGroupsHaveOneAsset && groupedAssets.size() > 1;
-
-        if (!combineIntoOneGroup) {
-            return groupedAssets;
+        final List<GroupedAssetsVulnerabilityCounts> combinedGroups = optionallyCombineAssetGroups(groupedAssets, enableSingleAssetGroups);
+        if (combinedGroups != null) {
+            groupedAssets.clear();
+            groupedAssets.addAll(combinedGroups);
         }
 
-        log.debug("Combining all groups into a single group [{}] as all groups have exactly one asset: {}", DEFAULT_ASSET_GROUP_NAME,
-                groupedAssets.stream().map(c -> c.getAssetGroupDisplayName() + " (" + c.getGroupedAssetVulnerabilityCounts().stream().map(GroupedAssetVulnerabilityCounts::getAssetDisplayName).collect(Collectors.joining(", ")) + ")").collect(Collectors.joining(", ")));
+        return groupedAssets;
+    }
+
+    private static List<GroupedAssetsVulnerabilityCounts> optionallyCombineAssetGroups(List<GroupedAssetsVulnerabilityCounts> groupedAssets, boolean enableSingleAssetGroups) {
+        final List<GroupedAssetsVulnerabilityCounts> groupsWithSingleAsset = groupedAssets.stream()
+                .filter(group -> group.getGroupedAssetVulnerabilityCounts().size() == 1)
+                .collect(Collectors.toList());
+
+        // check if any or all groups contain exactly one asset
+        final boolean allGroupsHaveOneAsset = !groupedAssets.isEmpty() && groupsWithSingleAsset.size() == groupedAssets.size();
+        final boolean anyGroupHasOneAsset = !groupedAssets.isEmpty() && !groupsWithSingleAsset.isEmpty();
+
+        final List<GroupedAssetsVulnerabilityCounts> groupsToBeCombinedIntoDefaultGroup;
+        if (allGroupsHaveOneAsset) {
+            // if all groups have exactly one asset and there is more than one group, combine them into a single group
+            groupsToBeCombinedIntoDefaultGroup = new ArrayList<>(groupedAssets);
+        } else if (anyGroupHasOneAsset && !enableSingleAssetGroups) {
+            // combine all assets from all groups with only one asset into a single default group
+            groupsToBeCombinedIntoDefaultGroup = new ArrayList<>(groupsWithSingleAsset);
+        } else {
+            return null;
+        }
+
+        log.debug("Combining [{}] groups into a single group [{}] as all groups have exactly one asset: {}", groupsToBeCombinedIntoDefaultGroup.size(), DEFAULT_ASSET_GROUP_NAME,
+                groupsToBeCombinedIntoDefaultGroup.stream().map(c -> c.getAssetGroupDisplayName() + " (" + c.getGroupedAssetVulnerabilityCounts().stream().map(GroupedAssetVulnerabilityCounts::getAssetDisplayName).collect(Collectors.joining(", ")) + ")").collect(Collectors.joining(", ")));
 
         final GroupedAssetsVulnerabilityCounts combinedGroup = new GroupedAssetsVulnerabilityCounts();
-        final List<GroupedAssetVulnerabilityCounts> combinedAssets = groupedAssets.stream()
+        final List<GroupedAssetVulnerabilityCounts> combinedAssets = groupsToBeCombinedIntoDefaultGroup.stream()
                 .flatMap(group -> group.getGroupedAssetVulnerabilityCounts().stream())
                 .sorted(Comparator.comparing(GroupedAssetVulnerabilityCounts::getAssetDisplayName))
                 .collect(Collectors.toList());
 
-        combinedGroup.setGroupedAssetVulnerabilityCounts(combinedAssets);
-        combinedGroup.setAssetGroupDisplayName(DEFAULT_ASSET_GROUP_NAME);
-        combinedGroup.setAssetGroupAsXmlId(InventoryReport.xmlEscapeStringAttribute(DEFAULT_ASSET_GROUP_NAME));
-        combinedGroup.setTotalVulnerabilityCounts(VulnerabilityCounts.sumFrom(combinedAssets.stream()
-                .map(GroupedAssetVulnerabilityCounts::getTotalCounts).collect(Collectors.toList())));
+        combinedGroup.setGroupedAssetVulnerabilityCounts(combinedAssets)
+                .setAssetGroupDisplayName(DEFAULT_ASSET_GROUP_NAME)
+                .setAssetGroupAsXmlId(InventoryReport.xmlEscapeStringAttribute(DEFAULT_ASSET_GROUP_NAME))
+                .setTotalVulnerabilityCounts(VulnerabilityCounts.sumFrom(combinedAssets.stream()
+                        .map(GroupedAssetVulnerabilityCounts::getTotalCounts).collect(Collectors.toList())));
 
-        return Collections.singletonList(combinedGroup);
+        final List<GroupedAssetsVulnerabilityCounts> result = new ArrayList<>();
+        result.add(combinedGroup);
+
+        for (GroupedAssetsVulnerabilityCounts groupedAsset : groupedAssets) {
+            if (!groupsToBeCombinedIntoDefaultGroup.contains(groupedAsset)) {
+                result.add(groupedAsset);
+            }
+        }
+
+        return result;
     }
 
     public VulnerabilityCounts countVulnerabilities(AssetMetaData assetMetaData, boolean useEffectiveSeverity) {
@@ -180,20 +215,23 @@ public class AssessmentReportAdapter {
     }
 
     @Data
+    @Accessors(chain = true)
     public static class GroupedAssetVulnerabilityCounts {
         public AssetMetaData asset;
         public String assetGroupDisplayName;
         public String assetPath;
         public String assetDisplayName;
+        public String assetVersion;
         public VulnerabilityCounts totalCounts;
 
         public void log() {
-            log.info(" - Asset:     {} (in {}) (path: {})", assetDisplayName, assetGroupDisplayName, assetPath);
+            log.info(" - Asset:     {} (v {}) (in {}) (path: {})", assetDisplayName, assetVersion, assetGroupDisplayName, assetPath);
             log.info("   Counts:    {}", totalCounts);
         }
     }
 
     @Data
+    @Accessors(chain = true)
     public static class GroupedAssetsVulnerabilityCounts {
         public List<GroupedAssetVulnerabilityCounts> groupedAssetVulnerabilityCounts;
         public VulnerabilityCounts totalVulnerabilityCounts;

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/configuration/ReportConfigurationParameters.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/configuration/ReportConfigurationParameters.java
@@ -65,6 +65,18 @@ public class ReportConfigurationParameters {
     @Builder.Default
     private boolean filterAdvisorySummary = false;
 
+    /**
+     * Controls whether the Summary Report will collapse the Asset Groups with only one Asset into a group
+     * {@link org.metaeffekt.core.inventory.processor.report.adapter.AssessmentReportAdapter#DEFAULT_ASSET_GROUP_NAME}
+     * that will be displayed instead.
+     * <p>
+     * Setting it to <code>true</code> will NOT group the assets, even if there are some groups with only one asset,
+     * <code>false</code> will group them if present.
+     * Defaults to <code>false</code>.
+     */
+    @Builder.Default
+    private boolean enableSingleAssetGroups = false;
+
     // fail behaviour section
 
     @Builder.Default

--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/assessment-report/macros/assessment-report.vm
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/assessment-report/macros/assessment-report.vm
@@ -1,8 +1,8 @@
 ## do not insert blank lines in between macros. as this document is loaded before the XML tag of the main document,
 ## this will result in the empty lines appearing at the head of the document, which is not allowed in XML.
 ##
-#macro (assetAssessmentSummary $id $assets, $useModifiedSeverity)
-    #set ($assetGroups = $assessmentReportAdapter.groupAssetsByAssetGroup($assets, $useModifiedSeverity))
+#macro (assetAssessmentSummary $id $assets, $useModifiedSeverity, $enableSingleAssetGroups)
+    #set ($assetGroups = $assessmentReportAdapter.groupAssetsByAssetGroup($assets, $useModifiedSeverity, $enableSingleAssetGroups))
     #foreach ($group in $assetGroups)
         #assetAssessmentSummaryTable($id $group)
     #end
@@ -41,10 +41,13 @@
         #foreach ($groupedAssetCounts in $groupedAssetVulnerabilityCounts)
             #set ($counts = $groupedAssetCounts.totalCounts)
             #set ($assetDisplayName = $groupedAssetCounts.assetDisplayName)
+            #set ($assetVersion = $groupedAssetCounts.assetVersion)
             #set ($assetPath = $groupedAssetCounts.assetPath)
             <row>
                 <entry align="center"><lines>#if ($vulnerabilityAdapter.notNull($assetPath))<i>$assetPath</i>
-#end$assetDisplayName</lines></entry>
+#end$assetDisplayName#if ($assetVersion)
+
+$assetVersion#end</lines></entry>
                 <entry>$counts.criticalCounter</entry>
                 <entry>$counts.highCounter</entry>
                 <entry>$counts.mediumCounter</entry>

--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/assessment-report/tpc_asset-assessment-overview-modified.dita.vt
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/assessment-report/tpc_asset-assessment-overview-modified.dita.vt
@@ -18,7 +18,7 @@
         #else
             <p>$utils.getText("assessment-report.vuln-table-descr")</p>
             <p>$utils.getText("assessment-report.vuln-table-descr-modified")</p>
-            #assetAssessmentSummary("asset-assessment-summary-effective", $assets, true)
+            #assetAssessmentSummary("asset-assessment-summary-effective", $assets, true, $configParams.isEnableSingleAssetGroups())
         #end
     </body>
 </topic>

--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/assessment-report/tpc_asset-assessment-overview-unmodified.dita.vt
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/assessment-report/tpc_asset-assessment-overview-unmodified.dita.vt
@@ -18,7 +18,7 @@
         #else
         <p>$utils.getText("assessment-report.vuln-table-descr")</p>
         <p>$utils.getText("assessment-report.vuln-table-descr-unmodified")</p>
-            #assetAssessmentSummary("asset-assessment-summary-associated", $assets, false)
+            #assetAssessmentSummary("asset-assessment-summary-associated", $assets, false, $configParams.isEnableSingleAssetGroups())
         #end
     </body>
 </topic>

--- a/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/report/adapter/AssessmentReportAdapterTest.java
+++ b/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/report/adapter/AssessmentReportAdapterTest.java
@@ -90,7 +90,7 @@ public class AssessmentReportAdapterTest {
 
         final AssessmentReportAdapter adapter = new AssessmentReportAdapter(testInventory, new CentralSecurityPolicyConfiguration());
 
-        final List<AssessmentReportAdapter.GroupedAssetsVulnerabilityCounts> grouped = adapter.groupAssetsByAssetGroup(testInventory.getAssetMetaData(), true);
+        final List<AssessmentReportAdapter.GroupedAssetsVulnerabilityCounts> grouped = adapter.groupAssetsByAssetGroup(testInventory.getAssetMetaData(), true, true);
 
         /*for (AssessmentReportAdapter.GroupedAssetsVulnerabilityCounts group : grouped) {
             group.log();
@@ -187,7 +187,7 @@ Total Counts: AssessmentReportAdapter.VulnerabilityCounts(criticalCounter=0, hig
 
         final AssessmentReportAdapter adapter = new AssessmentReportAdapter(testInventory, new CentralSecurityPolicyConfiguration());
 
-        final List<AssessmentReportAdapter.GroupedAssetsVulnerabilityCounts> grouped = adapter.groupAssetsByAssetGroup(testInventory.getAssetMetaData(), true);
+        final List<AssessmentReportAdapter.GroupedAssetsVulnerabilityCounts> grouped = adapter.groupAssetsByAssetGroup(testInventory.getAssetMetaData(), true, false);
 
         Assert.assertEquals(1, grouped.size());
         Assert.assertEquals("Default", grouped.get(0).getAssetGroupDisplayName());

--- a/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/report/adapter/AssessmentReportAdapterTest.java
+++ b/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/report/adapter/AssessmentReportAdapterTest.java
@@ -25,6 +25,8 @@ import org.metaeffekt.core.inventory.processor.report.configuration.CentralSecur
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -208,6 +210,86 @@ Total Counts: AssessmentReportAdapter.VulnerabilityCounts(criticalCounter=0, hig
         Assert.assertEquals(2, totalCounts.noneCounter);
         Assert.assertEquals(3, totalCounts.assessedCounter);
         Assert.assertEquals(3, totalCounts.totalCounter);
+    }
+
+    @Test
+    public void testEnableSingleAssetGroupsParameter() {
+        final Inventory testInventory = new Inventory();
+
+        final String[][] assetsData = {
+                {"Asset Id 1", "001", "GROUP A", "Asset 1 - Version 1"},
+                {"Asset Id 2", "002", "GROUP B", "Asset 2 - Version 2"},
+                {"Asset Id 3", "003", "GROUP C", "Asset 3 - Version 3"},
+                {"Asset Id 4", "004", "GROUP D", "Asset 4-Version 4"},
+                {"Asset Id 5", "005", "GROUP E", "Asset 5 - Version 5"},
+                {"Asset Id 6", "006", "GROUP F", "Asset 6"},
+                {"Asset Id 7", "007", "GROUP G", "Asset 7"},
+                {"Asset Id 8", "008", "GROUP G", "Asset 8"},
+        };
+
+        for (String[] assetData : assetsData) {
+            final AssetMetaData asset = new AssetMetaData();
+            asset.set(AssetMetaData.Attribute.ASSET_ID, assetData[0]);
+            asset.set(AssetMetaData.Attribute.ASSESSMENT, assetData[1]);
+            asset.set("Asset Group", assetData[2]);
+            asset.set(AssetMetaData.Attribute.NAME, assetData[3]);
+            testInventory.getAssetMetaData().add(asset);
+            testInventory.getVulnerabilityMetaData(assetData[1]).add(constructVulnerability("critical", "applicable"));
+        }
+
+        final AssessmentReportAdapter adapter = new AssessmentReportAdapter(testInventory, new CentralSecurityPolicyConfiguration());
+
+        // enableSingleAssetGroups = false
+        // single-asset groups should be merged into the "Default" group
+        {
+            final List<AssessmentReportAdapter.GroupedAssetsVulnerabilityCounts> grouped = adapter.groupAssetsByAssetGroup(testInventory.getAssetMetaData(), true, false);
+
+            Assert.assertEquals(2, grouped.size());
+
+            final Map<String, AssessmentReportAdapter.GroupedAssetsVulnerabilityCounts> groupMap = grouped.stream()
+                    .collect(Collectors.toMap(AssessmentReportAdapter.GroupedAssetsVulnerabilityCounts::getAssetGroupDisplayName, Function.identity()));
+
+            Assert.assertTrue(groupMap.containsKey("GROUP G"));
+            Assert.assertTrue(groupMap.containsKey("Default"));
+
+            final AssessmentReportAdapter.GroupedAssetsVulnerabilityCounts groupG = groupMap.get("GROUP G");
+            Assert.assertEquals(2, groupG.getGroupedAssetVulnerabilityCounts().size());
+            final List<String> groupGAssetNames = groupG.getGroupedAssetVulnerabilityCounts().stream()
+                    .map(AssessmentReportAdapter.GroupedAssetVulnerabilityCounts::getAsset)
+                    .map(a -> a.get(AssetMetaData.Attribute.ASSET_ID))
+                    .collect(Collectors.toList());
+            Assert.assertTrue(groupGAssetNames.containsAll(Arrays.asList("Asset Id 7", "Asset Id 8")));
+
+            final AssessmentReportAdapter.GroupedAssetsVulnerabilityCounts defaultGroup = groupMap.get("Default");
+            Assert.assertEquals(6, defaultGroup.getGroupedAssetVulnerabilityCounts().size());
+            final List<String> defaultGroupAssetNames = defaultGroup.getGroupedAssetVulnerabilityCounts().stream()
+                    .map(AssessmentReportAdapter.GroupedAssetVulnerabilityCounts::getAsset)
+                    .map(a -> a.get(AssetMetaData.Attribute.ASSET_ID))
+                    .collect(Collectors.toList());
+            Assert.assertTrue(defaultGroupAssetNames.containsAll(Arrays.asList("Asset Id 1", "Asset Id 2", "Asset Id 3", "Asset Id 4", "Asset Id 5", "Asset Id 6")));
+        }
+
+        // enableSingleAssetGroups = true
+        // all asset groups should be preserved
+        {
+            final List<AssessmentReportAdapter.GroupedAssetsVulnerabilityCounts> grouped = adapter.groupAssetsByAssetGroup(testInventory.getAssetMetaData(), true, true);
+            Assert.assertEquals(7, grouped.size());
+
+            final Map<String, AssessmentReportAdapter.GroupedAssetsVulnerabilityCounts> groupMap = grouped.stream()
+                    .collect(Collectors.toMap(AssessmentReportAdapter.GroupedAssetsVulnerabilityCounts::getAssetGroupDisplayName, Function.identity()));
+
+            Assert.assertTrue(groupMap.containsKey("GROUP A"));
+            Assert.assertTrue(groupMap.containsKey("GROUP B"));
+            Assert.assertTrue(groupMap.containsKey("GROUP C"));
+            Assert.assertTrue(groupMap.containsKey("GROUP D"));
+            Assert.assertTrue(groupMap.containsKey("GROUP E"));
+            Assert.assertTrue(groupMap.containsKey("GROUP F"));
+            Assert.assertTrue(groupMap.containsKey("GROUP G"));
+
+            Assert.assertEquals(1, groupMap.get("GROUP A").getGroupedAssetVulnerabilityCounts().size());
+            Assert.assertEquals(1, groupMap.get("GROUP B").getGroupedAssetVulnerabilityCounts().size());
+            Assert.assertEquals(2, groupMap.get("GROUP G").getGroupedAssetVulnerabilityCounts().size());
+        }
     }
 
     private static int vulnerabilityCount = 0;


### PR DESCRIPTION
## Report Parameter `enableSingleAssetGroups`

The new report parameter `enableSingleAssetGroups` with a default value of `false` allows controlling whether asset group tables containing only a single asset should be allowed to exist, or whether they should be merged into the `Default` group.

Previously, if all groups only had a single asset, they would be merged into a single group. This property allows this criteria to be weakened to group single-assets groups even if there are asset groups with more than one asset.

### Example

The two cases are visualized using this sample inventory:

<img width="542" height="196" alt="Screenshot 2025-09-01 at 09 44 21" src="https://github.com/user-attachments/assets/f626c705-073a-4a97-a415-64b029eefd61" />
<br/><br/>

<table>
  <tr>
    <th><code>enableSingleAssetGroups</code> = <code>true</code><br/>(previous versions behavior)</th>
    <th><code>enableSingleAssetGroups</code> = <code>false</code><br/>(new behavior)</th>
  </tr>
  <tr>
    <td>
      <img width="543" height="1052" alt="Screenshot 2025-09-01 at 09 45 03" src="https://github.com/user-attachments/assets/189700d3-dd71-4d55-9eaf-62d04bc4cccf" />
    </td>
    <td>
      <img width="775" height="686" alt="Screenshot 2025-09-01 at 09 43 34" src="https://github.com/user-attachments/assets/84cd16cf-2af4-4436-a6e6-3cc5c5d61b52" />
    </td>
  </tr>
</table>

## Version Rendering

The version field is now displayed in a separate row in the table.
If the `Name` attribute contains the version separated with a ` - `, this version will be stripped away and instead displayed in the following line (see example inventory above and image below).

<img width="102" height="72" alt="Screenshot 2025-09-01 at 09 59 04" src="https://github.com/user-attachments/assets/5392c231-d1c2-41f6-863c-33fef625530c" />

## Enable `velocimacro.arguments.strict = true`

This will ensure that calls with an invalid amount of arguments inside a velocity template will throw an exception to better ensure valid behavior inside the reports.

```
# ----------------------------------------------------------------------------
# VELOCIMACRO STRICT MODE
# ----------------------------------------------------------------------------
# if true, will throw an exception for incorrect number 
# of arguments.  false by default (for backwards compatibility)
# but this option will eventually be removed and will always
# act as if true
# ----------------------------------------------------------------------------
```