### PR TITLE
AE-1917:  includeVulnerabilitiesWithAdvisoryProviders Consolidation No.2

### DIFF
--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/configuration/CentralSecurityPolicyConfiguration.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/configuration/CentralSecurityPolicyConfiguration.java
@@ -580,10 +580,14 @@ public class CentralSecurityPolicyConfiguration extends ProcessConfiguration {
         }
 
         JSONArray includeVulnerabilitiesWithAdvisoryProvidersJ = new JSONArray(includeVulnerabilitiesWithAdvisoryProviders);
-        for (int i = 0; i < includeVulnerabilitiesWithAdvisoryProvidersJ.length(); i++) {
-            final JSONObject provider = includeVulnerabilitiesWithAdvisoryProvidersJ.optJSONObject(i, null);
-            if (provider == null) {
-                misconfigurations.add(new ProcessMisconfiguration("includeVulnerabilitiesWithAdvisoryProviders", "Advisory provider must not be null or is not a JSON object: " + includeVulnerabilitiesWithAdvisoryProviders));
+        if (includeVulnerabilitiesWithAdvisoryProvidersJ.isEmpty()) {
+            misconfigurations.add(new ProcessMisconfiguration("includeVulnerabilitiesWithAdvisoryProviders", "Must not be empty"));
+        } else {
+            for (int i = 0; i < includeVulnerabilitiesWithAdvisoryProvidersJ.length(); i++) {
+                final JSONObject provider = includeVulnerabilitiesWithAdvisoryProvidersJ.optJSONObject(i, null);
+                if (provider == null) {
+                    misconfigurations.add(new ProcessMisconfiguration("includeVulnerabilitiesWithAdvisoryProviders", "Advisory provider must not be null or is not a JSON object: " + includeVulnerabilitiesWithAdvisoryProviders));
+                }
             }
         }
 

--- a/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/report/StatisticsOverviewTableTest.java
+++ b/libraries/ae-inventory-processor/src/test/java/org/metaeffekt/core/inventory/processor/report/StatisticsOverviewTableTest.java
@@ -89,6 +89,33 @@ public class StatisticsOverviewTableTest {
     }
 
     @Test
+    public void filterVulnerabilitiesForAdvisoryProvidersStringTest() {
+        final List<AeaaVulnerability> vulnerabilities = new ArrayList<>();
+
+        vulnerabilities.add(this.createVulnerabilityUnmodifiedSeverity(VulnerabilityMetaData.STATUS_VALUE_APPLICABLE, Severity.CRITICAL.getV3(), AeaaAdvisoryTypeStore.CERT_FR));
+        vulnerabilities.add(this.createVulnerabilityUnmodifiedSeverity(VulnerabilityMetaData.STATUS_VALUE_APPLICABLE, Severity.CRITICAL.getV3(), AeaaAdvisoryTypeStore.CERT_SEI));
+        vulnerabilities.add(this.createVulnerabilityUnmodifiedSeverity(VulnerabilityMetaData.STATUS_VALUE_APPLICABLE, Severity.HIGH.getV3(), AeaaAdvisoryTypeStore.CERT_FR, AeaaAdvisoryTypeStore.CERT_SEI));
+        vulnerabilities.add(this.createVulnerabilityUnmodifiedSeverity(VulnerabilityMetaData.STATUS_VALUE_APPLICABLE, Severity.LOW.getV3()));
+
+        this.precalculateCvss(vulnerabilities, this.unmodifiedMapperSecurityPolicy);
+
+        final StatisticsOverviewTable certFrTable = StatisticsOverviewTable.buildTableStrFilterAdvisor(this.unmodifiedMapperSecurityPolicy, vulnerabilities, "CERT-FR", false);
+        Assert.assertEquals(this.constructList("Critical", 1, 0, 0, 0, 0, 1, "100,0 %"), certFrTable.getTableRowValues("critical"));
+        Assert.assertEquals(this.constructList("High", 1, 0, 0, 0, 0, 1, "100,0 %"), certFrTable.getTableRowValues("high"));
+        Assert.assertEquals(this.constructList("Low", 0, 0, 0, 0, 0, 0, "n/a"), certFrTable.getTableRowValues("low"));
+
+        final StatisticsOverviewTable certSeiTable = StatisticsOverviewTable.buildTableStrFilterAdvisor(this.unmodifiedMapperSecurityPolicy, vulnerabilities, "CERT-SEI", false);
+        Assert.assertEquals(this.constructList("Critical", 1, 0, 0, 0, 0, 1, "100,0 %"), certSeiTable.getTableRowValues("critical"));
+        Assert.assertEquals(this.constructList("High", 1, 0, 0, 0, 0, 1, "100,0 %"), certSeiTable.getTableRowValues("high"));
+        Assert.assertEquals(this.constructList("Low", 0, 0, 0, 0, 0, 0, "n/a"), certSeiTable.getTableRowValues("low"));
+
+        final StatisticsOverviewTable noFilterTable = StatisticsOverviewTable.buildTableStrFilterAdvisor(this.unmodifiedMapperSecurityPolicy, vulnerabilities, null, false);
+        Assert.assertEquals(this.constructList("Critical", 2, 0, 0, 0, 0, 2, "100,0 %"), noFilterTable.getTableRowValues("critical"));
+        Assert.assertEquals(this.constructList("High", 1, 0, 0, 0, 0, 1, "100,0 %"), noFilterTable.getTableRowValues("high"));
+        Assert.assertEquals(this.constructList("Low", 1, 0, 0, 0, 0, 1, "100,0 %"), noFilterTable.getTableRowValues("low"));
+    }
+
+    @Test
     public void createStatisticsOverviewTableTest() {
         final List<AeaaVulnerability> vulnerabilities = new ArrayList<>();
 


### PR DESCRIPTION
https://github.com/org-metaeffekt/metaeffekt-artifact-analysis/pull/514

- Add misconfiguration check for empty includeVulnerabilitiesWithAdvisoryProviders array.