### PR TITLE
AE-2020: Change comparison logic for CVSS base/modified metrics

### DIFF
--- a/libraries/ae-security/src/main/java/org/metaeffekt/core/security/cvss/CvssVector.java
+++ b/libraries/ae-security/src/main/java/org/metaeffekt/core/security/cvss/CvssVector.java
@@ -360,13 +360,22 @@ public abstract class CvssVector {
 
     protected Pair<Integer, Integer> findOldNewSeverityOrder(CvssVectorAttribute unmodifiedAttribute, CvssVectorAttribute modifiedAttribute, CvssVectorAttribute newAttribute, boolean isNewAttributeModified) {
         // compare either the modified or the unmodified attribute with the new attribute
-        final boolean isModifiedAttributeSet = modifiedAttribute != null && modifiedAttribute.isSet();
-        final CvssVectorAttribute oldAttribute = isModifiedAttributeSet && isNewAttributeModified ? modifiedAttribute : unmodifiedAttribute;
+        final boolean isModifiedAttributeSet = modifiedAttribute != null &&
+                modifiedAttribute.isSet() &&
+                !VALUE_NOT_DEFINED.equals(modifiedAttribute.getIdentifier()) &&
+                !VALUE_NULL.equals(modifiedAttribute.getIdentifier()) &&
+                !"X".equals(modifiedAttribute.getShortIdentifier());
 
-        final int oldSeverity = determineAttributeSeverityOrder(oldAttribute);
-        final int newSeverity = determineAttributeSeverityOrder(newAttribute);
+        // if applying a new modified attribute, evaluate against the existing modified attribute (if set) or fallback to base.
+        // if applying a new base attribute, evaluate only against the existing base attribute.
+        final CvssVectorAttribute oldAttribute = isNewAttributeModified && isModifiedAttributeSet ? modifiedAttribute : unmodifiedAttribute;
 
-        // LOG.info("Comparing old [{} {}] with new [{} {}]", oldAttribute, oldSeverity, newAttribute, newSeverity);
+        final int oldSeverity = this.determineAttributeSeverityOrder(oldAttribute);
+        final int newSeverity = this.determineAttributeSeverityOrder(newAttribute);
+
+        // LOG.info("Comparing old [{} {} {}] with new [{} {} {}]",
+        //         oldAttribute.getClass().getSimpleName(), oldAttribute, oldSeverity,
+        //         newAttribute.getClass().getSimpleName(), newAttribute, newSeverity);
 
         return Pair.of(oldSeverity, newSeverity);
     }

--- a/libraries/ae-security/src/test/java/org/metaeffekt/core/security/cvss/CvssVectorTest.java
+++ b/libraries/ae-security/src/test/java/org/metaeffekt/core/security/cvss/CvssVectorTest.java
@@ -223,6 +223,18 @@ public class CvssVectorTest {
         );
     }
 
+    @Test
+    public void applyPartsBaseVsModifiedTest() {
+        assertPartsLowerHigherApplied("CVSS:4.0/AV:N/MAV:L", "MAV:A",
+                "CVSS:4.0/AV:N/MAV:L",
+                "CVSS:4.0/AV:N/MAV:A"
+        );
+        assertPartsLowerHigherApplied("CVSS:4.0/AV:N", "MAV:A",
+                "CVSS:4.0/AV:N/MAV:A",
+                "CVSS:4.0/AV:N"
+        );
+    }
+
     private void assertPartsLowerHigherApplied(String originalVector, String applyMetrics, String expectedLower, String expectedHigher) {
         final CvssVector lower = CvssVector.parseVector(originalVector);
         lower.applyVectorPartsIfMetricsLower(applyMetrics);
@@ -242,7 +254,7 @@ public class CvssVectorTest {
     private static UniversalCvssCalculatorLinkGenerator createLinkForHigherLowerMetrics(String input, String mod, CvssVector result) {
         final UniversalCvssCalculatorLinkGenerator gen = new UniversalCvssCalculatorLinkGenerator();
         gen.addOpenSection("base").addOpenSection("temporal").addOpenSection("environmental");
-        gen.setBaseUrl("http://localhost:63342/metaeffekt-cvss-web-calculator/site/index.html");
+        gen.setBaseUrl("https://metaeffekt.com/security/cvss/calculator");
         gen.addVector(CvssVector.parseVector(input), "input", true);
         gen.addVector(CvssVector.parseVector(mod), "mod", true);
         gen.addVector(result, "result", true);


### PR DESCRIPTION
Modified the behavior when applying CVSS vector metrics conditionally based on their severity (using `applyVectorPartsIfMetricsLower` or `applyVectorPartsIfMetricsHigher`).

1. The logic used to determine if a modified attribute was set was inverted. It returned true if the attribute was not defined, meaning explicitly set modified metrics were ignored while unset metrics were treated as set.
2. Applying a new base metric incorrectly attempted to compare its severity against it's modified metric counterpart, instead of comparing only the base metric value.

An example:
If a vector was initialized as `CVSS:4.0/AV:N/MAV:L`, calling `applyVectorPartsIfMetricsLower` with `MAV:A` would incorrectly evaluate the severity against the base metric `AV:N` instead of the current effective severity `MAV:L`. Because `MAV:A` is less severe than `AV:N`, it incorrectly overwrote `MAV:L` to become `MAV:A`.