### PR TITLE
Change order in CVSS3 toString method

### DIFF
--- a/libraries/ae-security/src/main/java/org/metaeffekt/core/security/cvss/v3/Cvss3.java
+++ b/libraries/ae-security/src/main/java/org/metaeffekt/core/security/cvss/v3/Cvss3.java
@@ -797,6 +797,9 @@ public abstract class Cvss3 extends MultiScoreCvssVector {
         appendIfValid(vector, "E", exploitCodeMaturity.shortIdentifier, filterUndefinedProperties);
         appendIfValid(vector, "RL", remediationLevel.shortIdentifier, filterUndefinedProperties);
         appendIfValid(vector, "RC", reportConfidence.shortIdentifier, filterUndefinedProperties);
+        appendIfValid(vector, "CR", confidentialityRequirement.shortIdentifier, filterUndefinedProperties);
+        appendIfValid(vector, "IR", integrityRequirement.shortIdentifier, filterUndefinedProperties);
+        appendIfValid(vector, "AR", availabilityRequirement.shortIdentifier, filterUndefinedProperties);
         appendIfValid(vector, "MAV", modifiedAttackVector.shortIdentifier, filterUndefinedProperties);
         appendIfValid(vector, "MAC", modifiedAttackComplexity.shortIdentifier, filterUndefinedProperties);
         appendIfValid(vector, "MPR", modifiedPrivilegesRequired.shortIdentifier, filterUndefinedProperties);
@@ -805,9 +808,6 @@ public abstract class Cvss3 extends MultiScoreCvssVector {
         appendIfValid(vector, "MC", modifiedConfidentialityImpact.shortIdentifier, filterUndefinedProperties);
         appendIfValid(vector, "MI", modifiedIntegrityImpact.shortIdentifier, filterUndefinedProperties);
         appendIfValid(vector, "MA", modifiedAvailabilityImpact.shortIdentifier, filterUndefinedProperties);
-        appendIfValid(vector, "CR", confidentialityRequirement.shortIdentifier, filterUndefinedProperties);
-        appendIfValid(vector, "IR", integrityRequirement.shortIdentifier, filterUndefinedProperties);
-        appendIfValid(vector, "AR", availabilityRequirement.shortIdentifier, filterUndefinedProperties);
 
         if (vector.length() > 0 && vector.charAt(vector.length() - 1) == '/') {
             vector.setLength(vector.length() - 1);

--- a/libraries/ae-security/src/test/java/org/metaeffekt/core/security/cvss/CvssVectorTest.java
+++ b/libraries/ae-security/src/test/java/org/metaeffekt/core/security/cvss/CvssVectorTest.java
@@ -328,7 +328,7 @@ public class CvssVectorTest {
         Assert.assertEquals("AV:A/CDP:L", CvssVector.parseVector("AV:A/CDP:L", true).toString());
         Assert.assertEquals("AV:A/AC:X/Au:X/C:X/I:X/A:X/E:X/RL:X/RC:X/CDP:L/TD:ND/CR:ND/IR:ND/AR:ND", CvssVector.parseVector("AV:A/CDP:L", true).toString(false));
         Assert.assertEquals("CVSS:3.1/AV:L/MAV:L", CvssVector.parseVector("CVSS:3.1/AV:L/MAV:L", true).toString());
-        Assert.assertEquals("CVSS:3.1/AV:L/AC:X/PR:X/UI:X/S:X/C:X/I:X/A:X/E:X/RL:X/RC:X/MAV:L/MAC:X/MPR:X/MUI:X/MS:X/MC:X/MI:X/MA:X/CR:X/IR:X/AR:X", CvssVector.parseVector("CVSS:3.1/AV:L/MAV:L", true).toString(false));
+        Assert.assertEquals("CVSS:3.1/AV:L/AC:X/PR:X/UI:X/S:X/C:X/I:X/A:X/E:X/RL:X/RC:X/CR:X/IR:X/AR:X/MAV:L/MAC:X/MPR:X/MUI:X/MS:X/MC:X/MI:X/MA:X", CvssVector.parseVector("CVSS:3.1/AV:L/MAV:L", true).toString(false));
         Assert.assertEquals("CVSS:4.0/AV:L/MAV:L", CvssVector.parseVector("CVSS:4.0/AV:L/MAV:L", true).toString());
         Assert.assertEquals("CVSS:4.0/AV:L/AC:X/AT:X/PR:X/UI:X/VC:X/VI:X/VA:X/SC:X/SI:X/SA:X/E:X/CR:X/IR:X/AR:X/MAV:L/MAC:X/MAT:X/MPR:X/MUI:X/MVC:X/MVI:X/MVA:X/MSC:X/MSI:X/MSA:X/S:X/AU:X/R:X/V:X/RE:X/U:X", CvssVector.parseVector("CVSS:4.0/AV:L/MAV:L", true).toString(false));
     }

--- a/libraries/ae-security/src/test/java/org/metaeffekt/core/security/cvss/v3/Cvss3P1Test.java
+++ b/libraries/ae-security/src/test/java/org/metaeffekt/core/security/cvss/v3/Cvss3P1Test.java
@@ -136,8 +136,8 @@ public class Cvss3P1Test {
             checkCvssScores(vector,
                     9.8, 5.9, 3.9, 8.5, 5.7, 4.7, 5.7);
 
-            Assert.assertEquals("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/E:P/RL:T/RC:R/MAV:A/MAC:H/MPR:L/MUI:N/MS:C/MC:L/MI:N/MA:X/CR:X/IR:M/AR:X", vector.toString(false));
-            Assert.assertEquals("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/E:P/RL:T/RC:R/MAV:A/MAC:H/MPR:L/MUI:N/MS:C/MC:L/MI:N/IR:M", vector.toString());
+            Assert.assertEquals("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/E:P/RL:T/RC:R/CR:X/IR:M/AR:X/MAV:A/MAC:H/MPR:L/MUI:N/MS:C/MC:L/MI:N/MA:X", vector.toString(false));
+            Assert.assertEquals("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/E:P/RL:T/RC:R/IR:M/MAV:A/MAC:H/MPR:L/MUI:N/MS:C/MC:L/MI:N", vector.toString());
         }
     }
 
@@ -237,7 +237,7 @@ public class Cvss3P1Test {
 
     @Test
     public void toStringAllPropertiesDefinedTest() {
-        final String input = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:U/RL:W/RC:R/MAV:A/MAC:H/MPR:L/MUI:N/MS:C/MC:N/MI:L/MA:N/CR:H/IR:L/AR:H";
+        final String input = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:U/RL:W/RC:R/CR:H/IR:L/AR:H/MAV:A/MAC:H/MPR:L/MUI:N/MS:C/MC:N/MI:L/MA:N";
         final Cvss3P1 cvss = new Cvss3P1(input);
         Assert.assertEquals(input, cvss.toString());
         Assert.assertEquals(input, cvss.toString(true));
@@ -246,10 +246,10 @@ public class Cvss3P1Test {
 
     @Test
     public void toStringSomePropertiesUndefinedTest() {
-        final String input = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:U/RL:W/RC:R/MAV:A/MAC:H/MS:C/MC:N/MI:L/MA:N/CR:H";
+        final String input = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:U/RL:W/RC:R/CR:H/MAV:A/MAC:H/MS:C/MC:N/MI:L/MA:N";
         final Cvss3P1 cvss = new Cvss3P1(input);
         Assert.assertEquals(input, cvss.toString());
         Assert.assertEquals(input, cvss.toString(true));
-        Assert.assertEquals("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:U/RL:W/RC:R/MAV:A/MAC:H/MPR:X/MUI:X/MS:C/MC:N/MI:L/MA:N/CR:H/IR:X/AR:X", cvss.toString(false));
+        Assert.assertEquals("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:U/RL:W/RC:R/CR:H/IR:X/AR:X/MAV:A/MAC:H/MPR:X/MUI:X/MS:C/MC:N/MI:L/MA:N", cvss.toString(false));
     }
 }

--- a/libraries/ae-security/src/test/java/org/metaeffekt/core/security/cvss/v3/Cvss3P1Test.java
+++ b/libraries/ae-security/src/test/java/org/metaeffekt/core/security/cvss/v3/Cvss3P1Test.java
@@ -252,4 +252,12 @@ public class Cvss3P1Test {
         Assert.assertEquals(input, cvss.toString(true));
         Assert.assertEquals("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:U/RL:W/RC:R/CR:H/IR:X/AR:X/MAV:A/MAC:H/MPR:X/MUI:X/MS:C/MC:N/MI:L/MA:N", cvss.toString(false));
     }
+
+    @Test
+    public void rearrangeMetricsOrderTest() {
+        final String input = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:U/RL:W/RC:R/MAV:A/MAC:H/MS:C/MC:N/MI:L/MA:N/CR:H";
+        final Cvss3P1 cvss = new Cvss3P1(input);
+        Assert.assertEquals("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:U/RL:W/RC:R/CR:H/IR:X/AR:X/MAV:A/MAC:H/MPR:X/MUI:X/MS:C/MC:N/MI:L/MA:N", cvss.toString(false));
+        Assert.assertEquals("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:U/RL:W/RC:R/CR:H/MAV:A/MAC:H/MS:C/MC:N/MI:L/MA:N", cvss.toString(true));
+    }
 }


### PR DESCRIPTION
## Problem

When invoking the `toString` method on a CVSS3 vector you get, for example, a vector like `AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/E:H/RL:X/RC:X/MAV:A/MAC:X/MPR:X/MUI:X/MS:X/MC:X/MI:X/MA:X/CR:X/IR:X/AR:X`. If you pass this into a [NVD CVSS calculator link](https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/E:H/RL:X/RC:X/MAV:A/MAC:X/MPR:X/MUI:X/MS:X/MC:X/MI:X/MA:X/CR:X/IR:X/AR:X) their webpage does not read and apply modifications correctly.

Looking at [the specifications](https://www.first.org/cvss/v3-1/specification-document), you can see that impact modifiers come before other environmental modifiers.

<img width="1243" height="1280" alt="Screenshot 2025-09-04 at 1 01 25 PM" src="https://github.com/user-attachments/assets/c85ed4b4-bfa4-4bda-8243-36b9fdbdf5cd" />

## Solution

Change the CVSS3 vector string output by reordering the Environmental metrics (CR, IR, AR) to appear before Modified metrics (MAV, MAC, etc.) in the toString method. From our example above, our new vector would be `AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/E:H/RL:X/RC:X/CR:X/IR:X/AR:X/MAV:A/MAC:X/MPR:X/MUI:X/MS:X/MC:X/MI:X/MA:X` which when applied to a [NVD calculator link](https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/E:H/RL:X/RC:X/CR:X/IR:X/AR:X/MAV:A/MAC:X/MPR:X/MUI:X/MS:X/MC:X/MI:X/MA:X) everything is rendered correctly.

Updated corresponding unit tests to reflect the new ordering.

## What the reviewer should know

I will print/sign/send [the CLA](https://github.com/org-metaeffekt/metaeffekt-core/blob/master/CLA.md) tomorrow when I have access to a printer (unless there's a digital version I can sign today)