### PR TITLE
AE-1631: Modify English process timestamp format

### DIFF
--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/adapter/VulnerabilityReportAdapter.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/adapter/VulnerabilityReportAdapter.java
@@ -1132,11 +1132,11 @@ public class VulnerabilityReportAdapter {
 
     @Getter
     public static class FormattedTime {
-        private final static SimpleDateFormat EN_FORMAT = new SimpleDateFormat("dd/MM/yyyy HH:mm");
+        private final static SimpleDateFormat EN_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm");
         private final static SimpleDateFormat DE_FORMAT = new SimpleDateFormat("dd.MM.yyyy HH:mm");
         private final static FormattedTime EMPTY = new FormattedTime(0);
         private final long time;
-        private final String en; // 31/12/2024 hh:mm
+        private final String en; // 2024-12-31 hh:mm
         private final String de; // 31.12.2024 hh:mm
 
         public FormattedTime(long time) {

--- a/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/report/VulnerabilityReportAdapterTest.java
+++ b/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/report/VulnerabilityReportAdapterTest.java
@@ -72,6 +72,6 @@ public class VulnerabilityReportAdapterTest {
         Assert.assertEquals(3, new ProcessorTimeTracker(inventory).getEntries().size());
 
         final VulnerabilityReportAdapter adapter = new VulnerabilityReportAdapter(inventory, new CentralSecurityPolicyConfiguration());
-        adapter.generateEnrichmentTimestampConfigs();
+        log.info(adapter.generateEnrichmentTimestampConfigs());
     }
 }


### PR DESCRIPTION
english process timestamps now uses YYYY-MM-DD (ISO 8601) instead of DD/MM/YYYY