### PR TITLE
AE-2191: bump dependency io.fabric8:knative-client to 7.7.0 (shoehorned into pypi environment resolver ticket)

### DIFF
--- a/libraries/ae-container-control/pom.xml
+++ b/libraries/ae-container-control/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>knative-client</artifactId>
-            <version>6.13.5</version>
+            <version>7.7.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This is simply a dependency bump. I stumbled over some errors with the outdated library version while developing the pypi environment resolver and thought I'd fix it.