### PR TITLE
AE-2265: Report Content Issues

### DIFF
--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/ReportUtils.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/ReportUtils.java
@@ -69,7 +69,7 @@ public class ReportUtils {
         return StringUtils.isNotBlank(value);
     }
 
-    public boolean notEmpty(List<?> value) {
+    public boolean listNotEmpty(List<?> value) {
         return value != null && !value.isEmpty();
     }
 

--- a/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/ReportUtils.java
+++ b/libraries/ae-inventory-processor/src/main/java/org/metaeffekt/core/inventory/processor/report/ReportUtils.java
@@ -69,6 +69,10 @@ public class ReportUtils {
         return StringUtils.isNotBlank(value);
     }
 
+    public boolean notEmpty(List<?> value) {
+        return value != null && !value.isEmpty();
+    }
+
     public String ratio(long part, long total) {
         return String.format("%.1f", ((double) part) / total);
     }

--- a/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/inventory-report-vulnerability/tpc_inventory-vulnerability-details.dita.vt
+++ b/libraries/ae-inventory-processor/src/main/resources/META-INF/templates/inventory-report-vulnerability/tpc_inventory-vulnerability-details.dita.vt
@@ -67,7 +67,7 @@
                 </body>
             </section>
 ##
-            #if ($utils.notEmpty($vulnerability.getFilteredReferencedWeaknessRefs()))
+            #if ($utils.listNotEmpty($vulnerability.getFilteredReferencedWeaknessRefs()))
             <section>
                 #set($title = $utils.getText("inventory-report-vulnerability.short.weakness"))
                 <title>$title</title>


### PR DESCRIPTION
Weakness section in vulnerability report details section will no longer be displayed if empty.

---

Apparently, another issue exists where CERT-SEI and CERT-EU are no longer shown, but I suspect this may be a configuration issue.