### PR TITLE
AE-1786: Fix faulty serialization of legacy process time tracker-output

### DIFF
--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/tracker/ProcessTimeEntry.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/tracker/ProcessTimeEntry.java
@@ -61,7 +61,7 @@ public class ProcessTimeEntry {
                 .put("processId", processType.get())
                 .put("timestamp", timestamp.toJson());
 
-        if(processName != null) {
+        if (processName != null) {
             json.put("processName", processName);
         }
 
@@ -88,22 +88,19 @@ public class ProcessTimeEntry {
         Object indexTimestampJsonProperty = json.opt("indexTimestamps");
 
         // legacy format
-        if(indexTimestampJsonProperty instanceof JSONObject) {
+        if (indexTimestampJsonProperty instanceof JSONObject) {
             JSONObject indexTimestamps = (JSONObject) indexTimestampJsonProperty;
-            for(String index : indexTimestamps.keySet()) {
+            for (String index : indexTimestamps.keySet()) {
                 tracker.indexTimestamps.put(index, ProcessTimestamp.fromJSON(indexTimestamps.getJSONObject(index)));
             }
-        }
-
-        else if(indexTimestampJsonProperty instanceof JSONArray) {
+        } else if (indexTimestampJsonProperty instanceof JSONArray) {
             final JSONArray indexTimestamps = (JSONArray) indexTimestampJsonProperty;
             for (int i = 0; i < indexTimestamps.length(); i++) {
                 JSONObject index = indexTimestamps.getJSONObject(i);
                 ProcessTimestamp timestamp = ProcessTimestamp.fromJSON(index.getJSONObject("timestamp"));
                 tracker.indexTimestamps.put(index.getString("indexId"), timestamp);
             }
-        }
-        else {
+        } else {
             throw new RuntimeException(String.format("Property: 'indexTimestamps' is not able to be parsed in [ {%s} ]", json));
         }
 

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/tracker/ProcessTimeEntry.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/tracker/ProcessTimeEntry.java
@@ -85,14 +85,28 @@ public class ProcessTimeEntry {
         }
 
         final ProcessTimeEntry tracker = new ProcessTimeEntry(processType, json.optString("processName", null), ProcessTimestamp.fromJSON(json.getJSONObject("timestamp")));
-        if (json.getJSONArray("indexTimestamps") != null) {
-            final JSONArray indexTimestamps = json.getJSONArray("indexTimestamps");
+        Object indexTimestampJsonProperty = json.opt("indexTimestamps");
+
+        // legacy format
+        if(indexTimestampJsonProperty instanceof JSONObject) {
+            JSONObject indexTimestamps = (JSONObject) indexTimestampJsonProperty;
+            for(String index : indexTimestamps.keySet()) {
+                tracker.indexTimestamps.put(index, ProcessTimestamp.fromJSON(indexTimestamps.getJSONObject(index)));
+            }
+        }
+
+        else if(indexTimestampJsonProperty instanceof JSONArray) {
+            final JSONArray indexTimestamps = (JSONArray) indexTimestampJsonProperty;
             for (int i = 0; i < indexTimestamps.length(); i++) {
                 JSONObject index = indexTimestamps.getJSONObject(i);
                 ProcessTimestamp timestamp = ProcessTimestamp.fromJSON(index.getJSONObject("timestamp"));
                 tracker.indexTimestamps.put(index.getString("indexId"), timestamp);
             }
         }
+        else {
+            throw new RuntimeException(String.format("Property: 'indexTimestamps' is not able to be parsed in [ {%s} ]", json));
+        }
+
         return tracker;
     }
 

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/tracker/ProcessType.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/tracker/ProcessType.java
@@ -18,19 +18,22 @@ package org.metaeffekt.core.inventory.processor.tracker;
 import lombok.AllArgsConstructor;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 @AllArgsConstructor
 public enum ProcessType {
-    SPDX_IMPORTER("spdx-importer"),
-    CYCLONEDX_IMPORTER("cyclonedx-importer"),
-    SBOM_CREATION("sbom-creation"),
-    INVENTORY_ENRICHMENT("inventory-enrichment"),
-    ADVISOR_PERIODIC_ENRICHMENT("advisor-periodic-enrichment"),
-    INVENTORY_MERGER("inventory-merger"),
-    REPORT_GENERATION("report-generation"),
+    SPDX_IMPORTER("spdx-importer", Collections.emptyList()),
+    CYCLONEDX_IMPORTER("cyclonedx-importer", Collections.emptyList()),
+    SBOM_CREATION("sbom-creation", Arrays.asList("spdx-bom", "cyclonedx-bom")),
+    INVENTORY_ENRICHMENT("inventory-enrichment", Collections.emptyList()),
+    ADVISOR_PERIODIC_ENRICHMENT("advisor-periodic-enrichment", Collections.emptyList()),
+    INVENTORY_MERGER("inventory-merger", Collections.emptyList()),
+    REPORT_GENERATION("report-generation", Collections.emptyList()),
     ;
 
     final String id;
+    final List<String> deprecatedNames;
 
     public String get() {
         return id;
@@ -38,7 +41,7 @@ public enum ProcessType {
 
     public static ProcessType fromText(String text) {
         return Arrays.stream(ProcessType.values())
-                .filter(v -> v.id.equals(text))
+                .filter(v -> v.id.equals(text) || v.deprecatedNames.contains(text))
                 .findFirst()
                 .orElseThrow(() -> new IllegalArgumentException("unknown value: " + text));
     }

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/tracker/ProcessorTimeTracker.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/tracker/ProcessorTimeTracker.java
@@ -104,7 +104,7 @@ public class ProcessorTimeTracker {
 
             for (int i = 0; i < json.length(); i++) {
                 final JSONObject object = json.getJSONObject(i);
-                try{
+                try {
                     entries.add(ProcessTimeEntry.fromJson(object));
                 } catch (Exception e) {
                     log.warn("Failed to parse process event entry: [{}], skipping...", object);
@@ -192,7 +192,7 @@ public class ProcessorTimeTracker {
         } else {
             sj.add(String.format(".timestamp=%d - %d\n\n", first, last));
 
-            if(formattedFirstEn.equals(formattedLastEn)) {
+            if (formattedFirstEn.equals(formattedLastEn)) {
                 sj.add(String.format(".date.en=%s\n", formattedLastEn));
                 sj.add(String.format(".date.de=%s\n\n", formattedLastDe));
             } else {

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/tracker/ProcessorTimeTracker.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/tracker/ProcessorTimeTracker.java
@@ -104,7 +104,11 @@ public class ProcessorTimeTracker {
 
             for (int i = 0; i < json.length(); i++) {
                 final JSONObject object = json.getJSONObject(i);
-                entries.add(ProcessTimeEntry.fromJson(object));
+                try{
+                    entries.add(ProcessTimeEntry.fromJson(object));
+                } catch (Exception e) {
+                    log.warn("Failed to parse process event entry: [{}], skipping...", object);
+                }
             }
         } catch (Exception e) {
             log.warn("Failed to parse process timestamps: {}", e.getMessage(), e);

--- a/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/tracker/ProcessTimeTrackerTest.java
+++ b/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/tracker/ProcessTimeTrackerTest.java
@@ -41,7 +41,7 @@ public class ProcessTimeTrackerTest {
         tracker.addTimestamp(new ProcessTimeEntry(ProcessType.SBOM_CREATION, 1));
         tracker.addTimestamp(new ProcessTimeEntry(ProcessType.SPDX_IMPORTER, 10));
 
-        final  ProcessTimeEntry processTimeEntry1 = new ProcessTimeEntry(ProcessType.INVENTORY_ENRICHMENT, 11);
+        final ProcessTimeEntry processTimeEntry1 = new ProcessTimeEntry(ProcessType.INVENTORY_ENRICHMENT, 11);
         processTimeEntry1.addIndexTimestamp("index1", 1);
         processTimeEntry1.addIndexTimestamp("index2", 3);
         processTimeEntry1.addIndexTimestamp("index1", 5);

--- a/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/tracker/ProcessTimeTrackerTest.java
+++ b/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/tracker/ProcessTimeTrackerTest.java
@@ -96,6 +96,8 @@ public class ProcessTimeTrackerTest {
         // check if attempting to read or add a timestamp fails
         ProcessorTimeTracker tracker = ProcessorTimeTracker.fromInventory(inv);
         tracker.addTimestamp(new ProcessTimeEntry(ProcessType.SPDX_IMPORTER, 1));
+
+        Assert.assertEquals(5, tracker.getEntries().size());
     }
 
     @Test


### PR DESCRIPTION
The [test](https://github.com/org-metaeffekt/metaeffekt-core/blob/bca7db244744d432b808303e5b59b42a1ee3a2d4/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/tracker/ProcessTimeTrackerTest.java#L91) for parsing legacy time tracker output is faulty, as it is only invalidated by a thrown exception which is swallowed anyway, close to the same level it is thrown and therefore never fails when it supposed to. The behavior of this test also hid the fact that we do not correctly parse legacy timetracker output.
