### PR TITLE
AE-1820: Enable Shared Strings Table on .xlsx inventory writer to save memory

### DIFF
--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/writer/excel/AbstractXlsxInventoryWriter.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/writer/excel/AbstractXlsxInventoryWriter.java
@@ -15,10 +15,10 @@
  */
 package org.metaeffekt.core.inventory.processor.writer.excel;
 
-import org.apache.poi.hssf.usermodel.HSSFRichTextString;
 import org.apache.poi.ss.SpreadsheetVersion;
 import org.apache.poi.ss.usermodel.CellBase;
 import org.apache.poi.xssf.streaming.SXSSFRow;
+import org.apache.poi.xssf.usermodel.XSSFRichTextString;
 import org.metaeffekt.core.inventory.processor.model.AbstractModelBase;
 import org.metaeffekt.core.inventory.processor.writer.AbstractInventoryWriter;
 import org.metaeffekt.core.inventory.processor.writer.excel.style.InventorySheetCellStyler;
@@ -46,7 +46,7 @@ public abstract class AbstractXlsxInventoryWriter extends AbstractInventoryWrite
         return super.populateSheetWithModelData(
                 MAX_CELL_LENGTH,
                 models, columnHeaders,
-                headerCellSupplier, contentRowSupplier, HSSFRichTextString::new,
+                headerCellSupplier, contentRowSupplier, XSSFRichTextString::new,
                 headerCellStyler, dataCellStyler);
     }
 

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/writer/excel/XlsxInventoryWriter.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/writer/excel/XlsxInventoryWriter.java
@@ -42,7 +42,7 @@ public class XlsxInventoryWriter extends AbstractXlsxInventoryWriter {
     }
 
     public void writeInventory(Inventory inventory, File file) throws IOException {
-        final SXSSFWorkbook workbook = new SXSSFWorkbook();
+        final SXSSFWorkbook workbook = new SXSSFWorkbook(null, 100, true, true);
         final XlsxXSSFInventorySheetCellStylers stylers = new XlsxXSSFInventorySheetCellStylers(workbook);
 
         writeArtifacts(inventory, workbook, stylers);


### PR DESCRIPTION
This PR saves memory when writing .xlsx inventory files by enabling the Shared String Table feature on the apache POI worksheet that is being written.

```java
// before
final SXSSFWorkbook workbook = new SXSSFWorkbook();
// last parameter is useSharedStringsTable
final SXSSFWorkbook workbook = new SXSSFWorkbook(null, 100, true, true);
```

As the string table only supports `XSSFRichTextString`, I had to switch to that one (does not support the currently used `HSSFRichTextString`).

After vs. Before:

<img width="70" height="44" alt="image" src="https://github.com/user-attachments/assets/20a8d5b9-e0d2-4ac0-9611-deb6ee7d13fb" />
