### PR TITLE
AE-1798: Security Policy File metadata wrapper (Policy Version)

### DIFF
--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/configuration/CentralSecurityPolicyConfiguration.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/configuration/CentralSecurityPolicyConfiguration.java
@@ -65,6 +65,8 @@ public class CentralSecurityPolicyConfiguration extends ProcessConfiguration {
     @ExcludeProcessConfigurationProperty
     private static final Logger LOG = LoggerFactory.getLogger(CentralSecurityPolicyConfiguration.class);
 
+    public final static String LATEST_VERSION = "1";
+
     /**
      * Used to convert a CVSS score into a Severity Category (e.g. None, Low, Medium, High, Critical) for displaying in reports and dashboards.<br>
      * The syntax defines ranges using a format like <code>Label:color:min:max</code>.<p>

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/configuration/CspLoader.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/configuration/CspLoader.java
@@ -59,7 +59,8 @@ public class CspLoader {
             return this.loadConfigurationInternal();
         } catch (Exception e) {
             log.error("└── Failed to load Security Policy");
-            Arrays.stream(e.getMessage().split("\n")).forEach(msg -> log.error("    ├── {}", msg));
+            final String message = StringUtils.defaultString(e.getMessage(), e.getClass().getName());
+            Arrays.stream(message.split("\n")).forEach(msg -> log.error("    ├── {}", msg));
             log.error("    └── file={}, files={}, inlineOverwriteJson={}, activeIds={}", file, files, inlineOverwriteJson, activeIds);
             throw new RuntimeException("Central security policy loader failed to create Central security policy instance from parameters.", e);
         }

--- a/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/report/configuration/CspLoaderTest.java
+++ b/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/report/configuration/CspLoaderTest.java
@@ -104,4 +104,35 @@ public class CspLoaderTest {
             Assert.assertEquals(2.34, loader.loadConfiguration().getInsignificantThreshold(), 0.001);
         }
     }
+
+    @Test
+    public void versionComparisonTest() {
+        {
+            final CspLoader loader = new CspLoader();
+            loader.addFile(new File(RESOURCE_DIR, "versionComparisonTest/file-a.json"));
+            loader.setActiveIds(Collections.singletonList("config a"));
+            Assert.assertEquals("includeAdvisoryTypes", "[notice]", loader.loadConfiguration().getIncludeAdvisoryTypes().toString());
+        }
+        Assert.assertThrows(RuntimeException.class, () -> {
+            final CspLoader loader = new CspLoader();
+            loader.addFile(new File(RESOURCE_DIR, "versionComparisonTest/file-b.json"));
+            loader.loadConfiguration();
+        });
+        {
+            final CspLoader loader = new CspLoader();
+            loader.addFile(new File(RESOURCE_DIR, "versionComparisonTest/file-c.json"));
+            loader.loadConfiguration();
+        }
+        Assert.assertThrows(RuntimeException.class, () -> {
+            final CspLoader loader = new CspLoader();
+            loader.setFailOnMissingVersion(true);
+            loader.addFile(new File(RESOURCE_DIR, "versionComparisonTest/file-c.json"));
+            loader.loadConfiguration();
+        });
+        Assert.assertThrows(RuntimeException.class, () -> {
+            final CspLoader loader = new CspLoader();
+            loader.addFile(new File(RESOURCE_DIR, "versionComparisonTest/file-d.json"));
+            loader.loadConfiguration();
+        });
+    }
 }

--- a/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/report/configuration/CspLoaderTest.java
+++ b/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/report/configuration/CspLoaderTest.java
@@ -121,6 +121,7 @@ public class CspLoaderTest {
         {
             final CspLoader loader = new CspLoader();
             loader.addFile(new File(RESOURCE_DIR, "versionComparisonTest/file-c.json"));
+            loader.setInlineOverwriteJson("{}");
             loader.loadConfiguration();
         }
         Assert.assertThrows(RuntimeException.class, () -> {

--- a/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/report/configuration/CspLoaderTest.java
+++ b/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/report/configuration/CspLoaderTest.java
@@ -114,6 +114,7 @@ public class CspLoaderTest {
             Assert.assertEquals("includeAdvisoryTypes", "[notice]", loader.loadConfiguration().getIncludeAdvisoryTypes().toString());
         }
         Assert.assertThrows(RuntimeException.class, () -> {
+            // 'failOnVersionIncompatibility' is active and policy file version [2] does not match latest version [1]
             final CspLoader loader = new CspLoader();
             loader.addFile(new File(RESOURCE_DIR, "versionComparisonTest/file-b.json"));
             loader.loadConfiguration();
@@ -125,14 +126,22 @@ public class CspLoaderTest {
             loader.loadConfiguration();
         }
         Assert.assertThrows(RuntimeException.class, () -> {
+            // 'failOnMissingVersion' is active and policy file did not contain a version field
             final CspLoader loader = new CspLoader();
             loader.setFailOnMissingVersion(true);
             loader.addFile(new File(RESOURCE_DIR, "versionComparisonTest/file-c.json"));
             loader.loadConfiguration();
         });
         Assert.assertThrows(RuntimeException.class, () -> {
+            // Key 'configurations' is in an invalid format
             final CspLoader loader = new CspLoader();
             loader.addFile(new File(RESOURCE_DIR, "versionComparisonTest/file-d.json"));
+            loader.loadConfiguration();
+        });
+        Assert.assertThrows(RuntimeException.class, () -> {
+            // Unknown key in configuration wrapper 'author'
+            final CspLoader loader = new CspLoader();
+            loader.addFile(new File(RESOURCE_DIR, "versionComparisonTest/file-e.json"));
             loader.loadConfiguration();
         });
     }

--- a/libraries/ae-inventory-processor/src/test/resources/security-policy/CspLoaderTest/versionComparisonTest/file-a.json
+++ b/libraries/ae-inventory-processor/src/test/resources/security-policy/CspLoaderTest/versionComparisonTest/file-a.json
@@ -1,0 +1,11 @@
+{
+  "version": "1",
+  "configurations": [
+    {
+      "id": "config a",
+      "configuration": {
+        "includeAdvisoryTypes": ["notice"]
+      }
+    }
+  ]
+}

--- a/libraries/ae-inventory-processor/src/test/resources/security-policy/CspLoaderTest/versionComparisonTest/file-a.json
+++ b/libraries/ae-inventory-processor/src/test/resources/security-policy/CspLoaderTest/versionComparisonTest/file-a.json
@@ -1,8 +1,18 @@
 {
+  "id": "policy-001",
+  "name": "Test configuration",
+  "description": "Test configuration for versionComparisonTest",
   "version": "1",
   "configurations": [
     {
       "id": "config a",
+      "configuration": {
+        "includeAdvisoryTypes": ["notice"]
+      }
+    },
+    {
+      "id": "config b",
+      "activeByDefault": true,
       "configuration": {
         "includeAdvisoryTypes": ["notice"]
       }

--- a/libraries/ae-inventory-processor/src/test/resources/security-policy/CspLoaderTest/versionComparisonTest/file-b.json
+++ b/libraries/ae-inventory-processor/src/test/resources/security-policy/CspLoaderTest/versionComparisonTest/file-b.json
@@ -1,0 +1,11 @@
+{
+  "version": "2",
+  "configurations": [
+    {
+      "id": "config a",
+      "configuration": {
+        "includeAdvisoryTypes": ["notice"]
+      }
+    }
+  ]
+}

--- a/libraries/ae-inventory-processor/src/test/resources/security-policy/CspLoaderTest/versionComparisonTest/file-c.json
+++ b/libraries/ae-inventory-processor/src/test/resources/security-policy/CspLoaderTest/versionComparisonTest/file-c.json
@@ -1,0 +1,10 @@
+{
+  "configurations": [
+    {
+      "id": "config a",
+      "configuration": {
+        "includeAdvisoryTypes": ["notice"]
+      }
+    }
+  ]
+}

--- a/libraries/ae-inventory-processor/src/test/resources/security-policy/CspLoaderTest/versionComparisonTest/file-d.json
+++ b/libraries/ae-inventory-processor/src/test/resources/security-policy/CspLoaderTest/versionComparisonTest/file-d.json
@@ -1,0 +1,3 @@
+{
+  "configurations": "string"
+}

--- a/libraries/ae-inventory-processor/src/test/resources/security-policy/CspLoaderTest/versionComparisonTest/file-e.json
+++ b/libraries/ae-inventory-processor/src/test/resources/security-policy/CspLoaderTest/versionComparisonTest/file-e.json
@@ -1,0 +1,9 @@
+{
+  "author": "user-001",
+  "configurations": [
+    {
+      "id": "config a",
+      "configuration": {}
+    }
+  ]
+}


### PR DESCRIPTION
This PR enhances the `CspLoader` to support a wrapper structure for security policy files that contains metadata like versioning.
In addition, logging of the parsing process has been improved.

Workbench PR: https://github.com/org-metaeffekt/metaeffekt-workbench/pull/15

## Policy Wrapper & Versioning

New supported keys at the root wrapper level are `id`, `name`, `description`, `version`, and `configurations`.
Strict key validation is enforced for the wrapper object; unknown keys (e.g. `author`) will cause an exception.

The `CentralSecurityPolicyConfiguration` now defines an integer version stored as a string in `LATEST_VERSION` (currently `1`).
The loader validates the `version` field in policy files against this constant, if present.
In order for the validation to activate, the new wrapper functionality must be used.
The other two formats will not trigger the validation, as they do not allow for the specification of a version property.

Two new flags control this validation:

- `failOnVersionIncompatibility` (default: `true`): Throws an exception if the version does not match.
- `failOnMissingVersion` (default: `false`): Throws an exception if the wrapper syntax is used and version field is absent.

Example of the new file structure:

```json
{
  "id": "policy-001",
  "name": "Standard Configuration",
  "description": "Base policy",
  "version": "1",
  "configurations": [
    {
      "id": "config-a",
      "configuration": { ... }
    }
  ]
}
```

## Hierarchical Logging

The logging within `CspLoader` has been rewritten to use a hierarchical tree structure.
Example output:

```text
Security Policy Loader initialized for active Ids: [config a]
├── Loading: file:///Users/.../versionComparisonTest/file-a.json
│   ├── Test configuration (policy-001)
│   ├── Test configuration for versionComparisonTest
│   └── File provides 2 configurations: [config a, config b]
└── Resolving active configurations
    ├── [config b] (active by default)
    ├── [config a]
    └── Merged 2 configurations
```

```text
Security Policy Loader initialized, no active Ids provided (using defaults/inline only)
├── Loading: file:///Users/.../versionComparisonTest/file-b.json
│   ├── file-b.json-217a6303
└── Failed to load Security Policy
    ├── 'failOnVersionIncompatibility' is active and policy file version [2] does not match latest version [1] in file:///Users/.../versionComparisonTest/file-b.json
    └── file=null, files=[src/test/resources/security-policy/CspLoaderTest/versionComparisonTest/file-b.json], inlineOverwriteJson=null, activeIds=[]
```
