### PR TITLE
AE-1916: Fix NPE on concurrent CVSS part cache access

### DIFF
--- a/libraries/ae-security/src/main/java/org/metaeffekt/core/security/cvss/v2/Cvss2.java
+++ b/libraries/ae-security/src/main/java/org/metaeffekt/core/security/cvss/v2/Cvss2.java
@@ -24,6 +24,8 @@ import org.metaeffekt.core.security.cvss.MultiScoreCvssVector;
 import org.metaeffekt.core.security.cvss.processor.BakedCvssVectorScores;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 /**
  * Class for modeling a CVSS:2.0 Vector, allowing for manipulating the vector components and calculating scores.
@@ -1049,7 +1051,7 @@ public final class Cvss2 extends MultiScoreCvssVector {
         return Optional.of(new Cvss2(vector));
     }
 
-    private final static Map<Class<?>, Map<String, Object>> ATTRIBUTE_CACHE = new HashMap<>();
+    private final static ConcurrentMap<Class<?>, ConcurrentMap<String, Object>> ATTRIBUTE_CACHE = new ConcurrentHashMap<>();
 
     public interface Cvss2Attribute extends CvssVectorAttribute {
         default boolean isSet() {
@@ -1057,28 +1059,23 @@ public final class Cvss2 extends MultiScoreCvssVector {
         }
 
         static <T extends Cvss2Attribute> T fromString(String part, Class<T> clazz, T defaultValue) {
-            final Map<String, Object> cache;
-            if (ATTRIBUTE_CACHE.containsKey(clazz)) {
-                cache = ATTRIBUTE_CACHE.get(clazz);
-            } else {
-                cache = new HashMap<>();
-                ATTRIBUTE_CACHE.put(clazz, cache);
+            if (part == null) return defaultValue;
+
+            final ConcurrentMap<String, Object> cache = ATTRIBUTE_CACHE.computeIfAbsent(clazz, k -> new ConcurrentHashMap<>());
+            final Object cachedValue = cache.get(part);
+            if (cachedValue != null) {
+                return (T) cachedValue;
             }
-            if (cache.containsKey(part)) {
-                return (T) cache.get(part);
-            } else {
-                for (T value : clazz.getEnumConstants()) {
-                    if (value.getShortIdentifier().equalsIgnoreCase(part)) {
-                        cache.put(part, value);
-                        return value;
-                    } else if (value.getIdentifier().equalsIgnoreCase(part)) {
-                        cache.put(part, value);
-                        return value;
-                    }
+
+            for (T value : clazz.getEnumConstants()) {
+                if (value.getShortIdentifier().equalsIgnoreCase(part) || value.getIdentifier().equalsIgnoreCase(part)) {
+                    cache.put(part, value);
+                    return value;
                 }
-                cache.put(part, defaultValue);
-                return defaultValue;
             }
+
+            cache.put(part, defaultValue);
+            return defaultValue;
         }
     }
 

--- a/libraries/ae-security/src/main/java/org/metaeffekt/core/security/cvss/v3/Cvss3.java
+++ b/libraries/ae-security/src/main/java/org/metaeffekt/core/security/cvss/v3/Cvss3.java
@@ -23,6 +23,8 @@ import org.metaeffekt.core.security.cvss.MultiScoreCvssVector;
 import org.metaeffekt.core.security.cvss.processor.BakedCvssVectorScores;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 /**
  * Class for modeling a CVSS:3.1 Vector, allowing for manipulating the vector components and calculating scores.
@@ -1261,7 +1263,7 @@ public abstract class Cvss3 extends MultiScoreCvssVector {
 
     public abstract <T extends Cvss3> Optional<T> optionalParse(String vector);
 
-    private final static Map<Class<?>, Map<String, Object>> ATTRIBUTE_CACHE = new HashMap<>();
+    private final static ConcurrentMap<Class<?>, ConcurrentMap<String, Object>> ATTRIBUTE_CACHE = new ConcurrentHashMap<>();
 
     public interface Cvss3Attribute extends CvssVectorAttribute {
         default boolean isSet() {
@@ -1269,28 +1271,23 @@ public abstract class Cvss3 extends MultiScoreCvssVector {
         }
 
         static <T extends Cvss3Attribute> T fromString(String part, Class<T> clazz, T defaultValue) {
-            final Map<String, Object> cache;
-            if (ATTRIBUTE_CACHE.containsKey(clazz)) {
-                cache = ATTRIBUTE_CACHE.get(clazz);
-            } else {
-                cache = new HashMap<>();
-                ATTRIBUTE_CACHE.put(clazz, cache);
+            if (part == null) return defaultValue;
+
+            final ConcurrentMap<String, Object> cache = ATTRIBUTE_CACHE.computeIfAbsent(clazz, k -> new ConcurrentHashMap<>());
+            final Object cachedValue = cache.get(part);
+            if (cachedValue != null) {
+                return (T) cachedValue;
             }
-            if (cache.containsKey(part)) {
-                return (T) cache.get(part);
-            } else {
-                for (T value : clazz.getEnumConstants()) {
-                    if (value.getShortIdentifier().equalsIgnoreCase(part)) {
-                        cache.put(part, value);
-                        return value;
-                    } else if (value.getIdentifier().equalsIgnoreCase(part)) {
-                        cache.put(part, value);
-                        return value;
-                    }
+
+            for (T value : clazz.getEnumConstants()) {
+                if (value.getShortIdentifier().equalsIgnoreCase(part) || value.getIdentifier().equalsIgnoreCase(part)) {
+                    cache.put(part, value);
+                    return value;
                 }
-                cache.put(part, defaultValue);
-                return defaultValue;
             }
+
+            cache.put(part, defaultValue);
+            return defaultValue;
         }
     }
 

--- a/libraries/ae-security/src/main/java/org/metaeffekt/core/security/cvss/v4P0/Cvss4P0.java
+++ b/libraries/ae-security/src/main/java/org/metaeffekt/core/security/cvss/v4P0/Cvss4P0.java
@@ -28,6 +28,8 @@ import java.math.BigDecimal;
 import java.math.MathContext;
 import java.math.RoundingMode;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -1941,34 +1943,29 @@ public final class Cvss4P0 extends CvssVector {
         }
     }
 
-    private final static Map<Class<?>, Map<String, Object>> ATTRIBUTE_CACHE = new HashMap<>();
+    private final static ConcurrentMap<Class<?>, ConcurrentMap<String, Object>> ATTRIBUTE_CACHE = new ConcurrentHashMap<>();
 
     public interface Cvss4P0Attribute extends CvssVectorAttribute {
         Cvss4P0Attribute getWorseCase();
 
         static <T extends Cvss4P0Attribute> T fromString(String part, Class<T> clazz, T defaultValue) {
-            final Map<String, Object> cache;
-            if (ATTRIBUTE_CACHE.containsKey(clazz)) {
-                cache = ATTRIBUTE_CACHE.get(clazz);
-            } else {
-                cache = new HashMap<>();
-                ATTRIBUTE_CACHE.put(clazz, cache);
+            if (part == null) return defaultValue;
+
+            final ConcurrentMap<String, Object> cache = ATTRIBUTE_CACHE.computeIfAbsent(clazz, k -> new ConcurrentHashMap<>());
+            final Object cachedValue = cache.get(part);
+            if (cachedValue != null) {
+                return (T) cachedValue;
             }
-            if (cache.containsKey(part)) {
-                return (T) cache.get(part);
-            } else {
-                for (T value : clazz.getEnumConstants()) {
-                    if (value.getShortIdentifier().equalsIgnoreCase(part)) {
-                        cache.put(part, value);
-                        return value;
-                    } else if (value.getIdentifier().equalsIgnoreCase(part)) {
-                        cache.put(part, value);
-                        return value;
-                    }
+
+            for (T value : clazz.getEnumConstants()) {
+                if (value.getShortIdentifier().equalsIgnoreCase(part) || value.getIdentifier().equalsIgnoreCase(part)) {
+                    cache.put(part, value);
+                    return value;
                 }
-                cache.put(part, defaultValue);
-                return defaultValue;
             }
+
+            cache.put(part, defaultValue);
+            return defaultValue;
         }
 
         default boolean isSet() {


### PR DESCRIPTION
<img width="1620" height="129" alt="grafik" src="https://github.com/user-attachments/assets/56f16a58-0be5-427e-aaf4-e1a2350f2098" />

```
[ERROR] [INCOMPLETE] Failed to parse CVE entry for [CVE-2014-125114]: NullPointerException
java.lang.RuntimeException: Failed to parse CVE entry for [CVE-2014-125114]
    at com.metaeffekt.mirror.index.nvd.NvdCveApiIndex.processNvdFile (NvdCveApiIndex.java:190)
    at com.metaeffekt.mirror.index.nvd.NvdCveApiIndex.lambda$processDocuments$1 (NvdCveApiIndex.java:137)
    at com.metaeffekt.mirror.concurrency.ScheduledDelayedThreadPoolExecutor$ThrowingRunnable.run (ScheduledDelayedThreadPoolExecutor.java:229)
    at java.util.concurrent.Executors$RunnableAdapter.call (Executors.java:511)
    at java.util.concurrent.FutureTask.run (FutureTask.java:266)
    at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201 (ScheduledThreadPoolExecutor.java:180)
    at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run (ScheduledThreadPoolExecutor.java:293)
    at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1149)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:624)
    at java.lang.Thread.run (Thread.java:750)
Caused by: java.lang.NullPointerException
    at org.metaeffekt.core.security.cvss.v4P0.Cvss4P0$Cvss4P0Attribute.fromString (Cvss4P0.java:1957)
    at org.metaeffekt.core.security.cvss.v4P0.Cvss4P0$ModifiedPrivilegesRequired.fromString (Cvss4P0.java:1726)
    at org.metaeffekt.core.security.cvss.v4P0.Cvss4P0.applyVectorArgument (Cvss4P0.java:278)
    at org.metaeffekt.core.security.cvss.CvssVector.applyNormalizedVector (CvssVector.java:234)
    at org.metaeffekt.core.security.cvss.CvssVector.applyVector (CvssVector.java:212)
    at org.metaeffekt.core.security.cvss.v4P0.Cvss4P0.<init> (Cvss4P0.java:188)
    at com.metaeffekt.mirror.index.parsers.impl.NvdVulnerabilityParser.parseCvssMetricArray (NvdVulnerabilityParser.java:196)
    at com.metaeffekt.mirror.index.parsers.impl.NvdVulnerabilityParser.fromNvdMirrorCveItem2P0 (NvdVulnerabilityParser.java:152)
    at com.metaeffekt.mirror.index.nvd.NvdCveApiIndex.processNvdFile (NvdCveApiIndex.java:188)
    at com.metaeffekt.mirror.index.nvd.NvdCveApiIndex.lambda$processDocuments$1 (NvdCveApiIndex.java:137)
    at com.metaeffekt.mirror.concurrency.ScheduledDelayedThreadPoolExecutor$ThrowingRunnable.run (ScheduledDelayedThreadPoolExecutor.java:229)
    at java.util.concurrent.Executors$RunnableAdapter.call (Executors.java:511)
    at java.util.concurrent.FutureTask.run (FutureTask.java:266)
    at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201 (ScheduledThreadPoolExecutor.java:180)
    at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run (ScheduledThreadPoolExecutor.java:293)
    at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1149)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:624)
    at java.lang.Thread.run (Thread.java:750)
```