### PR TITLE
AE-1548: Introduce CVSS Applicability Condition Attributes on Vulnerabilities

### DIFF
--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/model/aeaa/AeaaInventoryAttribute.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/model/aeaa/AeaaInventoryAttribute.java
@@ -17,6 +17,7 @@ package org.metaeffekt.core.inventory.processor.report.model.aeaa;
 
 import org.metaeffekt.core.inventory.processor.model.AbstractModelBase;
 import org.metaeffekt.core.inventory.processor.report.model.aeaa.eol.export.AeaaExportedCycleState;
+import org.metaeffekt.core.inventory.processor.report.model.aeaa.score.AeaaCvssConditionAttributes;
 
 /**
  * Mirrors structure of <code>com.metaeffekt.artifact.analysis.vulnerability.enrichment.AeaaInventoryAttribute</code>
@@ -109,6 +110,15 @@ public enum AeaaInventoryAttribute implements AbstractModelBase.Attribute {
      */
     INAPPLICABLE_PURLS("Inapplicable PURLs"),
     RETAINED_VULNERABLE_SOFTWARE_CONFIGURATIONS("Version Ranges"),
+    /**
+     * Stores a JSON Object of arbitrary data which may be used to evaluate the applicability condition of CVSS vectors in {@code com.metaeffekt.mirror.contents.vulnerability.Vulnerability.isCvssVectorApplicable()}.
+     * <p>
+     * Currently known uses of this are:
+     * <ul>
+     *     <li> Stores the {@link AeaaInventoryAttribute#MS_PRODUCT_ID}s of referenced artifacts as a JSON Array using the {@link AeaaCvssConditionAttributes#MATCHES_ON_MS_PRODUCT_ID} key.</li>
+     * </ul>
+     */
+    CVSS_APPLICABILITY_CONDITION_ATTRIBUTES("CVSS Applicability Condition Attributes"),
     ;
 
     private final String key;

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/model/aeaa/AeaaInventoryAttribute.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/model/aeaa/AeaaInventoryAttribute.java
@@ -118,8 +118,7 @@ public enum AeaaInventoryAttribute implements AbstractModelBase.Attribute {
      *     <li> Stores the {@link AeaaInventoryAttribute#MS_PRODUCT_ID}s of referenced artifacts as a JSON Array using the {@link AeaaCvssConditionAttributes#MATCHES_ON_MS_PRODUCT_ID} key.</li>
      * </ul>
      */
-    CVSS_APPLICABILITY_CONDITION_ATTRIBUTES("CVSS Applicability Condition Attributes"),
-    ;
+    CVSS_APPLICABILITY_CONDITION_ATTRIBUTES("CVSS Applicability Condition Attributes");
 
     private final String key;
 

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/model/aeaa/AeaaVulnerability.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/model/aeaa/AeaaVulnerability.java
@@ -566,7 +566,7 @@ public class AeaaVulnerability extends AeaaMatchableDetailsAmbDataClass<Vulnerab
                 for (Artifact artifact : this.getAffectedArtifactsByDefaultKey()) {
                     String data = artifact.get(AeaaInventoryAttribute.MS_PRODUCT_ID);
 
-                    final Set<String> artifactMsProductIds = StringUtils.hasText(data) ? new HashSet<>(Arrays.asList(data.split(", "))) : new HashSet<>();
+                    final Set<String> artifactMsProductIds = StringUtils.hasText(data) ? new HashSet<>(Arrays.asList(data.split(", ?"))) : new HashSet<>();
 
                     if (artifactMsProductIds.stream().anyMatch(findMsProductIds::contains)) {
                         foundMatchingArtifact = true;

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/model/aeaa/AeaaVulnerability.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/model/aeaa/AeaaVulnerability.java
@@ -107,7 +107,7 @@ public class AeaaVulnerability extends AeaaMatchableDetailsAmbDataClass<Vulnerab
     private final List<AeaaCweEntry> cweData = new ArrayList<>();
 
     @Getter
-    private final List<AeaaCapecEntry> capecData =  new ArrayList<>();
+    private final List<AeaaCapecEntry> capecData = new ArrayList<>();
 
     private final Set<AeaaAdvisoryEntry> securityAdvisories = new LinkedHashSet<>();
 
@@ -306,6 +306,7 @@ public class AeaaVulnerability extends AeaaMatchableDetailsAmbDataClass<Vulnerab
             this.addCwe(new AeaaCweEntry(cwe));
         }
     }
+
     public void addCwe(AeaaCweEntry cwe) {
         if (cwe == null) {
             return;
@@ -554,15 +555,23 @@ public class AeaaVulnerability extends AeaaMatchableDetailsAmbDataClass<Vulnerab
             final List<String> findMsProductIds = ((JSONArray) findMsProductIdsObj).toList().stream().map(String::valueOf).collect(Collectors.toList());
             boolean foundMatchingArtifact = false;
 
-            for (Artifact artifact : this.getAffectedArtifactsByDefaultKey()) {
-                final String msProductId = artifact.get(AeaaInventoryAttribute.MS_PRODUCT_ID);
-                if (msProductId == null) {
-                    continue;
-                }
-                final List<String> artifactMsProductIds = Arrays.asList(msProductId.split(", "));
-                if (artifactMsProductIds.stream().anyMatch(findMsProductIds::contains)) {
+            final JSONArray msCvssApplicabilityConditionAttributes = getAdditionalCvssApplicabilityConditionAttributes().optJSONArray(AeaaCvssConditionAttributes.MATCHES_ON_MS_PRODUCT_ID);
+            if (msCvssApplicabilityConditionAttributes != null) {
+                if (msCvssApplicabilityConditionAttributes.toList().stream().map(Object::toString).anyMatch(findMsProductIds::contains)) {
                     foundMatchingArtifact = true;
-                    break;
+                }
+            }
+
+            if (!foundMatchingArtifact) {
+                for (Artifact artifact : this.getAffectedArtifactsByDefaultKey()) {
+                    String data = artifact.get(AeaaInventoryAttribute.MS_PRODUCT_ID);
+
+                    final Set<String> artifactMsProductIds = StringUtils.hasText(data) ? new HashSet<>(Arrays.asList(data.split(", "))) : new HashSet<>();
+
+                    if (artifactMsProductIds.stream().anyMatch(findMsProductIds::contains)) {
+                        foundMatchingArtifact = true;
+                        break;
+                    }
                 }
             }
 
@@ -576,6 +585,12 @@ public class AeaaVulnerability extends AeaaMatchableDetailsAmbDataClass<Vulnerab
         }
 
         return true;
+    }
+
+    public JSONObject getAdditionalCvssApplicabilityConditionAttributes() {
+        final String cvssConditions = this.getAdditionalAttribute(AeaaInventoryAttribute.CVSS_APPLICABILITY_CONDITION_ATTRIBUTES);
+        if (StringUtils.isEmpty(cvssConditions)) return new JSONObject();
+        return new JSONObject(cvssConditions);
     }
 
     public CvssSelectionResult selectEffectiveCvssVectors(CvssVectorSet cvssVectorSet, CvssSelector baseSelector, CvssSelector effectiveSelector, List<CvssScoreVersionSelectionPolicy> versionSelectionPolicy) {


### PR DESCRIPTION
- https://github.com/org-metaeffekt/metaeffekt-artifact-analysis/pull/381
- https://github.com/org-metaeffekt/metaeffekt-artifact-analysis/pull/382
- https://github.com/org-metaeffekt/metaeffekt-core/pull/312

Due to newly introduced "CVSS Applicability Condition Attributes" attribute, Vulnerability.isCvssVectorApplicable() additionally checks if msProductIds are found on the vulnerability, if artifacts are missing.

Dependent on [PR](https://github.com/org-metaeffekt/metaeffekt-artifact-analysis/pull/381) in AA

