### PR TITLE
AE-1917: Misconfiguration for "includeVulnerabilitiesWithAdvisoryProviders"-property

### DIFF
--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/configuration/CentralSecurityPolicyConfiguration.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/configuration/CentralSecurityPolicyConfiguration.java
@@ -580,6 +580,9 @@ public class CentralSecurityPolicyConfiguration extends ProcessConfiguration {
         }
 
         JSONArray includeVulnerabilitiesWithAdvisoryProvidersJ = new JSONArray(includeVulnerabilitiesWithAdvisoryProviders);
+        if(includeVulnerabilitiesWithAdvisoryProvidersJ.isEmpty()) {
+            misconfigurations.add(new ProcessMisconfiguration("includeVulnerabilitiesWithAdvisoryProviders", "List of included advisory provider may not be empty: " + includeVulnerabilitiesWithAdvisoryProviders));
+        }
         for (int i = 0; i < includeVulnerabilitiesWithAdvisoryProvidersJ.length(); i++) {
             final JSONObject provider = includeVulnerabilitiesWithAdvisoryProvidersJ.optJSONObject(i, null);
             if (provider == null) {


### PR DESCRIPTION
added a CSP misconfiguration for the "includeVulnerabilitiesWithAdvisoryProviders"-property

[AA](https://github.com/org-metaeffekt/metaeffekt-artifact-analysis/pull/513)